### PR TITLE
chore(ci): policy v4 — total ignore on arktype

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,13 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Runtime validator at every external boundary; rc → stable
+      # (and even minor bumps in the early 2.x line) can drift in
+      # subtle ways. Bump only with a planned upgrade and targeted
+      # tests. Workspace-aware: Dependabot detects arktype from the
+      # workspace packages even though the root package.json does
+      # not declare it directly.
+      - dependency-name: "arktype"
 
   - package-ecosystem: "npm"
     directory: "/packages/mcp-server"
@@ -76,6 +83,8 @@ updates:
         update-types: ["version-update:semver-major"]
       # Pinned (and a fork in our case) — bump only when intentional.
       - dependency-name: "@modelcontextprotocol/sdk"
+      # See root config — runtime validator, planned upgrades only.
+      - dependency-name: "arktype"
 
   - package-ecosystem: "npm"
     directory: "/packages/obsidian-plugin"
@@ -101,6 +110,8 @@ updates:
       # Type-only npm package; runtime is injected by Obsidian itself.
       # Bump alongside an Obsidian compat audit, not on auto-PR.
       - dependency-name: "obsidian"
+      # See root config — runtime validator, planned upgrades only.
+      - dependency-name: "arktype"
 
   - package-ecosystem: "npm"
     directory: "/packages/shared"
@@ -121,6 +132,8 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
       - dependency-name: "obsidian"
+      # See root config — runtime validator, planned upgrades only.
+      - dependency-name: "arktype"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Policy v3 (#43) blanket-ignored majors but did not block minor bumps, which let Dependabot open #46 for `arktype` 2.0.0-rc.30 → 2.2.0.

Formally a minor bump per semver, but in practice an **rc → stable** transition of the runtime validator at every external boundary. Subtle API drift can break validation in non-obvious ways — needs a coordinated upgrade with targeted tests, not an auto-PR. Same reasoning we apply to `svelte` (patched), `obsidian` (.d.ts only), `@modelcontextprotocol/sdk` (pinned fork).

## Changes

- `arktype` added to the TOTAL ignore list in: `/`, `/packages/mcp-server`, `/packages/obsidian-plugin`, `/packages/shared`.
- Comment in each block explaining the workspace-detection quirk that made #46 open against the root config even though arktype is declared only in the workspace packages.

## Test plan

- [x] yaml syntactically valid
- [ ] After merge: confirm no immediate-reaction PRs from Dependabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)