### PR TITLE
chore(ci): Dependabot policy v3 — blanket ignore majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,19 +2,26 @@
 # Bun workspaces use the npm registry under the hood, so the `npm`
 # ecosystem covers `package.json` files in every workspace package.
 #
-# Policy notes (set 2026-04-28 after the welcome-wave triage):
+# Policy notes (set 2026-04-28, v3 — draconian after two welcome-wave
+# triages):
 # - Schedule monthly to avoid PR noise on a small-team fork.
 # - `versioning-strategy: increase-if-necessary` keeps PRs minimal
 #   (only bump constraints when a security fix or peer dep requires
-#   it). Combined with `ignore` blocks below, version-update PRs are
-#   limited to truly safe minor/patch bumps.
-# - Major bumps on load-bearing packages are explicitly ignored —
-#   they require coordinated work, not auto-PRs. Listed per-config
-#   below with the reason inline.
+#   it).
+# - **Blanket: ignore EVERY major bump on EVERY package across EVERY
+#   ecosystem (`dependency-name: "*"`, `version-update:semver-major`).**
+#   Major upgrades require coordinated work, breaking-change review,
+#   and often workflow/test changes — they will be done manually,
+#   case-by-case, when the upgrade is intentional.
+# - A few packages get a TOTAL ignore (any bump, even minor/patch)
+#   because they are pinned for non-version reasons (patch file,
+#   fork pin, type-only injection at runtime). Listed inline.
 # - `open-pull-requests-limit` is kept low (3 npm root, 2 per
 #   workspace package, 2 github-actions). Security-update PRs are
 #   counted separately by Dependabot, so this is a hard cap on
 #   *version* updates only.
+# - Security updates are unaffected by this config — they continue
+#   to open PRs for actual GHSA alerts regardless of the ignore rules.
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -46,13 +53,7 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      # TypeScript major bumps reveal strict-mode regressions across
-      # all three workspace packages — coordinate manually.
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
-      # @types/node tracks the Node LTS we ship against — bump
-      # alongside a Node upgrade, not standalone.
-      - dependency-name: "@types/node"
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
@@ -71,21 +72,10 @@ updates:
       prefix: "chore(deps,mcp-server)"
       include: "scope"
     ignore:
-      # ArkType is the runtime validator at every external boundary —
-      # major bumps (incl. rc → stable) need an audit pass.
-      - dependency-name: "arktype"
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-      # MCP SDK is pinned (and is a fork in our case) — bump only
-      # when intentional, never via auto-PR.
+      # Pinned (and a fork in our case) — bump only when intentional.
       - dependency-name: "@modelcontextprotocol/sdk"
-      # Turndown semantics for HTML → markdown can change between
-      # majors — coordinate with /fetch tool snapshot tests.
-      - dependency-name: "turndown"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/packages/obsidian-plugin"
@@ -103,29 +93,14 @@ updates:
       prefix: "chore(deps,plugin)"
       include: "scope"
     ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
       # Patched at 5.16.0 — see patches/svelte@5.16.0.patch.
       # Any bump must re-validate the patch under bun's bundler.
       - dependency-name: "svelte"
-      # Express 5 is a major rewrite (middleware/error semantics
-      # changed); the plugin's REST endpoints — /templates/execute,
-      # /search/smart, /mcp-tools/command-permission — need
-      # coordinated work. Stay on 4.x line.
-      - dependency-name: "express"
-        update-types: ["version-update:semver-major"]
-      # Obsidian npm package is .d.ts only and tracks Obsidian
-      # releases; bump alongside an Obsidian compat audit.
+      # Type-only npm package; runtime is injected by Obsidian itself.
+      # Bump alongside an Obsidian compat audit, not on auto-PR.
       - dependency-name: "obsidian"
-      # ESLint v9 flat-config migration is a breaking redesign —
-      # block major bumps on the parser/plugin pair until the migration
-      # is intentional.
-      - dependency-name: "@typescript-eslint/parser"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@typescript-eslint/eslint-plugin"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/packages/shared"
@@ -143,13 +118,9 @@ updates:
       prefix: "chore(deps,shared)"
       include: "scope"
     ignore:
-      - dependency-name: "arktype"
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]
       - dependency-name: "obsidian"
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -165,3 +136,6 @@ updates:
     commit-message:
       prefix: "chore(ci)"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Policy v2 (#36) had three gaps that the next Dependabot run exposed within minutes:

- ESLint stack majors at root (`eslint`, `@eslint/js`, `@typescript-eslint/eslint-plugin`) — produced ESLint v9→v10 PRs.
- `@typescript-eslint/{parser,eslint-plugin}` were ignored only in `/packages/obsidian-plugin`, not at root.
- GitHub Actions majors were never blocked — produced `softprops/action-gh-release` v1→v3.

6 more unwanted version-update PRs landed (#37–#42), all closed. This PR replaces the per-package allow-listed bans with a single blanket rule per ecosystem.

## Changes

- Blanket rule on every ecosystem:
  ```yaml
  ignore:
    - dependency-name: \"*\"
      update-types: [\"version-update:semver-major\"]
  ```
- Dropped the per-package major bans (now redundant) — config size went from 168 to ~140 lines.
- Kept TOTAL ignores (any bump) on the three packages pinned for non-version reasons:
  - `@modelcontextprotocol/sdk` (mcp-server) — pinned + a fork
  - `svelte` (obsidian-plugin) — `patches/svelte@5.16.0.patch` must be re-validated under bun's bundler
  - `obsidian` (obsidian-plugin, shared) — .d.ts only, runtime injected by Obsidian

## Out of scope

- Security updates are unaffected — Dependabot still opens PRs for GHSA alerts regardless of these `ignore` rules. Currently outstanding: `obsidian` critical, `vite` moderate (test-site).

## Test plan

- [x] yaml syntactically valid
- [ ] After merge: confirm the immediate-reaction run produces 0 PRs (or, at most, a tiny minor/patch we hadn't seen yet)
- [ ] First scheduled monthly window (Mon 2026-05-04 07:00 Europe/Rome): expect ≤ 5 PRs total, all minor/patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)