### PR TITLE
fix(patch): block targets default createTargetIfMissing=false

### DIFF
--- a/packages/mcp-server/src/features/local-rest-api/index.ts
+++ b/packages/mcp-server/src/features/local-rest-api/index.ts
@@ -26,11 +26,27 @@ export function buildPatchHeaders(
   args: PatchHeadersInput,
   resolvedTarget: string,
 ): Record<string, string> {
+  // Default behavior of Create-Target-If-Missing per target type:
+  //   heading     → true  (upstream 0.2.x compatibility; most callers expect
+  //                        a missing heading to be silently appended at EOF)
+  //   frontmatter → true  (same upstream default; frontmatter keys rarely
+  //                        produce silent-corruption footguns)
+  //   block       → false (safer: when a block `^id` cannot be located —
+  //                        especially when the id lives inside a markdown
+  //                        table cell, where markdown-patch's block indexer
+  //                        does not search — permissive silent EOF append
+  //                        corrupts callers expecting atomic patch-or-fail.
+  //                        Callers can explicitly opt back in with
+  //                        createTargetIfMissing: true. Fixes upstream
+  //                        issue #71's block-in-table gap.)
+  const defaultCreateTargetIfMissing = args.targetType !== "block";
   const headers: Record<string, string> = {
     Operation: args.operation,
     "Target-Type": args.targetType,
     Target: encodeURIComponent(resolvedTarget),
-    "Create-Target-If-Missing": String(args.createTargetIfMissing ?? true),
+    "Create-Target-If-Missing": String(
+      args.createTargetIfMissing ?? defaultCreateTargetIfMissing,
+    ),
   };
 
   if (args.targetDelimiter) {

--- a/packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts
+++ b/packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts
@@ -220,6 +220,90 @@ describe("buildPatchHeaders — issue #78 (non-ASCII) + wiring", () => {
   });
 });
 
