### PR TITLE
fix(0.3.8): guard frontmatter ops against silent corruption + 500s (#12, #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,63 @@
 All notable changes to **MCP Connector** (formerly `obsidian-mcp-tools`) are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.3.8] — 2026-04-26
+
+### Fixed
+- **`search_vault_smart` returned HTTP 400 `must be a string (was an
+  object)` on every call** — the plugin-side `/search/smart` endpoint
+  validated `req.body` with `string.json.parse → searchRequest`, but
+  Express had already parsed the body via `bodyParser.json()` upstream.
+  ArkType saw an object, failed the `string` domain check, and the
+  handler 400'd before Smart Connections was ever invoked, making
+  semantic search fully unreachable from any MCP client (Claude
+  Desktop, Claude Code, Cline). Promoted `searchRequest` to a public
+  export and dropped the obsolete `jsonSearchRequest` alias; the
+  caller now binds against the parsed-object schema directly. Six
+  regression tests in `packages/shared/src/types/smart-search.test.ts`
+  pin the parsed-object contract (minimal `{query}`, populated
+  `filter`, empty `filter: {}`, missing/empty `query`, and an
+  explicit guard against the double-parse regressing). Closes #9;
+  contributed by @ezrahill (#10).
+- **`patch_vault_file` / `patch_active_file` silently destroyed
+  array-valued frontmatter fields on `replace` with text/markdown
+  content** — same family as the silent EOF append behaviour fixed
+  for `targetType: "block"` in #71 (0.3.7). The wrapper now
+  pre-fetches the parsed frontmatter (one extra GET, only when the
+  call shape is `frontmatter + replace + non-JSON content`) and
+  rejects with `McpError(InvalidParams, …)` when the target field is
+  an array. The error message points the caller at the JSON-content
+  escape hatch with concrete examples (`'["new"]'` for a
+  single-element array, `'null'` to clear). Pre-fetch is best-effort:
+  if the GET fails (404, permission), the precheck is skipped and the
+  original PATCH propagates its own error. The new helper
+  `detectFrontmatterReplaceArrayMismatch` is pure / synchronous and
+  unit-tested in isolation (10 cases). Closes #12; reported by
+  @folotp.
+- **`patch_vault_file` / `patch_active_file` returned HTTP 500 on
+  frontmatter `append` / `prepend` with a JSON scalar payload** — the
+  upstream Local REST API parser cannot handle a scalar value on the
+  array-form append/prepend op. The wrapper now auto-wraps a JSON
+  scalar in a single-element array client-side via
+  `JSON.stringify([parsed])` before forwarding the PATCH —
+  unambiguous DWIM since there is exactly one reasonable
+  interpretation (append THIS element to the array). Only triggers on
+  `targetType: "frontmatter" + (append|prepend) +
+  contentType: "application/json"` to keep the surface area minimal;
+  malformed JSON is forwarded untouched so the REST API surfaces its
+  own error. The `normalizeAppendBody` `\n\n` trailer is intentionally
+  skipped on the JSON branch so it does not invalidate the JSON body.
+  The new helper `coerceFrontmatterAppendArrayContent` is pure /
+  synchronous and unit-tested in isolation (10 cases covering
+  string/number/boolean/null/object scalars, array passthrough,
+  prepend symmetry, malformed JSON, and four pass-through paths).
+  Closes #13; reported by @folotp.
+
+### Changed
+- Added 20 regression tests in `packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts`
+  (10 for #12 + 10 for #13) pinning the frontmatter precheck and
+  scalar auto-wrap behavior against accidental regression.
+
 ## [0.3.7] — 2026-04-24
 
 ### Fixed

--- a/packages/mcp-server/src/features/local-rest-api/index.ts
+++ b/packages/mcp-server/src/features/local-rest-api/index.ts
@@ -1,4 +1,5 @@
 import { makeBinaryRequest, makeRequest, type ToolRegistry } from "$/shared";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { type } from "arktype";
 import { LocalRestAPI } from "shared";
 
@@ -325,6 +326,108 @@ export function applySimpleSearchLimit<T>(
   return limit !== undefined ? data.slice(0, limit) : data;
 }
 
+export interface FrontmatterPatchPrecheckArgs {
+  targetType: "heading" | "block" | "frontmatter";
+  operation: PatchOperation;
+  contentType?: "text/markdown" | "application/json";
+}
+
+/**
+ * Same family as the block-target silent EOF append issue (#71): the wrapper
+ * must not let a write reshape the targeted data without flagging the type
+ * change.
+ *
+ * When a caller targets an array-valued frontmatter field with `replace` and
+ * does NOT explicitly opt into JSON content (i.e. `contentType` is unset or
+ * `text/markdown`), the Local REST API silently coerces the field from array
+ * to scalar string. The PATCH returns 200 OK while the persisted file has
+ * lost its array structure. Reject the request with an actionable 400
+ * instead, so the caller has to either:
+ *
+ *   (a) restate intent as JSON (`contentType: "application/json"` and a
+ *       JSON-encoded value — `'["new"]'` for a single-element array,
+ *       `'null'` to clear), or
+ *   (b) opt explicitly into the destructive coercion via `application/json`
+ *       and a JSON scalar (which is at least an explicit signal, not a
+ *       silent footgun).
+ *
+ * Returns the error message string when the call should be rejected, or
+ * `null` when it is safe to proceed. Pure / synchronous so it can be unit
+ * tested without network. Fixes folotp's #12.
+ */
+export function detectFrontmatterReplaceArrayMismatch(
+  frontmatter: Record<string, unknown> | undefined | null,
+  args: FrontmatterPatchPrecheckArgs,
+  target: string,
+): string | null {
+  if (
+    args.targetType !== "frontmatter" ||
+    args.operation !== "replace" ||
+    args.contentType === "application/json"
+  ) {
+    return null;
+  }
+  if (!frontmatter) return null;
+  const value = frontmatter[target];
+  if (!Array.isArray(value)) return null;
+  return (
+    `Refusing to replace array-valued frontmatter field "${target}" ` +
+    `with text/markdown content: the Local REST API would silently ` +
+    `coerce the field from array to scalar string and corrupt the ` +
+    `existing structure. Pass contentType="application/json" and ` +
+    `content as a JSON-encoded value — for example ` +
+    `'["new"]' to set a single-element array, ` +
+    `'["a","b"]' for multiple elements, or ` +
+    `'null' to clear the field.`
+  );
+}
+
+/**
+ * Frontmatter `append`/`prepend` against an array-valued field requires the
+ * Local REST API to receive the new element wrapped in a JSON array. When the
+ * caller passes a JSON scalar (`'"new-tag"'` rather than `'["new-tag"]'`)
+ * the upstream parser raises and the request returns HTTP 500 with no
+ * actionable hint. The intent is unambiguous (append THIS element to the
+ * array), so wrap the scalar in a single-element array client-side rather
+ * than reject — DWIM where there is exactly one reasonable interpretation.
+ *
+ * Only triggers on `targetType === "frontmatter"` + `append`/`prepend` +
+ * `contentType === "application/json"` to keep the surface area minimal:
+ *
+ *   - heading/block targets are unaffected (their content is markdown text,
+ *     not JSON).
+ *   - `replace` is unaffected (caller may legitimately want to replace an
+ *     array with a scalar; that ambiguity is handled by
+ *     `detectFrontmatterReplaceArrayMismatch` above, not by auto-wrapping).
+ *   - non-JSON content types are unaffected.
+ *
+ * If the body is not parseable JSON we forward it untouched and let the REST
+ * API surface its own error — silently rewriting a malformed payload would
+ * just move the failure further down the stack.
+ *
+ * Pure / synchronous for unit testing. Fixes folotp's #13.
+ */
+export function coerceFrontmatterAppendArrayContent(
+  content: string,
+  args: FrontmatterPatchPrecheckArgs,
+): string {
+  if (
+    args.targetType !== "frontmatter" ||
+    (args.operation !== "append" && args.operation !== "prepend") ||
+    args.contentType !== "application/json"
+  ) {
+    return content;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return content;
+  }
+  if (Array.isArray(parsed)) return content;
+  return JSON.stringify([parsed]);
+}
+
 export function registerLocalRestApiTools(tools: ToolRegistry) {
   // GET Status
   tools.register(
@@ -451,7 +554,51 @@ export function registerLocalRestApiTools(tools: ToolRegistry) {
         }
       }
 
-      const body = normalizeAppendBody(args.content, args.operation);
+      // Step 2 (issue #12): when a frontmatter `replace` lands on an
+      // array-valued field without an explicit JSON content type, the
+      // PATCH would silently destroy the array structure. Pre-fetch the
+      // parsed frontmatter and reject with an actionable 400 instead.
+      // Only one extra GET per frontmatter+replace+text-markdown call;
+      // all other patch shapes skip the precheck.
+      if (
+        args.targetType === "frontmatter" &&
+        args.operation === "replace" &&
+        args.contentType !== "application/json"
+      ) {
+        let frontmatter: Record<string, unknown> | undefined;
+        try {
+          const note = await makeRequest(LocalRestAPI.ApiNoteJson, "/active/", {
+            headers: { Accept: "application/vnd.olrapi.note+json" },
+          });
+          frontmatter = note.frontmatter;
+        } catch {
+          // Best-effort: if we cannot read the file (404, permission, etc.)
+          // skip the precheck and let the actual PATCH propagate the error.
+        }
+        const errorMessage = detectFrontmatterReplaceArrayMismatch(
+          frontmatter,
+          args,
+          args.target,
+        );
+        if (errorMessage) {
+          throw new McpError(ErrorCode.InvalidParams, errorMessage);
+        }
+      }
+
+      // Step 3 (issue #13): for frontmatter append/prepend with JSON
+      // content, auto-wrap a JSON scalar payload in a single-element
+      // array. The REST API returns 500 on scalar input — DWIM where
+      // there is one reasonable interpretation. Skip normalizeAppendBody
+      // in this branch so the trailing "\n\n" does not invalidate the
+      // JSON body we just normalized.
+      const isJsonFrontmatterAppendPrepend =
+        args.targetType === "frontmatter" &&
+        (args.operation === "append" || args.operation === "prepend") &&
+        args.contentType === "application/json";
+
+      const body = isJsonFrontmatterAppendPrepend
+        ? coerceFrontmatterAppendArrayContent(args.content, args)
+        : normalizeAppendBody(args.content, args.operation);
       const headers = buildPatchHeaders(args, resolvedTarget);
 
       const response = await makeRequest(
@@ -776,12 +923,13 @@ export function registerLocalRestApiTools(tools: ToolRegistry) {
       "Insert or modify content in a file relative to a heading, block reference, or frontmatter field.",
     ),
     async ({ arguments: args }) => {
-      // See patch_active_file above for the full rationale of these three
-      // steps. The only difference here is the endpoint from which we
-      // fetch file content for heading resolution — the named vault file
-      // instead of the currently active file.
+      // See patch_active_file above for the full rationale of every step.
+      // The only difference here is the endpoint from which we fetch file
+      // content (heading resolution + frontmatter precheck) — the named
+      // vault file instead of the currently active file.
       const targetDelimiter = args.targetDelimiter ?? "::";
       let resolvedTarget = args.target;
+      const fileEndpoint = `/vault/${encodeURIComponent(args.filename)}`;
 
       if (
         args.targetType === "heading" &&
@@ -789,7 +937,7 @@ export function registerLocalRestApiTools(tools: ToolRegistry) {
       ) {
         const fileContent = await makeRequest(
           LocalRestAPI.ApiContentResponse,
-          `/vault/${encodeURIComponent(args.filename)}`,
+          fileEndpoint,
           { headers: { Accept: "text/markdown" } },
         );
         const fullPath = resolveHeadingPath(
@@ -802,12 +950,49 @@ export function registerLocalRestApiTools(tools: ToolRegistry) {
         }
       }
 
-      const body = normalizeAppendBody(args.content, args.operation);
+      // Issue #12: reject silent array→scalar coercion on frontmatter
+      // replace. See patch_active_file for the full rationale.
+      if (
+        args.targetType === "frontmatter" &&
+        args.operation === "replace" &&
+        args.contentType !== "application/json"
+      ) {
+        let frontmatter: Record<string, unknown> | undefined;
+        try {
+          const note = await makeRequest(
+            LocalRestAPI.ApiNoteJson,
+            fileEndpoint,
+            { headers: { Accept: "application/vnd.olrapi.note+json" } },
+          );
+          frontmatter = note.frontmatter;
+        } catch {
+          // Best-effort: skip the precheck on read failure.
+        }
+        const errorMessage = detectFrontmatterReplaceArrayMismatch(
+          frontmatter,
+          args,
+          args.target,
+        );
+        if (errorMessage) {
+          throw new McpError(ErrorCode.InvalidParams, errorMessage);
+        }
+      }
+
+      // Issue #13: auto-wrap scalar JSON payload for frontmatter
+      // append/prepend. See patch_active_file for the full rationale.
+      const isJsonFrontmatterAppendPrepend =
+        args.targetType === "frontmatter" &&
+        (args.operation === "append" || args.operation === "prepend") &&
+        args.contentType === "application/json";
+
+      const body = isJsonFrontmatterAppendPrepend
+        ? coerceFrontmatterAppendArrayContent(args.content, args)
+        : normalizeAppendBody(args.content, args.operation);
       const headers = buildPatchHeaders(args, resolvedTarget);
 
       const response = await makeRequest(
         LocalRestAPI.ApiContentResponse,
-        `/vault/${encodeURIComponent(args.filename)}`,
+        fileEndpoint,
         {
           method: "PATCH",
           headers,

--- a/packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts
+++ b/packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildPatchHeaders,
+  coerceFrontmatterAppendArrayContent,
+  detectFrontmatterReplaceArrayMismatch,
   normalizeAppendBody,
   resolveHeadingPath,
 } from "./index";
@@ -335,5 +337,247 @@ describe("normalizeAppendBody — trailing newline safeguard", () => {
     // must not crash, and the `\n\n` is preserved semantics (a zero-length
     // payload followed by separation) rather than a special case.
     expect(normalizeAppendBody("", "append")).toBe("\n\n");
+  });
+});
+
+describe("detectFrontmatterReplaceArrayMismatch — issue #12 (silent array→scalar corruption)", () => {
+  const replaceTextMd = {
+    targetType: "frontmatter" as const,
+    operation: "replace" as const,
+  };
+
+  test("returns an error for an array-valued field with text/markdown replace", () => {
+    // The exact scenario folotp reported: tags is an array, the caller
+    // passes a plain string, the REST API would coerce array→scalar
+    // silently. We must reject so the corruption never reaches the file.
+    const message = detectFrontmatterReplaceArrayMismatch(
+      { tags: ["alpha", "beta"] },
+      replaceTextMd,
+      "tags",
+    );
+    expect(message).not.toBeNull();
+    expect(message).toContain('"tags"');
+    expect(message).toContain("application/json");
+  });
+
+  test("returns null when the field exists but is a scalar string", () => {
+    // Replacing a scalar with another scalar is the legitimate, safe case
+    // and must keep working with no extra friction.
+    expect(
+      detectFrontmatterReplaceArrayMismatch(
+        { title: "old" },
+        replaceTextMd,
+        "title",
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null when the field exists but is a number", () => {
+    // Numbers are scalars too; no array-shape concern.
+    expect(
+      detectFrontmatterReplaceArrayMismatch(
+        { rating: 4 },
+        replaceTextMd,
+        "rating",
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null when the field is absent (caller is creating it)", () => {
+    // If the field doesn't exist yet, there is no array structure to
+    // preserve; createTargetIfMissing handles the rest at the REST API.
+    expect(
+      detectFrontmatterReplaceArrayMismatch(
+        { other: "value" },
+        replaceTextMd,
+        "tags",
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null when frontmatter itself is undefined", () => {
+    // Defensive: pre-fetch may have failed (404, permission). We bail
+    // out cleanly instead of throwing.
+    expect(
+      detectFrontmatterReplaceArrayMismatch(undefined, replaceTextMd, "tags"),
+    ).toBeNull();
+  });
+
+  test("returns null when frontmatter itself is null", () => {
+    // Same defensive case for null.
+    expect(
+      detectFrontmatterReplaceArrayMismatch(null, replaceTextMd, "tags"),
+    ).toBeNull();
+  });
+
+  test("returns null when caller has explicitly opted into application/json", () => {
+    // Explicit JSON content type means the caller knows what they're
+    // doing — even if the resulting write reshapes the field, that's
+    // an explicit signal, not silent corruption.
+    expect(
+      detectFrontmatterReplaceArrayMismatch(
+        { tags: ["alpha"] },
+        {
+          targetType: "frontmatter",
+          operation: "replace",
+          contentType: "application/json",
+        },
+        "tags",
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null for non-replace operations (append/prepend handled elsewhere)", () => {
+    // The append/prepend silent-coercion class is handled by the
+    // coerceFrontmatterAppendArrayContent helper, not this one.
+    expect(
+      detectFrontmatterReplaceArrayMismatch(
+        { tags: ["alpha"] },
+        { targetType: "frontmatter", operation: "append" },
+        "tags",
+      ),
+    ).toBeNull();
+    expect(
+      detectFrontmatterReplaceArrayMismatch(
+        { tags: ["alpha"] },
+        { targetType: "frontmatter", operation: "prepend" },
+        "tags",
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null for non-frontmatter targets", () => {
+    // The wrapper only owns frontmatter shape preservation; heading and
+    // block patches go through their own (#71) safety nets.
+    expect(
+      detectFrontmatterReplaceArrayMismatch(
+        { tags: ["alpha"] },
+        { targetType: "heading", operation: "replace" },
+        "tags",
+      ),
+    ).toBeNull();
+    expect(
+      detectFrontmatterReplaceArrayMismatch(
+        { tags: ["alpha"] },
+        { targetType: "block", operation: "replace" },
+        "tags",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("coerceFrontmatterAppendArrayContent — issue #13 (500 on JSON scalar append)", () => {
+  const jsonAppend = {
+    targetType: "frontmatter" as const,
+    operation: "append" as const,
+    contentType: "application/json" as const,
+  };
+  const jsonPrepend = {
+    targetType: "frontmatter" as const,
+    operation: "prepend" as const,
+    contentType: "application/json" as const,
+  };
+
+  test('wraps a JSON string scalar in a single-element array on append', () => {
+    // The exact 500 case folotp reported: '"new-tag"' becomes '["new-tag"]'.
+    expect(coerceFrontmatterAppendArrayContent('"new-tag"', jsonAppend)).toBe(
+      '["new-tag"]',
+    );
+  });
+
+  test("wraps a JSON number scalar in a single-element array on append", () => {
+    expect(coerceFrontmatterAppendArrayContent("42", jsonAppend)).toBe("[42]");
+  });
+
+  test("wraps a JSON boolean scalar in a single-element array on append", () => {
+    expect(coerceFrontmatterAppendArrayContent("true", jsonAppend)).toBe(
+      "[true]",
+    );
+  });
+
+  test("wraps a JSON null scalar in a single-element array on append", () => {
+    // `null` is technically a scalar too — wrap it consistently rather
+    // than special-case (the user is explicit about wanting it appended).
+    expect(coerceFrontmatterAppendArrayContent("null", jsonAppend)).toBe(
+      "[null]",
+    );
+  });
+
+  test("wraps an object payload in a single-element array on append", () => {
+    // Same logic for an object payload — the REST API expects array form
+    // on the append/prepend op against an array-valued field.
+    expect(
+      coerceFrontmatterAppendArrayContent('{"key":"val"}', jsonAppend),
+    ).toBe('[{"key":"val"}]');
+  });
+
+  test("leaves a JSON array payload untouched on append", () => {
+    // Array form is the documented path; do not double-wrap.
+    expect(coerceFrontmatterAppendArrayContent('["new-tag"]', jsonAppend)).toBe(
+      '["new-tag"]',
+    );
+    expect(coerceFrontmatterAppendArrayContent("[1,2,3]", jsonAppend)).toBe(
+      "[1,2,3]",
+    );
+  });
+
+  test("applies the same wrap on prepend", () => {
+    // Prepend has the same scalar-vs-array constraint as append.
+    expect(coerceFrontmatterAppendArrayContent('"head"', jsonPrepend)).toBe(
+      '["head"]',
+    );
+  });
+
+  test("forwards malformed JSON untouched (lets the REST API surface its own error)", () => {
+    // Silently rewriting an invalid payload would just move the failure
+    // further down the stack and produce more confusing diagnostics.
+    expect(
+      coerceFrontmatterAppendArrayContent("not valid json", jsonAppend),
+    ).toBe("not valid json");
+    expect(coerceFrontmatterAppendArrayContent("{unbalanced", jsonAppend)).toBe(
+      "{unbalanced",
+    );
+  });
+
+  test("does not touch content when contentType is not application/json", () => {
+    // Plain text content (default) is not in scope — the REST API treats
+    // it differently and the auto-wrap reasoning does not apply.
+    expect(
+      coerceFrontmatterAppendArrayContent("plain text", {
+        targetType: "frontmatter",
+        operation: "append",
+      }),
+    ).toBe("plain text");
+  });
+
+  test("does not touch content on replace (replace ambiguity is handled elsewhere)", () => {
+    // Replace + scalar is intentionally NOT auto-wrapped — caller's
+    // intent is ambiguous (set scalar vs set single-element array). That
+    // ambiguity is handled by detectFrontmatterReplaceArrayMismatch.
+    expect(
+      coerceFrontmatterAppendArrayContent('"gamma"', {
+        targetType: "frontmatter",
+        operation: "replace",
+        contentType: "application/json",
+      }),
+    ).toBe('"gamma"');
+  });
+
+  test("does not touch content for non-frontmatter targets", () => {
+    // Heading / block content is markdown text, not JSON.
+    expect(
+      coerceFrontmatterAppendArrayContent('"foo"', {
+        targetType: "heading",
+        operation: "append",
+        contentType: "application/json",
+      }),
+    ).toBe('"foo"');
+    expect(
+      coerceFrontmatterAppendArrayContent('"foo"', {
+        targetType: "block",
+        operation: "prepend",
+        contentType: "application/json",
+      }),
+    ).toBe('"foo"');
   });
 });


### PR DESCRIPTION
## Summary

Two related footguns reported by @folotp on `patch_vault_file` /
`patch_active_file`, plus the 0.3.8 CHANGELOG entry that also credits
@ezrahill's PR #10 (already on `main` as `d27edfe`).

- **#12** — frontmatter `replace` on an array-valued field with
  text/markdown content silently coerced the field to scalar string
  (HTTP 200, file corrupted). Same family as the silent EOF append
  behaviour fixed for `targetType: "block"` in #71. The wrapper now
  pre-fetches the parsed frontmatter (one extra GET, only when the
  call shape is `frontmatter + replace + non-JSON content`) and
  rejects with `McpError(InvalidParams, …)` and an actionable message
  pointing at the JSON-content escape hatch (`'["new"]'`, `'null'`).
- **#13** — frontmatter `append`/`prepend` with `contentType:
  "application/json"` and a JSON scalar payload returned HTTP 500.
  The wrapper now auto-wraps the scalar in a single-element array
  client-side (DWIM since the intent is unambiguous). Malformed JSON
  is forwarded untouched.

Both helpers (`detectFrontmatterReplaceArrayMismatch`,
`coerceFrontmatterAppendArrayContent`) are pure / synchronous and
unit-tested in isolation.

## Verification

- `bun --filter '*' check`: 0 errors / 0 warnings across all four
  packages.
- `bun test` in `packages/mcp-server`: **178 pass / 0 fail** (158
  baseline + 20 new — 10 for #12, 10 for #13).
- `bun test` in `packages/shared` and `packages/obsidian-plugin`:
  unchanged, still green.
- `bun.lock`: unchanged (no risk of frozen-lockfile CI regression).

End-to-end smoke test against vault `TEST` + Obsidian 1.12.7 +
`obsidian-local-rest-api` 3.6.1 + Claude Desktop:

| Test | Setup | Expected | Actual |
|---|---|---|---|
| #12 | `tags: [alpha, beta]`, `op=replace`, `content="gamma"`, no `contentType` | 400 actionable, file unchanged | ✅ `McpError -32602` with full JSON-escape-hatch message; file mtime untouched |
| #13 | `tags: [existing]`, `op=append`, `contentType=application/json`, `content='"new-tag"'` | 200 success, `tags: [existing, new-tag]` | ✅ identical |

PR #10 fix (search_vault_smart) was not re-smoke-tested in this
session because the `TEST` vault does not have Smart Connections
installed; ezrahill's 6 unit tests in
`packages/shared/src/types/smart-search.test.ts` pin the contract
and are green in this branch.

## Test plan

- [x] `bun --filter '*' check` clean.
- [x] `bun test` in all three runtime packages green.
- [x] Smoke test #12 in vault TEST: file preserved, error message actionable.
- [x] Smoke test #13 in vault TEST: file correctly extended.
- [x] Cleanup of test files in vault TEST.

## Out of scope (deferred)

- **#11** (install outside vault writes empty `mcpServers: {}`) — not
  reproducible from the code path. Awaiting log/context from @folotp
  before targeting 0.3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)