### PR TITLE
fix(0.3.9): reject root-orphan H2+ heading targets (#71 heading half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to **MCP Connector** (formerly `obsidian-mcp-tools`) are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.3.9] — 2026-04-26
+
+### Fixed
+- **`patch_vault_file` / `patch_active_file` silently EOF-appended
+  content when targeting a root-orphan heading** (`targetType:
+  "heading"`, `operation: "replace"`/`"append"`/`"prepend"`, leaf
+  name pointing at a non-H1 heading at the root of the file with no
+  level-1 (`#`) parent). Same family as the silent EOF append
+  behaviour fixed for `block` targets in #71 (0.3.7). Root cause: the
+  Local REST API's `markdown-patch` indexer keys headings by their
+  full hierarchical path starting from H1, so a root-orphan H2/H3/…
+  cannot be addressed by leaf name. With the upstream-compat default
+  `Create-Target-If-Missing: true` for headings, the PATCH fell
+  through to the silent-create branch and returned HTTP 200 with the
+  caller's content appended at EOF, leaving a duplicate heading and
+  no in-place edit.
+
+  The wrapper now calls a new `detectOrphanRootHeading` helper
+  immediately after fetching the file content (which it already
+  needed for `resolveHeadingPath` — no extra GET roundtrip) and
+  throws `McpError(ErrorCode.InvalidParams, …)` with an actionable
+  message before the silent corruption can land. The error message
+  documents both workarounds: add a level-1 heading at the top of
+  the file, or pass `createTargetIfMissing=false` to make the
+  failure explicit.
+
+  Twelve regression tests in `patchVaultFile.test.ts` pin the
+  detection: @folotp's exact repro, the canonical valid cases (H1
+  root, H2 nested under H1, H3 under H1+H2), the orphan
+  generalization to H3 and H3-under-orphan-H2, the first-match-wins
+  ambiguity rule, and defensive cases (heading not found, empty
+  content, mid-paragraph fake-heading text, sticky H1 ancestor
+  flag). Closes the heading half of upstream
+  `jacksteamdev/obsidian-mcp-tools#71`; reported by @folotp on the
+  v0.3.7 follow-up.
+
 ## [0.3.8] — 2026-04-26
 
 ### Fixed