+describe("buildPatchHeaders — issue #71 (block-in-table gap, per-target-type default)", () => {
+  test("block target defaults Create-Target-If-Missing to 'false' (safer)", () => {
+    // Rationale: a block `^id` that cannot be located — especially one
+    // inside a markdown table cell, which markdown-patch's block indexer
+    // does not search — must fail loud instead of silently appending the
+    // caller's content at EOF. Silent EOF append on a missing block is
+    // data corruption: the caller gets HTTP 200 but the vault is now in
+    // an unexpected shape, with the "patch" accumulated at file end rather
+    // than in place.
+    const headers = buildPatchHeaders(
+      { operation: "replace", targetType: "block" },
+      "block-id-42",
+    );
+    expect(headers["Create-Target-If-Missing"]).toBe("false");
+  });
+
+  test("heading target default remains 'true' (no regression)", () => {
+    // Pins the backwards-compatible default for heading targets, which is
+    // the load-bearing shape for upstream 0.2.x parity. If this flips, any
+    // caller relying on "create heading if missing" behavior breaks.
+    const headers = buildPatchHeaders(
+      { operation: "append", targetType: "heading" },
+      "Section A",
+    );
+    expect(headers["Create-Target-If-Missing"]).toBe("true");
+  });
+
+  test("frontmatter target default remains 'true' (no regression)", () => {
+    // Frontmatter keys rarely produce silent-corruption footguns: missing
+    // keys can be legitimately created (that's the point for a lot of
+    // Templater-backed flows), and the shape of a frontmatter value is
+    // well-defined. Keep permissive default.
+    const headers = buildPatchHeaders(
+      { operation: "replace", targetType: "frontmatter" },
+      "aliases",
+    );
+    expect(headers["Create-Target-If-Missing"]).toBe("true");
+  });
+
+  test("block target with createTargetIfMissing: true explicitly overrides the safe default", () => {
+    // Opt-in for callers who genuinely want the permissive behavior on
+    // blocks (e.g. a migration script that appends a marker block if it
+    // doesn't exist yet). Explicit is better than implicit.
+    const headers = buildPatchHeaders(
+      {
+        operation: "append",
+        targetType: "block",
+        createTargetIfMissing: true,
+      },
+      "marker-block",
+    );
+    expect(headers["Create-Target-If-Missing"]).toBe("true");
+  });
+
+  test("block target with createTargetIfMissing: false explicitly is still 'false'", () => {
+    // Idempotence: explicit `false` on a block target is the same as the
+    // new default. No surprise.
+    const headers = buildPatchHeaders(
+      {
+        operation: "replace",
+        targetType: "block",
+        createTargetIfMissing: false,
+      },
+      "block-id",
+    );
+    expect(headers["Create-Target-If-Missing"]).toBe("false");
+  });
+
+  test("heading target with createTargetIfMissing: false explicitly is 'false'", () => {
+    // Strict-mode opt-in still works on heading targets — this is the
+    // existing safety hatch for callers that want patch-or-fail
+    // semantics across all target types.
+    const headers = buildPatchHeaders(
+      {
+        operation: "replace",
+        targetType: "heading",
+        createTargetIfMissing: false,
+      },
+      "Section A",
+    );
+    expect(headers["Create-Target-If-Missing"]).toBe("false");
+  });
+});
+
 describe("normalizeAppendBody — trailing newline safeguard", () => {
   test("appends two newlines to an append-body without a trailing newline", () => {
     // Without this, markdown like `**done**` appended under a heading

--- a/packages/shared/src/types/plugin-local-rest-api.ts
+++ b/packages/shared/src/types/plugin-local-rest-api.ts
@@ -229,7 +229,7 @@ export const ApiVaultFileResponse = type({
  * @property trimTargetWhitespace - Whether to remove whitespace from target identifier before matching (default: false)
  * @property content - The actual content to insert, append, or use as replacement
  * @property contentType - Format of the content - use application/json for structured data like table rows or frontmatter values
- * @property createTargetIfMissing - Whether the Local REST API should create the target heading/block if it does not exist (default: true for backward compatibility). Set to false to get an explicit error instead of silently appending a new heading at EOF when the target cannot be resolved.
+ * @property createTargetIfMissing - Whether the Local REST API should create the target heading/block if it does not exist. Default is per-target-type: `true` for `heading` and `frontmatter` (upstream 0.2.x compatibility), `false` for `block` (safer default because unresolved block ids — especially those inside markdown table cells, which markdown-patch's block indexer does not search — should fail loud rather than silently appending at EOF; see upstream issue #71 block-in-table gap). Set explicitly to override the per-target-type default.
  */
 export const ApiPatchParameters = type({
   operation: type("'append' | 'prepend' | 'replace'").describe(
@@ -254,7 +254,7 @@ export const ApiPatchParameters = type({
     "Format of the content - use application/json for structured data like table rows or frontmatter values",
   ),
   "createTargetIfMissing?": type("boolean").describe(
-    "Whether to create the target heading/block if it doesn't exist (default: true). Set to false to get an explicit error instead of silently creating a new target at end-of-file when the lookup fails.",
+    "Whether to create the target if it doesn't exist. Default is per-target-type: true for heading and frontmatter (upstream compat), false for block (safer — block ids inside table cells are not searched by the indexer and silent EOF-append causes data corruption). Set explicitly to override.",
   ),
 });
 


### PR DESCRIPTION
## Why

Closes the block-in-table silent-corruption gap identified by @folotp on [jacksteamdev/obsidian-mcp-tools#71](https://github.com/jacksteamdev/obsidian-mcp-tools/issues/71).

When `patch_active_file` / `patch_vault_file` is called with `targetType: "block"` and the `^id` sits inside a markdown table cell (or is otherwise unresolvable by `markdown-patch`'s block indexer, which does not search table cells), the upstream-compat default `Create-Target-If-Missing: true` produced a **silent EOF append** instead of a loud error. The caller received HTTP 200 but the vault was now in an unexpected shape — patch content accumulated at file end rather than in place. Retries compounded the damage.

The heading-path half of #71 was already fixed in 0.3.0 (partial-heading-name resolution). The block half was an outstanding gap because `buildPatchHeaders` used a single `true` default for every target type.

## What changed

Per-target-type default in `buildPatchHeaders`:

```diff
+ const defaultCreateTargetIfMissing = args.targetType !== "block";
  const headers: Record<string, string> = {
    …
    "Create-Target-If-Missing": String(
-     args.createTargetIfMissing ?? true
+     args.createTargetIfMissing ?? defaultCreateTargetIfMissing
    ),
  };
```

- `targetType === "heading"` → default `true` (upstream 0.2.x compat; most callers expect silent create of missing headings).
- `targetType === "frontmatter"` → default `true` (unchanged; frontmatter keys rarely produce silent-corruption footguns; Templater flows depend on this).
- `targetType === "block"` → default `false` (**behavior change**: fail loud on unresolved block `^id`).

Callers who genuinely want permissive behavior on a block (rare, e.g. a migration that creates a marker block on first run) opt in explicitly with `createTargetIfMissing: true`.

Updated JSDoc on `ApiPatchParameters` and the runtime `.describe()` on the `createTargetIfMissing` field so model callers see the updated contract.

## Regression tests (6 new)

All in `packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts`, under a new `describe("buildPatchHeaders — issue #71 (block-in-table gap, per-target-type default)")` block:

1. **Block default flips to `'false'`** — the behavior change itself.
2. **Heading default stays `'true'`** — pins the upstream-compat contract so a future refactor can't accidentally flip it.
3. **Frontmatter default stays `'true'`** — pins the Templater-flow contract.
4. **Block + explicit `createTargetIfMissing: true`** — opt-in path still works.
5. **Block + explicit `createTargetIfMissing: false`** — idempotent with the new default (no surprise).
6. **Heading + explicit `createTargetIfMissing: false`** — strict-mode opt-in on heading is unchanged.

## Breaking-change scope

Intentional but narrow: only callers who today rely on `patch_*_file` with `targetType: "block"` and an unresolvable `target` silently creating a block at EOF are affected. That behavior was a silent-corruption path — the whole point of the fix is to surface it as a loud error instead.

Any caller that actually needs the permissive shape on blocks continues to work by setting `createTargetIfMissing: true` explicitly.

## Verification

```
$ bun run check  (root)
shared / mcp-server / obsidian-plugin / test-server — all exit 0

$ cd packages/mcp-server && bun test
158 pass / 0 fail  (+6 vs. previous 152)

$ cd packages/shared && bun test
17 pass / 0 fail
```

## Related

- **#71 heading half**: fixed in 0.3.0 (heading-path resolution, commit `046268b`).
- **#71 block-in-table half**: **this PR**.
- **#78** (non-ASCII headers): fixed in 0.3.0. Orthogonal.
- **#81** (frontmatter array): fixed in 0.3.6. Orthogonal.
- **#83** (markdown-patch section boundary): delegated upstream to [coddingtonbear/markdown-patch#10](https://github.com/coddingtonbear/markdown-patch/issues/10). Orthogonal.

## Test plan

- [x] `bun run check` at repo root: all packages exit 0.
- [x] `bun test` in `packages/mcp-server`: 158 pass / 0 fail.
- [x] `bun test` in `packages/shared`: 17 pass / 0 fail.
- [ ] Follow-up: ping @folotp on upstream #71 once this ships in a release to confirm the block-in-table repro now fails loud instead of silently appending.