### PR TITLE
fix(plugin): #19 + #20 — richer /templates/execute response shape

### DIFF
--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -168,12 +168,14 @@ export default class McpToolsPlugin extends Plugin {
         content: processedContent,
       });
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       logger.error("Prompt execution error:", {
-        error: error instanceof Error ? error.message : error,
+        error: message,
         body: req.body,
       });
       res.status(503).json({
         error: "An error occurred while processing the prompt",
+        message,
       });
       return;
     }

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -159,6 +159,7 @@ export default class McpToolsPlugin extends Plugin {
         res.json({
           message: "Prompt executed and file created successfully",
           content: processedContent,
+          path: params.targetPath,
         });
         return;
       }


### PR DESCRIPTION
## Summary

Two additive response-shape fixes on `POST /templates/execute`, both reported by @folotp:

- **#19** — propagate the caught error \`message\` so HTTP callers can surface template-time throws (e.g. \`tp.user.*\` validation, \`<%* throw new Error(...) %>\`).
- **#20** — include the created file's \`path\` in the success response so callers don't have to re-derive it.

Both are additive: every existing client keeps working; clients that opt into the new fields get richer diagnostics / one-call create-and-locate.

## Changes

\`packages/obsidian-plugin/src/main.ts\`

- \`handleTemplateExecution\` catch block now adds \`message\` alongside the existing \`error\` field. \`String(error)\` fallback covers \`throw \"string\"\` and \`throw {custom}\`.
- \`handleTemplateExecution\` success branch (createFile: true) now adds \`path: params.targetPath\`.

Two commits, one per issue, easy to cherry-pick separately if needed.

## Decisions on #20 open questions

1. \`path\` only in the \`createFile: true\` branch (the \`false\` branch doesn't operate on a file).
2. Field name \`path\` (concise, aligned with \`GET /vault/{path}\`, forward-compatible if we later switch to \`templater.create_new_note_from_template(...)\` and read \`tp.config.target_file.path\`).

## Test plan

- [x] \`bun run check\` at repo root — all packages green
- [ ] After merge: roll into 0.3.11 release. Manual smoke test: invoke \`/templates/execute\` with a throwing template (verify \`message\` in 503 body) and with \`createFile: true\` (verify \`path\` in success body).

## Why no automated regression test

Mounting the plugin's \`handleTemplateExecution\` in \`bun:test\` requires faking the Templater plugin (\`loadTemplaterAPI\`), the Local REST API plugin, the vault, and the express request/response — significant scaffolding for a 4-line change with obvious semantics. Type-check + manual smoke test in 0.3.11 are the pragmatic verification.

Closes #19. Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)