### PR TITLE
docs(changelog): cut 0.3.7 release notes for #71 block gap fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to **MCP Connector** (formerly `obsidian-mcp-tools`) are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.3.7] — 2026-04-24
+
+### Fixed
+- **`patch_active_file` / `patch_vault_file` block-in-table silent
+  corruption** — `Create-Target-If-Missing` now defaults per target
+  type: `true` for `heading` and `frontmatter` (upstream 0.2.x compat,
+  unchanged), `false` for `block`. `markdown-patch`'s block indexer
+  does not search inside markdown table cells, so a block `^id` sitting
+  in a cell was unresolvable; under the previous single `true` default,
+  the Local REST API silently appended the caller's `content` at EOF
+  and returned HTTP 200. Retries compounded the damage. Block targets
+  now fail loud on unresolved ids so callers can decide the recovery
+  path explicitly. Heading + frontmatter behavior is preserved.
+  Closes the block-in-table half of upstream issue #71 (heading half
+  was fixed in 0.3.0); reported by @folotp.
+
+### Changed
+- Updated the JSDoc on `ApiPatchParameters.createTargetIfMissing` and
+  the runtime `.describe()` string so model callers see the new
+  per-target-type default contract.
+- Added 6 regression tests in `patchVaultFile.test.ts` pinning the
+  per-target-type defaults (block → false, heading → true,
+  frontmatter → true) against accidental regression, plus opt-in
+  overrides for block targets (explicit `true` and `false`) and
+  heading-target strict-mode (explicit `false`).
+
 ## [0.3.6] — 2026-04-24
 
 ### Fixed


### PR DESCRIPTION
Backfills the CHANGELOG entry for the 0.3.7 release shipped today (tag `0.3.7`).

Same pattern as [#5](https://github.com/istefox/obsidian-mcp-connector/pull/5): `bun run version` bumps metadata + tag, changelog entry lands in a separate docs PR per repo convention.

### Scope

Documents the per-target-type `Create-Target-If-Missing` default (block → false, heading + frontmatter → true) and the 6 regression tests added in `patchVaultFile.test.ts`. Credits @folotp and references upstream #71.

### Test plan

- [x] Markdown renders correctly.
- [x] Version pin (0.3.7) and date (2026-04-24) match the git tag.