### PR TITLE
fix(shared): accept array-valued frontmatter in ApiNoteJson schema

### DIFF
--- a/packages/shared/src/types/plugin-local-rest-api.test.ts
+++ b/packages/shared/src/types/plugin-local-rest-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { type } from "arktype";
 import {
+  ApiNoteJson,
   ApiStatusResponse,
   ApiVaultFileResponse,
 } from "./plugin-local-rest-api";
@@ -150,6 +151,129 @@ describe("ApiVaultFileResponse — issue #41 (frontmatter.tags optional)", () =>
     const result = ApiVaultFileResponse({
       ...incomplete,
       frontmatter: {},
+    });
+    expect(result).toBeInstanceOf(type.errors);
+  });
+});
+
+describe("ApiNoteJson — issue #81 (array-valued frontmatter keys)", () => {
+  const baseNote = {
+    content: "# Heading\n\nBody text.",
+    path: "Notes/example.md",
+    stat: { ctime: 1700000000000, mtime: 1700000000000, size: 42 },
+    tags: ["#todo"],
+  };
+
+  test("accepts a note whose frontmatter has an array-valued `aliases` key", () => {
+    // The original bug: Obsidian Flavored Markdown routinely declares
+    // `aliases` as a YAML sequence. A Record<string, string> shape
+    // rejected every such note at the validation boundary, making
+    // `get_vault_file(format: "json")` unusable. Record<string, unknown>
+    // accepts the array verbatim.
+    const result = ApiNoteJson({
+      ...baseNote,
+      frontmatter: { aliases: ["Example", "ex"] },
+    });
+    expect(result).toMatchObject({
+      frontmatter: { aliases: ["Example", "ex"] },
+    });
+  });
+
+  test("accepts the full OFM convention set (aliases + tags + up + down)", () => {
+    // Representative real-world frontmatter from an OFM-heavy vault:
+    // linked-note keys (`up`, `down`, `next`, `previous`) carrying
+    // wikilink arrays, `tags` as an array, scalar title. All of these
+    // must validate in a single pass; this test pins that intent.
+    const ofmFrontmatter = {
+      title: "Example",
+      aliases: ["Example", "ex"],
+      tags: ["topic/example", "source/user"],
+      up: ["[[Parent Note]]"],
+      down: ["[[Child A]]", "[[Child B]]"],
+      next: ["[[Next Note]]"],
+      previous: ["[[Previous Note]]"],
+      cssclasses: ["wide-layout"],
+    };
+    const result = ApiNoteJson({
+      ...baseNote,
+      frontmatter: ofmFrontmatter,
+    });
+    expect(result).toMatchObject({ frontmatter: ofmFrontmatter });
+  });
+
+  test("accepts frontmatter with mixed scalar and array values", () => {
+    // Backwards compatibility: a plain string-valued key must still
+    // pass alongside array-valued keys. YAML permits both on the same
+    // document and Obsidian emits both routinely.
+    const result = ApiNoteJson({
+      ...baseNote,
+      frontmatter: {
+        title: "Plain scalar",
+        aliases: ["alt"],
+        created: "2026-04-24",
+      },
+    });
+    expect(result).toMatchObject({
+      frontmatter: {
+        title: "Plain scalar",
+        aliases: ["alt"],
+        created: "2026-04-24",
+      },
+    });
+  });
+
+  test("accepts frontmatter with non-string scalars (number, boolean, null)", () => {
+    // YAML allows these; Obsidian passes them through unchanged. The
+    // wrapper must not reject them — the caller (often an LLM agent)
+    // can inspect types on the receiving side.
+    const result = ApiNoteJson({
+      ...baseNote,
+      frontmatter: {
+        priority: 3,
+        pinned: true,
+        archived: false,
+        parent: null,
+      },
+    });
+    expect(result).toMatchObject({
+      frontmatter: {
+        priority: 3,
+        pinned: true,
+        archived: false,
+        parent: null,
+      },
+    });
+  });
+
+  test("accepts frontmatter with a nested object value", () => {
+    // YAML mapping as a frontmatter value. Uncommon but legal, and
+    // some plugins (e.g. custom metadata plugins) do emit them.
+    const result = ApiNoteJson({
+      ...baseNote,
+      frontmatter: {
+        links: { github: "https://example.com", wiki: "[[Home]]" },
+      },
+    });
+    expect(result).toMatchObject({
+      frontmatter: {
+        links: { github: "https://example.com", wiki: "[[Home]]" },
+      },
+    });
+  });
+
+  test("accepts an empty frontmatter object", () => {
+    const result = ApiNoteJson({ ...baseNote, frontmatter: {} });
+    expect(result).toMatchObject({ frontmatter: {} });
+  });
+
+  test("still rejects a response missing a required core field", () => {
+    // Sanity check: the frontmatter relaxation has not accidentally
+    // widened the overall schema. `content`, `path`, `stat`, `tags`
+    // remain load-bearing.
+    const { content: _content, ...incomplete } = baseNote;
+    const result = ApiNoteJson({
+      ...incomplete,
+      frontmatter: { aliases: ["ex"] },
     });
     expect(result).toBeInstanceOf(type.errors);
   });

--- a/packages/shared/src/types/plugin-local-rest-api.ts
+++ b/packages/shared/src/types/plugin-local-rest-api.ts
@@ -16,10 +16,21 @@ export const ApiError = type({
  * JSON representation of a note including parsed tag and frontmatter data as well as filesystem metadata
  * Content-Type: application/vnd.olrapi.note+json
  * GET /vault/{filename} or GET /active/ with Accept: application/vnd.olrapi.note+json
+ *
+ * NOTE on `frontmatter`: values are declared as `unknown` because YAML
+ * frontmatter (and Obsidian Flavored Markdown in particular) allows
+ * arbitrary scalar and list shapes — `aliases`, `tags`, `up`, `down`,
+ * `next`, `previous`, `cssclasses` are routinely arrays; other keys
+ * may be numbers, booleans, null, or nested objects. A narrower
+ * `Record<string, string>` shape rejected every note with a list-valued
+ * key at the validation boundary, making `format: "json"` unusable on
+ * any realistic vault. Downstream consumers (LLM clients especially)
+ * handle dynamic frontmatter shapes natively; strict wrapper-side
+ * typing here costs more than it buys. Fixes upstream issue #81.
  */
 export const ApiNoteJson = type({
   content: "string",
-  frontmatter: "Record<string, string>",
+  frontmatter: "Record<string, unknown>",
   path: "string",
   stat: {
     ctime: "number",


### PR DESCRIPTION
## Why

`get_vault_file(filename, format: "json")` failed with a validation error on any note whose YAML frontmatter contained a list value. This is tracked upstream as [jacksteamdev/obsidian-mcp-tools#81](https://github.com/jacksteamdev/obsidian-mcp-tools/issues/81), reported by @folotp on 2026-04-22.

The failure mode:

```yaml
---
aliases:
  - Example
  - ex
tags:
  - topic/example
up:
  - "[[Parent Note]]"
---
```

→ `arguments.frontmatter.aliases must be a string (was an object)`

Because `aliases`, `tags`, `up`, `down`, `next`, `previous`, `cssclasses` etc. are **routinely** arrays in Obsidian Flavored Markdown, this effectively made `format: "json"` unusable on any realistic vault. Local REST API itself was returning the arrays correctly — the rejection happened at our wrapper's ArkType boundary.

## What changed

**One-line shape relaxation** in `packages/shared/src/types/plugin-local-rest-api.ts`:

```diff
- frontmatter: "Record<string, string>",
+ frontmatter: "Record<string, unknown>",
```

YAML permits any scalar, list, or nested-mapping value per frontmatter key. Downstream consumers (LLM agents especially) already handle dynamic shapes on the receiving side — strict wrapper-side typing here was purely restrictive without adding safety.

Added a comment block explaining the rationale and the link to #81 so the next contributor doesn't accidentally tighten it back.

## Regression tests (7 new)

All in `packages/shared/src/types/plugin-local-rest-api.test.ts`, under a new `describe("ApiNoteJson — issue #81 (array-valued frontmatter keys)")` block:

1. **Canonical repro** — `aliases: ["Example", "ex"]`, mirrors the filed bug.
2. **Full OFM convention set** — `aliases + tags + up + down + next + previous + cssclasses` all as arrays on the same note.
3. **Mixed scalar + array** — backwards compat: plain string-valued keys must still pass alongside array-valued ones.
4. **Non-string scalars** — `number`, `boolean`, `null` (YAML-legal, Obsidian passes through).
5. **Nested mapping value** — uncommon but legal; some plugins emit them.
6. **Empty frontmatter object** — degenerate case.
7. **Sanity check** — the top-level schema has NOT been incidentally widened; `content`, `path`, `stat`, `tags` remain load-bearing.

## Verification

```
$ cd packages/shared && bun test
17 pass / 0 fail

$ bun run check  (root)
shared / mcp-server / obsidian-plugin / test-server — all exit 0
```

No existing test regressed; all 152 mcp-server tests still pass.

## Related

- **#78** (non-ASCII header encoding) — orthogonal, fixed in 0.3.0.
- **#71** (heading-path silent append-EOF) — fixed in 0.3.0 for `targetType: "heading"`. Block-in-table extension reported by @folotp is a separate gap, follow-up at upstream #71.
- **#83** (section-boundary parser corruption on table + code-span) — novel bug, likely lives in upstream `coddingtonbear/markdown-patch` rather than this wrapper. Follow-up at upstream #83.

## Test plan

- [x] `bun test` in `packages/shared`: 17 pass / 0 fail.
- [x] `bun run check` at repo root: all packages exit 0.
- [x] `bun test` in `packages/mcp-server`: 152 pass / 0 fail (no regression on consumers of `ApiNoteJson`).
- [ ] Follow-up: ping @folotp on upstream #81 to test against the fork release that ships this fix.