--- a/packages/mcp-server/src/features/local-rest-api/index.ts
+++ b/packages/mcp-server/src/features/local-rest-api/index.ts
@@ -80,6 +80,62 @@ export function normalizeAppendBody(
 }
 
 /**
+ * Detect a "root-orphan" heading match: a non-H1 heading at the root of the
+ * file with no preceding H1 ancestor. The Local REST API's `markdown-patch`
+ * indexer keys headings by their full hierarchical path starting from H1,
+ * so a root-orphan H2/H3/… cannot be addressed by leaf name (or by any path
+ * the wrapper can synthesize). Under the upstream-compat default
+ * `Create-Target-If-Missing: true` for headings, the PATCH falls through to
+ * the silent-create branch and appends the caller's content at EOF, leaving
+ * the file with a duplicate heading and no in-place edit. Same family as
+ * the silent EOF append behaviour fixed for `block` targets in #71 (0.3.7).
+ *
+ * Returns an actionable error message string when the call must be rejected,
+ * or `null` when it is safe to proceed. Pure / synchronous so it can be unit
+ * tested without network. Closes the heading half of upstream
+ * `jacksteamdev/obsidian-mcp-tools#71`; reported by @folotp on the v0.3.7
+ * follow-up.
+ *
+ * Walks the document in order; the first match of `leafName` decides the
+ * outcome. If two headings share the same name and the earlier one is
+ * orphan-root, the call is rejected — that ambiguity is itself a footgun
+ * and a loud failure beats a coin-flip resolution.
+ */
+export function detectOrphanRootHeading(
+  content: string,
+  leafName: string,
+): string | null {
+  const lines = content.split("\n");
+  let hasH1Before = false;
+  for (const line of lines) {
+    const match = line.match(/^(#{1,6})\s+(.+)$/);
+    if (!match) continue;
+    const level = match[1].length;
+    const headingText = match[2].trim();
+    if (level === 1) hasH1Before = true;
+    if (headingText === leafName) {
+      if (level > 1 && !hasH1Before) {
+        return (
+          `Heading "${leafName}" is a level-${level} heading at the root ` +
+          `of the file with no level-1 (\`#\`) parent. The Local REST API's ` +
+          `markdown-patch indexer keys headings by their full hierarchical ` +
+          `path starting from H1 and cannot resolve a root-orphan H${level}+ ` +
+          `by leaf name; the PATCH would silently fall through to ` +
+          `Create-Target-If-Missing and append the content at EOF, leaving ` +
+          `a duplicate heading and no in-place edit. Workarounds: ` +
+          `(1) add a level-1 heading at the top of the file before this ` +
+          `section so the indexer has a key to anchor against; or ` +
+          `(2) pass createTargetIfMissing=false on the call to make the ` +
+          `failure explicit instead of a silent EOF append.`
+        );
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
  * Parse markdown content and resolve a partial heading name to its full
  * hierarchical path as expected by the Local REST API `markdown-patch`
  * indexer (e.g. `"Section A"` → `"Top Level::Section A"`).
@@ -544,6 +600,15 @@ export function registerLocalRestApiTools(tools: ToolRegistry) {
           "/active/",
           { headers: { Accept: "text/markdown" } },
         );
+        // Reject root-orphan H2+ targets BEFORE handing off to the REST API:
+        // markdown-patch keys headings under H1 and a leaf-only path for an
+        // orphan H2/H3 hits the silent-create branch. Closes the heading
+        // half of upstream #71. See detectOrphanRootHeading for the full
+        // rationale and workarounds.
+        const orphanError = detectOrphanRootHeading(fileContent, args.target);
+        if (orphanError) {
+          throw new McpError(ErrorCode.InvalidParams, orphanError);
+        }
         const fullPath = resolveHeadingPath(
           fileContent,
           args.target,
@@ -940,6 +1005,13 @@ export function registerLocalRestApiTools(tools: ToolRegistry) {
           fileEndpoint,
           { headers: { Accept: "text/markdown" } },
         );
+        // See patch_active_file for the full rationale: reject root-orphan
+        // H2+ targets before they hit the silent-create branch upstream.
+        // Closes the heading half of upstream #71.
+        const orphanError = detectOrphanRootHeading(fileContent, args.target);
+        if (orphanError) {
+          throw new McpError(ErrorCode.InvalidParams, orphanError);
+        }
         const fullPath = resolveHeadingPath(
           fileContent,
           args.target,

--- a/packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts
+++ b/packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts
@@ -3,6 +3,7 @@ import {
   buildPatchHeaders,
   coerceFrontmatterAppendArrayContent,
   detectFrontmatterReplaceArrayMismatch,
+  detectOrphanRootHeading,
   normalizeAppendBody,
   resolveHeadingPath,
 } from "./index";
@@ -579,5 +580,107 @@ describe("coerceFrontmatterAppendArrayContent — issue #13 (500 on JSON scalar 
         contentType: "application/json",
       }),
     ).toBe('"foo"');
+  });
+});
+
+describe("detectOrphanRootHeading — issue #71 heading half (root-orphan H2+)", () => {
+  test("rejects a level-2 heading at root with no H1 parent (folotp's exact repro)", () => {
+    // The minimal fixture from folotp's v0.3.7 follow-up on upstream #71:
+    // a single root H2 with no H1, addressed by leaf name. Without the
+    // wrapper-side rejection, markdown-patch would fall through to
+    // Create-Target-If-Missing and silently EOF-append.
+    const content = `## Section finale\n\nMarker.`;
+    const result = detectOrphanRootHeading(content, "Section finale");
+    expect(result).not.toBeNull();
+    expect(result).toContain('"Section finale"');
+    expect(result).toContain("level-2");
+    expect(result).toContain("createTargetIfMissing=false");
+  });
+
+  test("accepts a level-2 heading nested under an H1", () => {
+    // The canonical valid case: H2 has an H1 parent earlier in the doc.
+    // markdown-patch can resolve the full path "Top::Section A".
+    const content = `# Top\n\n## Section A\n\nBody.`;
+    expect(detectOrphanRootHeading(content, "Section A")).toBeNull();
+  });
+
+  test("accepts an H1 heading at root", () => {
+    // H1 itself is the indexer's anchor — no orphan concern. Folotp's
+    // control test on the v0.3.7 thread confirms this case works.
+    const content = `# Top Level\n\nBody.`;
+    expect(detectOrphanRootHeading(content, "Top Level")).toBeNull();
+  });
+
+  test("rejects a level-3 heading at root with no H1 ancestor", () => {
+    // Same family as the H2 case: any non-H1 heading without an H1 ancestor
+    // earlier in the document is an orphan as far as the indexer is
+    // concerned. Generalize the check to all levels >1.
+    const content = `### Deep root\n\nContent.`;
+    const result = detectOrphanRootHeading(content, "Deep root");
+    expect(result).not.toBeNull();
+    expect(result).toContain("level-3");
+  });
+
+  test("rejects a level-3 heading nested under a root-orphan H2", () => {
+    // The H3 inherits the orphan status from its only ancestor. There is
+    // no H1 anywhere before the match, so the indexer cannot key it.
+    const content = `## H2 root\n\n### H3 child\n\nContent.`;
+    const result = detectOrphanRootHeading(content, "H3 child");
+    expect(result).not.toBeNull();
+    expect(result).toContain('"H3 child"');
+    expect(result).toContain("level-3");
+  });
+
+  test("accepts a level-3 heading nested under an H1 → H2 chain", () => {
+    // Once a real H1 anchor exists, every deeper heading after it is
+    // resolvable. Folotp's "control test" listed this as passing on v0.3.7.
+    const content = `# Top\n\n## Middle\n\n### Deep\n\nContent.`;
+    expect(detectOrphanRootHeading(content, "Deep")).toBeNull();
+  });
+
+  test("rejects a root-orphan H2 even if a same-named H2 nested under H1 exists later", () => {
+    // First-match-wins. If the first occurrence of the leaf is orphan, we
+    // reject — otherwise the caller would silently target the orphan and
+    // get the EOF-append bug. The ambiguity itself is a separate footgun
+    // (two headings same name) and a loud failure is preferable.
+    const content = `## Section\n\n# Real Top\n\n## Section\n\nBody.`;
+    const result = detectOrphanRootHeading(content, "Section");
+    expect(result).not.toBeNull();
+  });
+
+  test("accepts when the first match is a valid H1, even with later orphan H2 with same name", () => {
+    // Inverse of the previous test: first match is the H1 itself, which
+    // is always valid. We never reach the later orphan H2 in the walk.
+    const content = `# Section\n\n## Other\n\nBody.`;
+    expect(detectOrphanRootHeading(content, "Section")).toBeNull();
+  });
+
+  test("returns null when the heading is not found at all", () => {
+    // Defensive: if the leaf doesn't exist anywhere, this helper has no
+    // opinion — the downstream PATCH will hit Create-Target-If-Missing
+    // (or fail explicitly per the per-target-type defaults wired in
+    // 0.3.7) and that is the correct behavior, not our concern here.
+    const content = `# Top\n\n## Section A`;
+    expect(detectOrphanRootHeading(content, "Nowhere")).toBeNull();
+  });
+
+  test("returns null for empty content", () => {
+    // Trivially safe — there is no heading to be orphan.
+    expect(detectOrphanRootHeading("", "anything")).toBeNull();
+  });
+
+  test("ignores non-heading lines that look like headings inside paragraph text", () => {
+    // The regex anchors to start-of-line, so a "## fake" mid-paragraph is
+    // not a heading. Mirrors the same parse rules as resolveHeadingPath.
+    const content = `paragraph with ## fake heading text\n\n# Real Top\n\n## Section`;
+    expect(detectOrphanRootHeading(content, "Section")).toBeNull();
+  });
+
+  test("respects an H1 that appears earlier even with intermediate non-heading content", () => {
+    // The ancestor flag is sticky once an H1 has been seen — anything
+    // matched after that line is non-orphan, even with arbitrary body
+    // content in between.
+    const content = `# Anchor\n\nLong body.\n\nMore body.\n\n## Later H2\n\nFinal body.`;
+    expect(detectOrphanRootHeading(content, "Later H2")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Closes the heading half of upstream `jacksteamdev/obsidian-mcp-tools#71`. Same family as the silent EOF append behaviour fixed for `block` targets in #71 (0.3.7); same family as the silent array→scalar coercion fixed for frontmatter `replace` in #12 (0.3.8). All three are wrapper-side mitigations against `markdown-patch` indexer gaps that would otherwise return HTTP 200 while corrupting the target file.

## The bug

@folotp confirmed the v0.3.7 block fix on upstream #71, then identified a separate failure on the heading half:

- Fixture: `## Section finale\n\nMarker.` (single H2 at root, no H1 parent)
- Call: `op=replace, targetType=heading, target="Section finale", content="REPLACED"`
- Result on 0.3.7: HTTP 200 + file becomes `## Section finale\n\nMarker.\n## Section finale\nREPLACED\n` (duplicate heading + EOF append, no in-place edit)
- Control tests (also v0.3.7): H1 root → OK, H2 under H1 → OK, H2 under H1 with non-ASCII → OK. Failure is specific to root-orphan H2+.

Root cause: `markdown-patch` keys headings by their full hierarchical path starting from H1. A root-orphan H2 has no key the indexer can resolve from a leaf-only target. With the upstream-compat default `Create-Target-If-Missing: true` for headings, the PATCH falls through to silent-create.

## What changed

New helper `detectOrphanRootHeading(content, leafName)`:

- Walks the document in order
- Tracks whether an H1 has been seen (`hasH1Before`)
- On the first match of `leafName`, if the matched heading is at level >1 with no preceding H1 ancestor, returns an actionable error message documenting both workarounds (add an H1 at the top, or pass `createTargetIfMissing=false`)
- Returns `null` otherwise (safe to proceed)

Both handlers (`patch_active_file`, `patch_vault_file`) call the helper immediately after fetching the file content (which they already needed for `resolveHeadingPath` — no extra GET roundtrip) and throw `McpError(ErrorCode.InvalidParams, …)` if the orphan case is detected.

## Verification

- `bun --filter '*' check`: 0 errors / 0 warnings across all four packages
- `bun test` in `packages/mcp-server`: **190 pass / 0 fail** (178 baseline + 12 new orphan-detection tests)
- `bun.lock`: unchanged

Twelve new tests in `patchVaultFile.test.ts` pin:

- @folotp's exact `## Section finale` repro
- Canonical valid cases: H1 at root, H2 under H1, H3 under H1+H2
- Orphan generalization: H3 root with no ancestors, H3 under root-orphan H2
- First-match-wins ambiguity rule (root-orphan + same-named valid later → reject; valid H1 + same-named orphan H2 later → accept)
- Defensive cases: heading not found, empty content, mid-paragraph fake-heading text, sticky H1 ancestor flag

## Test plan

- [x] `bun --filter '*' check` clean
- [x] `bun test` 190/190 green
- [x] CHANGELOG entry references @folotp's repro and cross-links upstream #71
- [ ] Smoke test in vault TEST after merge (worktree pattern, then symlink restore — same flow as 0.3.8)

## Out of scope

- Upstream `markdown-patch` indexer changes (would resolve this server-side too) — out of our control.
- Upstream `obsidian-local-rest-api` synthetic root-path admission — out of our control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)