### PR TITLE
chore: refresh CLAUDE.md version + add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,92 @@
+# Dependabot keeps direct dependencies and GitHub Actions current.
+# Bun workspaces use the npm registry under the hood, so the `npm`
+# ecosystem covers `package.json` files in every workspace package.
+# Schedule is monthly to avoid PR noise on a small-team fork.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      types:
+        patterns:
+          - "@types/*"
+      dev-tooling:
+        patterns:
+          - "prettier"
+          - "typescript"
+          - "tsc-watch"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/mcp-server"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "scope:mcp-server"
+    commit-message:
+      prefix: "chore(deps,mcp-server)"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/obsidian-plugin"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "scope:obsidian-plugin"
+    commit-message:
+      prefix: "chore(deps,plugin)"
+      include: "scope"
+    ignore:
+      # Patched at 5.16.0 — see patches/svelte@5.16.0.patch.
+      # Bumps must re-validate the patch under bun's bundler.
+      - dependency-name: "svelte"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/shared"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "scope:shared"
+    commit-message:
+      prefix: "chore(deps,shared)"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "scope:ci"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Two shipping components glued together by the Local REST API plugin:
 
 Why the detour through Local REST API instead of reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the server invoke other Obsidian plugins (Templater, Smart Connections, Dataview) through their APIs.
 
-Current version: **0.2.27** (see root `package.json`). License: MIT.
+Current version: **0.3.10** on `main` (latest stable, BRAT users install this); **0.4.0-beta.1** on `feat/http-embedded` (the HTTP-embedded pivot). See root `package.json`. License: MIT.
 
 ### Fork status
 
@@ -21,20 +21,20 @@ Active work happens on the **`istefox/obsidian-mcp-connector`** fork. Upstream `
 
 ### Branch protection policy (2026-04-25, set by Stefano)
 
-**`main` is the production-ready, user-facing branch — currently 0.3.7. Treat it as protected.**
+**`main` is the production-ready, user-facing branch — currently 0.3.10. Treat it as protected.**
 
-Active branches as of 2026-04-25:
+Active branches as of 2026-04-28:
 
 | Branch | Version | Status | Use |
 |---|---|---|---|
-| `main` | **0.3.7** | **PROTECTED** — stable, BRAT users install this | Bug-fix patches only (0.3.x line) |
-| `feat/http-embedded` | **0.4.0-alpha.1** | Active development — Phase 1 infrastructure | The HTTP-embedded pivot per `docs/design/2026-04-24-http-embedded-design.md` |
+| `main` | **0.3.10** | **PROTECTED** — stable, BRAT users install this | Bug-fix patches only (0.3.x line) |
+| `feat/http-embedded` | **0.4.0-beta.1** | Active development — Phase 1 infrastructure | The HTTP-embedded pivot per `docs/design/2026-04-24-http-embedded-design.md` |
 
 **Hard rules — apply unless Stefano explicitly authorizes the specific action:**
 
 1. **Never merge** `feat/http-embedded` (or any experimental branch) **into `main`**. The merge to 0.4.0 happens only when Stefano gives explicit go-ahead, after Phase 2-3-4 are complete and feature parity with 0.3.x is verified.
 2. **Never force-push, rebase, or `reset --hard`** on `main` under any circumstance.
-3. **Never delete or overwrite tags** on the 0.3.x line (0.3.0 through 0.3.7).
+3. **Never delete or overwrite tags** on the 0.3.x line (0.3.0 through 0.3.10).
 4. **Never delete the `0.3.x` GitHub releases** from the releases page.
 5. Bug fixes against 0.3.x are welcome — branch from `main`, PR, merge as 0.3.8 / 0.3.9 etc. This pattern preserves the stable line; it does not replace it.
 6. Merging `main` → `feat/http-embedded` (the inverse direction, to keep the dev branch aligned) is **safe and encouraged** — it does not touch `main`.


### PR DESCRIPTION
## Summary

Two housekeeping commits that came out of a status-audit sprint on 2026-04-28:

- **`docs(claude): refresh version markers to 0.3.10`** — `CLAUDE.md` still showed 0.2.27 (pre-fork) and 0.3.7 in the branch protection table. Synced to the actual main state after PRs #14, #16, #17, #18.
- **`chore(ci): add Dependabot config for npm + github-actions`** — repo-level Dependabot was off. Adds `.github/dependabot.yml` with monthly cadence, per-package scoping, `@types/*` grouping, and a Svelte pin (the `patches/svelte@5.16.0.patch` is load-bearing for bun bundler).

No code changes. `bun run check` passes.

## Test plan

- [x] `bun run check` at repo root (all 3 packages green; test-site svelte-check 0/0)
- [ ] After merge: enable repo-level vulnerability alerts + Dependabot security updates under Settings → Code security (requires admin scope, not doable from gh CLI)
- [ ] Watch for the first Dependabot PR window (first Monday of May 2026)

## Sprint context

Companion items handled in the same sprint, separately from this PR:

- Memory file `project_upstream_status.md` updated to reflect upstream's official unmaintained status (2026-04-24), reversing the prior "re-engaged" memory.
- Issue #19 (templates/execute error message) — triaged + accepted, target 0.3.11.
- Issue #20 (templates/execute path in response) — triaged + accepted with field-name decisions, target 0.3.11.
- Issue #21 opened — tracking the OBSIDIAN_HOST double-protocol bug (originally upstream #84), target 0.3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)