### PR TITLE
chore(install): pin updateClaudeConfig invariants for #11 + diagnostic logging

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-server-install/services/config.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-server-install/services/config.test.ts
@@ -282,3 +282,177 @@ describe("removeFromClaudeConfig", () => {
     expect(content).toEqual(originalContent);
   });
 });
+
+describe("updateClaudeConfig — issue #11 investigation (folotp toggle scenario + edge cases)", () => {
+  if (os.platform() !== "darwin") {
+    test.skip("issue #11 investigation tests run only on macOS", () => {});
+    return;
+  }
+
+  let tmpRoot: string;
+  let configPath: string;
+  let homedirSpy: Mock<typeof os.homedir>;
+
+  const SYS = "/Users/folotp/Library/Application Support/obsidian-mcp-tools/bin/mcp-server";
+  const VAULT = "/Users/folotp/Obsidian/vault/.obsidian/plugins/mcp-tools-istefox/bin/mcp-server";
+  const KEY = "test-api-key-64-hex-chars";
+
+  beforeEach(async () => {
+    tmpRoot = await fsp.mkdtemp(
+      path.join(os.tmpdir(), "mcp-tools-issue11-test-"),
+    );
+    homedirSpy = spyOn(os, "homedir").mockReturnValue(tmpRoot);
+    configPath = path.join(
+      tmpRoot,
+      "Library/Application Support/Claude/claude_desktop_config.json",
+    );
+  });
+
+  afterEach(async () => {
+    homedirSpy.mockRestore();
+    await fsp.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  test("folotp's exact toggle sequence: outside → vault → outside leaves the entry intact", async () => {
+    // The bug @folotp reported on the fork at #11 says: under
+    // "Outside vault" location, Install Server downloads the binary
+    // but the config is rewritten with `mcpServers: {}`. Toggling to
+    // "Inside vault" and re-installing fixes it; toggling back loses
+    // it again. handleInstallLocationChange does NOT call
+    // updateClaudeConfig — only the Install button does. So the
+    // observable sequence in the config writer is: write SYS, write
+    // VAULT, write SYS. This test pins that the writer never produces
+    // the empty `mcpServers: {}` shape across that sequence.
+
+    // Step 1: Install while location=outside-vault.
+    await updateClaudeConfig(null, SYS, KEY);
+    let content = JSON.parse(await fsp.readFile(configPath, "utf8"));
+    expect(content.mcpServers["obsidian-mcp-tools"]?.command).toBe(SYS);
+
+    // Step 2 (no-op in the writer): toggle to vault.
+
+    // Step 3: Install while location=vault.
+    await updateClaudeConfig(null, VAULT, KEY);
+    content = JSON.parse(await fsp.readFile(configPath, "utf8"));
+    expect(content.mcpServers["obsidian-mcp-tools"]?.command).toBe(VAULT);
+
+    // Step 4 (no-op): toggle back to outside-vault.
+
+    // Step 5: Install while location=outside-vault.
+    await updateClaudeConfig(null, SYS, KEY);
+    content = JSON.parse(await fsp.readFile(configPath, "utf8"));
+    // The bug would be: mcpServers === {} or entry missing.
+    expect(content.mcpServers["obsidian-mcp-tools"]?.command).toBe(SYS);
+    expect(Object.keys(content.mcpServers)).toContain("obsidian-mcp-tools");
+  });
+
+  test("serverPath as empty string still writes an entry (does NOT produce `mcpServers: {}`)", async () => {
+    // Defensive: even with a falsy serverPath, the writer assigns the
+    // entry. JSON.stringify omits undefined values inside the entry but
+    // keeps the entry key itself. This test pins that the writer never
+    // collapses to empty `mcpServers` regardless of serverPath shape.
+    await updateClaudeConfig(null, "", KEY);
+    const content = JSON.parse(await fsp.readFile(configPath, "utf8"));
+    expect("obsidian-mcp-tools" in content.mcpServers).toBe(true);
+    expect(content.mcpServers["obsidian-mcp-tools"].command).toBe("");
+    // mcpServers is NOT empty — the bug shape would be { mcpServers: {} }
+    expect(Object.keys(content.mcpServers).length).toBe(1);
+  });
+
+  test("serverPath as undefined still writes an entry (env survives, command omitted by JSON.stringify)", async () => {
+    // Probes the exact shape: undefined as serverPath via type cast
+    // (mimicking a buggy caller).
+    await updateClaudeConfig(null, undefined as unknown as string, KEY);
+    const content = JSON.parse(await fsp.readFile(configPath, "utf8"));
+    expect("obsidian-mcp-tools" in content.mcpServers).toBe(true);
+    // command is undefined → JSON.stringify omits the key, but the
+    // entry object survives because env is still there.
+    expect("command" in content.mcpServers["obsidian-mcp-tools"]).toBe(false);
+    expect(content.mcpServers["obsidian-mcp-tools"].env).toEqual({
+      OBSIDIAN_API_KEY: KEY,
+    });
+    // Entry NOT empty.
+    expect(Object.keys(content.mcpServers).length).toBe(1);
+  });
+
+  test("malformed existing JSON throws — the writer does NOT silently overwrite to `mcpServers: {}`", async () => {
+    // Pre-existing config that fails JSON.parse: the writer must
+    // throw, not swallow + overwrite with a fresh empty config.
+    // Folotp's "rewritten with empty mcpServers" symptom would
+    // manifest here if the writer caught SyntaxError silently.
+    await fsp.mkdir(path.dirname(configPath), { recursive: true });
+    const corrupt = "{ mcpServers: { invalid json no quotes";
+    await fsp.writeFile(configPath, corrupt);
+
+    await expect(
+      updateClaudeConfig(null, SYS, KEY),
+    ).rejects.toThrow(/Failed to update Claude config/);
+
+    // Confirm the writer did NOT replace the corrupt content.
+    const after = await fsp.readFile(configPath, "utf8");
+    expect(after).toBe(corrupt);
+  });
+
+  test("empty existing file throws (JSON.parse('') is a SyntaxError) — the writer does NOT overwrite", async () => {
+    // Same defensive guarantee for the special case of a zero-byte
+    // file. Some users hit this when an editor or sync tool truncates
+    // the config mid-write and leaves a 0-byte stub.
+    await fsp.mkdir(path.dirname(configPath), { recursive: true });
+    await fsp.writeFile(configPath, "");
+
+    await expect(
+      updateClaudeConfig(null, SYS, KEY),
+    ).rejects.toThrow(/Failed to update Claude config/);
+
+    const after = await fsp.readFile(configPath, "utf8");
+    expect(after).toBe("");
+  });
+
+  test("existing config with `mcpServers: {}` is written CORRECTLY with the entry on a fresh install", async () => {
+    // The control test: if a user's config legitimately has empty
+    // `mcpServers: {}` (e.g. they removed all entries manually), the
+    // first Install Server call must populate it correctly. If folotp
+    // saw `mcpServers: {}` AFTER clicking Install, this test path
+    // proves the writer does not produce that shape on this input.
+    await fsp.mkdir(path.dirname(configPath), { recursive: true });
+    await fsp.writeFile(configPath, JSON.stringify({ mcpServers: {} }));
+
+    await updateClaudeConfig(null, SYS, KEY);
+    const content = JSON.parse(await fsp.readFile(configPath, "utf8"));
+    expect(content.mcpServers["obsidian-mcp-tools"]?.command).toBe(SYS);
+  });
+
+  test("BOM-prefixed JSON file is rejected (writer does not silently strip and overwrite)", async () => {
+    // Some Windows editors prepend U+FEFF to JSON files. JSON.parse
+    // chokes on it. The writer must throw, not silently overwrite the
+    // BOM file with a fresh `mcpServers: {}` config.
+    await fsp.mkdir(path.dirname(configPath), { recursive: true });
+    const bomContent =
+      "﻿" + JSON.stringify({ mcpServers: { existing: { command: "/x" } } });
+    await fsp.writeFile(configPath, bomContent);
+
+    await expect(
+      updateClaudeConfig(null, SYS, KEY),
+    ).rejects.toThrow(/Failed to update Claude config/);
+    // The BOM-prefixed file is preserved on throw — not clobbered.
+    const after = await fsp.readFile(configPath, "utf8");
+    expect(after).toBe(bomContent);
+  });
+
+  test("missing top-level `mcpServers` key (config has only unrelated keys) gets `mcpServers` recreated and entry added", async () => {
+    // The `config.mcpServers = config.mcpServers || {}` guard at line
+    // 96 of config.ts kicks in here. Defensive against an existing
+    // config that someone edited to remove the mcpServers section
+    // entirely.
+    await fsp.mkdir(path.dirname(configPath), { recursive: true });
+    await fsp.writeFile(
+      configPath,
+      JSON.stringify({ unrelatedTopLevelKey: "preserve me" }),
+    );
+
+    await updateClaudeConfig(null, SYS, KEY);
+    const content = JSON.parse(await fsp.readFile(configPath, "utf8"));
+    expect(content.mcpServers["obsidian-mcp-tools"]?.command).toBe(SYS);
+    expect(content.unrelatedTopLevelKey).toBe("preserve me");
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-server-install/services/config.ts
+++ b/packages/obsidian-plugin/src/features/mcp-server-install/services/config.ts
@@ -85,20 +85,60 @@ export async function updateClaudeConfig(
     const configPath = getConfigPath();
     const configDir = path.dirname(configPath);
 
+    // Defensive logging: capture the inputs every time. Tracking down
+    // user reports that "the config is empty after Install" requires
+    // knowing what was actually called and with what arguments. We
+    // never log the apiKey itself — only its presence and length —
+    // because it is a credential.
+    logger.info("updateClaudeConfig: invoked", {
+      configPath,
+      serverPathLength: serverPath?.length ?? 0,
+      hasServerPath: typeof serverPath === "string" && serverPath.length > 0,
+      hasApiKey: typeof apiKey === "string" && apiKey.length > 0,
+      apiKeyLength: apiKey?.length ?? 0,
+      extraEnvKeys: extraEnv ? Object.keys(extraEnv) : [],
+    });
+
     // Ensure config directory exists
     await fsp.mkdir(configDir, { recursive: true });
 
     // Read existing config or create new one
     let config: ClaudeConfig = { mcpServers: {} };
+    let preExistingMcpServerKeys: string[] = [];
+    let fileExistedBefore = false;
     try {
       const content = await fsp.readFile(configPath, "utf8");
+      fileExistedBefore = true;
       config = JSON.parse(content);
       config.mcpServers = config.mcpServers || {};
+      preExistingMcpServerKeys = Object.keys(config.mcpServers);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        // SyntaxError on JSON.parse, EACCES, EISDIR, etc. — log the
+        // shape so diagnosis does not require attaching to the actual
+        // user's machine. Then propagate (caller decides how to recover).
+        logger.error("updateClaudeConfig: failed to read existing config", {
+          configPath,
+          errorName: error instanceof Error ? error.name : "Unknown",
+          errorCode: (error as NodeJS.ErrnoException).code,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
         throw error;
       }
       // File doesn't exist, use default empty config
+      logger.debug("updateClaudeConfig: config file did not exist, will create", {
+        configPath,
+      });
+    }
+
+    if (fileExistedBefore) {
+      logger.debug("updateClaudeConfig: read existing config", {
+        configPath,
+        preExistingMcpServerKeys,
+        hadOurEntryAlready: preExistingMcpServerKeys.includes(
+          "obsidian-mcp-tools",
+        ),
+      });
     }
 
     // Update config with our server entry. Any extra env vars are
@@ -111,9 +151,20 @@ export async function updateClaudeConfig(
       },
     };
 
+    const finalKeys = Object.keys(config.mcpServers);
+
     // Write updated config
     await fsp.writeFile(configPath, JSON.stringify(config, null, 2));
-    logger.info("Updated Claude config", { configPath });
+    // Defensive: log the post-write shape so a user reporting "the
+    // entry is missing after Install" can be cross-checked against
+    // what the writer actually persisted in the same process tick.
+    logger.info("updateClaudeConfig: wrote config", {
+      configPath,
+      mcpServerKeysAfter: finalKeys,
+      ourEntryWritten: finalKeys.includes("obsidian-mcp-tools"),
+      ourCommandLength:
+        config.mcpServers["obsidian-mcp-tools"]?.command?.length ?? 0,
+    });
   } catch (error) {
     logger.error("Failed to update Claude config:", { error });
     throw new Error(


### PR DESCRIPTION
## Summary

Investigation pack for fork [#11](https://github.com/istefox/obsidian-mcp-connector/issues/11) (folotp: Install Server "outside vault" leaves `mcpServers: {}` in claude_desktop_config.json). Two non-behavioral additions:

1. **8 invariant tests** in `config.test.ts` proving that `updateClaudeConfig` cannot produce the empty-`mcpServers` shape folotp described, across every edge case I could enumerate.
2. **Diagnostic logging** in `updateClaudeConfig` so the next time the symptom is reported, the Obsidian dev console shows exactly what was received and persisted — no more guessing whether the writer was even called.

No version bump (test + diagnostic only). The fix branch for #11 itself stays parked until folotp posts logs from the new diagnostic output.

## What changed

### `config.test.ts` (+174 lines, 8 new tests in a new `describe` block)

| Test | Pins |
|---|---|
| folotp's exact toggle sequence | write SYS, write VAULT, write SYS leaves entry at every step |
| `serverPath = ""` | entry present, command="" — does NOT collapse to `mcpServers: {}` |
| `serverPath = undefined` (cast) | entry present, command key omitted by JSON.stringify, env intact |
| Malformed existing JSON | THROWS, file preserved on disk (no silent overwrite to empty) |
| Empty existing file (zero-byte) | THROWS, file preserved |
| Existing `{ mcpServers: {} }` | entry written correctly |
| Existing config with BOM marker (UTF-8) | THROWS, BOM file preserved |
| Existing config without `mcpServers` key | recreated by the `\|\| {}` guard, entry added, unrelated keys preserved |

All 8 pass on `main` → the writer is not the source of folotp's symptom. The tests stay as regression pins so any future refactor that breaks an invariant surfaces loud.

### `config.ts` diagnostic logging (+38 lines)

- **INFO at entry**: `configPath`, presence/length of `serverPath`, presence/length of `apiKey`, `extraEnv` keys. **No credential leak** — only lengths and key names.
- **DEBUG on existing-config read**: pre-existing `mcpServers` keys + whether our entry was already there.
- **ERROR on non-ENOENT read failure** (SyntaxError, EACCES, EISDIR, etc.): structured context (`errorName`, `errorCode`, `errorMessage`) so diagnosis does not require attaching to the user's machine.
- **INFO post-write**: final `mcpServers` keys + whether our entry was written + length of our command.

The existing INFO `Updated Claude config` log is replaced with the more detailed `updateClaudeConfig: wrote config` line.

## Why no version bump

Pure test + observability change. No behavior change in the writer: every code path the writer takes today is preserved exactly. The diagnostic logs only fire if a logger transport is configured (file logger in production builds), so users on BRAT see no UI difference.

## Verification

- `bun --filter '*' check`: 0 errors / 0 warnings across all four packages
- `bun test packages/obsidian-plugin/src/features/mcp-server-install/services/config.test.ts`: **17 pass / 0 fail** (9 existing + 8 new)
- `bun.lock`: unchanged

## Test plan

- [x] `bun --filter '*' check` clean
- [x] All 17 config tests green
- [x] Logging strings reviewed for credential leak (only lengths + presence flags + key names)
- [x] Branch protection respected (chore-typed change, branch+PR, no direct push to main)

## Out of scope

- The actual fix for #11 (still pending repro from folotp's environment with the new logs).
- Changes to `installMcpServer` or `handleInstall` (no evidence those misbehave; the writer was the prime suspect and is now ruled out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)