### PR TITLE
fix(search): accept parsed-object body on POST /search/smart

### DIFF
--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -4,9 +4,9 @@ import { Notice, Plugin, TFile } from "obsidian";
 import { shake } from "radash";
 import { lastValueFrom } from "rxjs";
 import {
-  jsonSearchRequest,
   LocalRestAPI,
   searchParameters,
+  searchRequest,
   Templater,
   type PromptArgAccessor,
   type SearchResponse,
@@ -194,8 +194,8 @@ export default class McpToolsPlugin extends Plugin {
         return;
       }
 
-      // Validate request body
-      const requestBody = jsonSearchRequest
+      // bodyParser.json() has already parsed req.body into an object.
+      const requestBody = searchRequest
         .pipe(({ query, filter = {} }) => ({
           query,
           filter: shake({

--- a/packages/shared/src/types/smart-search.test.ts
+++ b/packages/shared/src/types/smart-search.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { type } from "arktype";
+import { searchRequest } from "./smart-search";
+
+describe("searchRequest — POST /search/smart body validator", () => {
+  // Regression for the "must be a string (was an object)" 400 returned
+  // by every search_vault_smart MCP call. The previous schema was
+  //   type("string.json.parse").to(searchRequest)
+  // which assumed `req.body` was a raw JSON string. The route is mounted
+  // on Express with bodyParser.json() upstream, so the body is already a
+  // parsed object — running it through string.json.parse rejected every
+  // real request. The validator must accept the parsed-object shape.
+
+  test("accepts a minimal parsed-object body with just a query", () => {
+    const result = searchRequest({ query: "hello" });
+    expect(result).not.toBeInstanceOf(type.errors);
+    if (!(result instanceof type.errors)) {
+      expect(result.query).toBe("hello");
+    }
+  });
+
+  test("accepts a body with an optional filter object", () => {
+    const body = {
+      query: "semantic",
+      filter: {
+        folders: ["Public"],
+        excludeFolders: ["Archive"],
+        limit: 10,
+      },
+    };
+    const result = searchRequest(body);
+    expect(result).not.toBeInstanceOf(type.errors);
+  });
+
+  test("accepts an empty filter object", () => {
+    const result = searchRequest({ query: "x", filter: {} });
+    expect(result).not.toBeInstanceOf(type.errors);
+  });
+
+  test("rejects a missing query", () => {
+    const result = searchRequest({ filter: { limit: 5 } });
+    expect(result).toBeInstanceOf(type.errors);
+  });
+
+  test("rejects an empty query string", () => {
+    const result = searchRequest({ query: "" });
+    expect(result).toBeInstanceOf(type.errors);
+  });
+
+  test("rejects a JSON string body (the previous schema accepted this — the new one must not)", () => {
+    // Sanity check that we are no longer trying to JSON.parse the body
+    // ourselves: a stringified body should fail validation, because
+    // bodyParser.json() will have already produced an object before we
+    // get here. If this passes, the double-parse bug has crept back in.
+    const result = searchRequest('{"query":"hello"}' as unknown as object);
+    expect(result).toBeInstanceOf(type.errors);
+  });
+});

--- a/packages/shared/src/types/smart-search.ts
+++ b/packages/shared/src/types/smart-search.ts
@@ -1,7 +1,7 @@
 import { type } from "arktype";
 import * as SmartConnections from "./plugin-smart-connections";
 
-const searchRequest = type({
+export const searchRequest = type({
   query: type("string>0").describe("A search phrase for semantic search"),
   "filter?": {
     "folders?": type("string[]").describe(
@@ -15,7 +15,6 @@ const searchRequest = type({
     ),
   },
 });
-export const jsonSearchRequest = type("string.json.parse").to(searchRequest);
 
 export interface SearchResponse {
   results: Array<{


### PR DESCRIPTION
Closes #9.

## Why

Every `search_vault_smart` MCP call returns:

```
400 Invalid request body
must be a string (was an object)
```

making semantic search unreachable from any MCP client (Claude Code, Claude Desktop, Cline). Reproducible against a fresh install of `mcp-tools-istefox` 0.3.7 with `obsidian-local-rest-api` 3.6.1 and `smart-connections` 4.3.0, regardless of `query`/`filter` shape.

## What changed

The `/search/smart` route is mounted on Express, which has `bodyParser.json()` upstream — by the time `handleSearchRequest` runs, `req.body` is already a parsed object. The previous validator was

```ts
export const jsonSearchRequest = type("string.json.parse").to(searchRequest);
```

i.e. it expected a raw JSON **string** and would parse it itself. That's a double-parse: arktype sees an object, fails the `string` domain check, and the handler returns 400 before Smart Connections is ever called.

The same comment in `packages/mcp-server/.../smart-connections/index.ts` (introduced for upstream issue #39) explicitly notes that the plugin side parses via `bodyParser.json()` — the schema just hadn't been updated to match.

Fix:

```diff
-export const jsonSearchRequest = type("string.json.parse").to(searchRequest);
+export const searchRequest = type({ … });   // promoted to public export
```

```diff
-import { jsonSearchRequest, … } from "shared";
+import { searchRequest, … } from "shared";

-const requestBody = jsonSearchRequest
+const requestBody = searchRequest
   .pipe(({ query, filter = {} }) => …)
   .to(searchParameters)(req.body);
```

`jsonSearchRequest` had no other callers — dropped rather than left as a deprecated alias.

## Regression test

New `packages/shared/src/types/smart-search.test.ts` (6 tests) pins the parsed-object contract:

1. Accepts a minimal `{ query }` object.
2. Accepts a body with the optional `filter` populated (folders / excludeFolders / limit).
3. Accepts an empty `filter: {}`.
4. Rejects a missing `query`.
5. Rejects an empty `query` string.
6. **Rejects a stringified body** — explicit guard against the double-parse regressing.

## Verification

```
$ bun --filter '*' check
shared / @obsidian-mcp-tools/obsidian-plugin / @obsidian-mcp-tools/mcp-server / test-server — all exit 0
0 errors / 0 warnings.

$ bun test packages/shared/src/types/smart-search.test.ts
6 pass / 0 fail
```

Live test against a running Obsidian (1.12.7) with the patched `main.js` swapped into the plugin folder, then Cmd+R:

| Tool | Pre-fix | Post-fix |
|---|---|---|
| `search_vault_smart` (no filter) | 400 | 200 `{ "results": […] }` |
| `search_vault_smart` (with `filter.folders` + `filter.limit`) | 400 | 200 |
| `search_vault_simple` | 200 | 200 |
| `get_server_info` / `list_vault_files` / `get_vault_file` / `get_active_file` / `list_obsidian_commands` | 200 | 200 |

No regressions on the wider MCP surface.

## Pre-existing failures, unrelated to this PR

`bun test` at the repo root currently surfaces failures in:

- `packages/obsidian-plugin/src/features/mcp-server-install/services/install.test.ts`
- `…/uninstall.test.ts` — `Cannot find package 'obsidian'` (peer dep, expects test-environment mock)
- `…/config.test.ts` — `GITHUB_DOWNLOAD_URL must be a string (was undefined)` / `GITHUB_REF_NAME …` (CI-only env vars)

These reproduce identically on `main` without this PR's changes.

## Test plan

- [x] `bun --filter '*' check` at repo root: 0 errors across all four packages.
- [x] `bun test` on the new `smart-search.test.ts`: 6/6 pass.
- [x] Live MCP smoke test against a real vault: `search_vault_smart` returns 200 with valid JSON; six other MCP tools unchanged.
- [x] Reproduction of the original 400 confirmed before the patch was installed.