### PR TITLE
fix(mcp-server): #21 — OBSIDIAN_HOST accepts URL form, parses intelligently

### DIFF
--- a/packages/mcp-server/src/shared/makeRequest.test.ts
+++ b/packages/mcp-server/src/shared/makeRequest.test.ts
@@ -3,6 +3,7 @@ import {
   normalizePath,
   parseApiUrl,
   parsePort,
+  resolveHostOverride,
   resolvePortFromArgs,
 } from "./makeRequest";
 
@@ -156,6 +157,58 @@ describe("parseApiUrl", () => {
     // the catch path returns undefined. Either way the caller gets a
     // safe fallback to the default port.
     expect(parseApiUrl("https://host:70000")).toBeUndefined();
+  });
+});
+
+describe("resolveHostOverride — issue #21", () => {
+  test("returns undefined for missing input", () => {
+    expect(resolveHostOverride(undefined)).toBeUndefined();
+    expect(resolveHostOverride("")).toBeUndefined();
+  });
+
+  test("treats a bare hostname as host-only (current behaviour)", () => {
+    expect(resolveHostOverride("10.0.0.1")).toEqual({ host: "10.0.0.1" });
+    expect(resolveHostOverride("obsidian.lan")).toEqual({
+      host: "obsidian.lan",
+    });
+  });
+
+  test("parses a full https URL", () => {
+    // The bug: setting OBSIDIAN_HOST=https://10.0.0.1:27124 used to be
+    // concatenated under a fixed https:// prefix and produced a
+    // malformed BASE_URL. Now the URL form is recognised and parsed.
+    expect(resolveHostOverride("https://10.0.0.1:27124")).toEqual({
+      host: "10.0.0.1",
+      port: 27124,
+      useHttp: false,
+    });
+  });
+
+  test("parses a full http URL with explicit port", () => {
+    // The reproduction case from issue #21.
+    expect(resolveHostOverride("http://127.0.0.1:27123")).toEqual({
+      host: "127.0.0.1",
+      port: 27123,
+      useHttp: true,
+    });
+  });
+
+  test("returns undefined for malformed URL forms", () => {
+    // Anything containing :// must parse cleanly via parseApiUrl, or
+    // we return undefined and let the caller fall back. We do NOT
+    // treat a malformed URL as a "bare hostname" — concatenating
+    // garbage under https:// is what we are fixing.
+    expect(resolveHostOverride("not://a-url")).toBeUndefined();
+    expect(resolveHostOverride("ftp://10.0.0.1")).toBeUndefined();
+  });
+
+  test("preserves bare hostnames that happen to contain a colon (IPv6 host literal not supported)", () => {
+    // Today we only special-case the `://` substring. A raw IPv6
+    // literal like `[::1]` is not on the supported-input table for
+    // OBSIDIAN_HOST today, but if a user passes one without `://` we
+    // pass it through verbatim — the URL constructor in BASE_URL will
+    // reject it downstream, which is the expected failure mode.
+    expect(resolveHostOverride("[::1]")).toEqual({ host: "[::1]" });
   });
 });
 

--- a/packages/mcp-server/src/shared/makeRequest.ts
+++ b/packages/mcp-server/src/shared/makeRequest.ts
@@ -78,27 +78,66 @@ export function parseApiUrl(raw: string | undefined): ApiUrlParts | undefined {
   }
 }
 
+/**
+ * Resolve `OBSIDIAN_HOST` into structured parts.
+ *
+ * Most users set this to a bare hostname (`10.0.0.1`, `obsidian.lan`),
+ * which is the documented usage. Some set it to a full URL
+ * (`http://10.0.0.1:27123`) — an easy mistake given how the variable
+ * name reads. Before this helper, the URL form was concatenated under
+ * a fixed `https://` prefix, producing malformed BASE_URLs like
+ * `https://http://10.0.0.1:27123:27124` (issue #21, originally upstream
+ * jacksteamdev/obsidian-mcp-tools#84).
+ *
+ * Behaviour:
+ * - empty / undefined input → `undefined` (caller falls back to other sources)
+ * - input contains `://` → parsed as a URL via `parseApiUrl`; if parsing
+ *   fails (malformed, non-http(s) protocol) returns `undefined` so the
+ *   caller can fall back rather than silently using bad input
+ * - otherwise → treated as a bare hostname (current behaviour preserved)
+ *
+ * Exported for unit testing.
+ */
+export function resolveHostOverride(
+  raw: string | undefined,
+): ApiUrlParts | undefined {
+  if (!raw) return undefined;
+  if (raw.includes("://")) return parseApiUrl(raw);
+  return { host: raw };
+}
+
 // Resolution precedence (most specific wins):
-// - Port:     --port CLI flag > OBSIDIAN_PORT > OBSIDIAN_API_URL port > default
+// - Port:     --port CLI flag > OBSIDIAN_PORT > OBSIDIAN_HOST URL port > OBSIDIAN_API_URL port > default
 // - Host:     OBSIDIAN_HOST > OBSIDIAN_API_URL host > 127.0.0.1
-// - Protocol: OBSIDIAN_USE_HTTP (if set) > OBSIDIAN_API_URL protocol > https
+// - Protocol: OBSIDIAN_USE_HTTP (if set) > OBSIDIAN_HOST URL protocol > OBSIDIAN_API_URL protocol > https
 // OBSIDIAN_API_URL is a convenience alias: it only fills slots that
 // the more specific variables leave empty. This keeps drop-in
 // compatibility with upstream v0.2.x configurations (issue #66) without
 // breaking anyone who already uses the granular env vars.
+// OBSIDIAN_HOST accepts either a bare hostname (the documented form)
+// or a full URL (a common mistake — see issue #21). When a URL form is
+// used, its port and protocol parts feed PORT/USE_HTTP only where the
+// more specific variables (OBSIDIAN_PORT, OBSIDIAN_USE_HTTP) are unset.
+const HOST_OVERRIDE = resolveHostOverride(process.env.OBSIDIAN_HOST);
 const API_URL_PARTS = parseApiUrl(process.env.OBSIDIAN_API_URL);
 const USE_HTTP_ENV = process.env.OBSIDIAN_USE_HTTP;
 const USE_HTTP =
   USE_HTTP_ENV != null && USE_HTTP_ENV !== ""
     ? USE_HTTP_ENV === "true"
-    : (API_URL_PARTS?.useHttp ?? false);
+    : (HOST_OVERRIDE?.useHttp ?? API_URL_PARTS?.useHttp ?? false);
 const PROTOCOL = USE_HTTP ? "http" : "https";
 const DEFAULT_PORT = USE_HTTP ? 27123 : 27124;
 const ARG_PORT = resolvePortFromArgs(process.argv);
 const ENV_PORT = parsePort(process.env.OBSIDIAN_PORT);
-const PORT = ARG_PORT ?? ENV_PORT ?? API_URL_PARTS?.port ?? DEFAULT_PORT;
-const HOST = process.env.OBSIDIAN_HOST || API_URL_PARTS?.host || "127.0.0.1";
+const PORT =
+  ARG_PORT ??
+  ENV_PORT ??
+  HOST_OVERRIDE?.port ??
+  API_URL_PARTS?.port ??
+  DEFAULT_PORT;
+const HOST = HOST_OVERRIDE?.host ?? API_URL_PARTS?.host ?? "127.0.0.1";
 export const BASE_URL = `${PROTOCOL}://${HOST}:${PORT}`;
+logger.info("Obsidian REST API base URL", { url: BASE_URL });
 
 // Disable TLS certificate validation for local self-signed certificates
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";


### PR DESCRIPTION
## Summary

Closes #21 (originally raised against upstream as jacksteamdev/obsidian-mcp-tools#84; fix lands here since upstream is officially unmaintained as of 2026-04-24).

\`OBSIDIAN_HOST\` was read as a raw hostname and concatenated under a fixed \`https://\` prefix. Setting \`OBSIDIAN_HOST=http://127.0.0.1:27123\` (a full URL — easy mistake given how the variable name reads) produced \`BASE_URL=https://http://127.0.0.1:27123:27124\` and every request failed.

## Changes

\`packages/mcp-server/src/shared/makeRequest.ts\`

- New \`resolveHostOverride(raw)\` helper:
  - empty / undefined → \`undefined\` (caller falls back)
  - input contains \`://\` → parse via \`parseApiUrl\`; on failure return \`undefined\` (don't silently accept bad input)
  - otherwise → bare hostname (current behaviour preserved)
- When a URL form is provided, its port and protocol parts feed PORT/USE_HTTP only where the more specific variables (\`OBSIDIAN_PORT\`, \`OBSIDIAN_USE_HTTP\`) are unset. The precedence comment block at the top of the resolution chain is updated.
- New \`logger.info(\"Obsidian REST API base URL\", { url: BASE_URL })\` at module load — surfaces this class of misconfiguration in the log file without requiring a network round trip to discover.

## Tests

\`packages/mcp-server/src/shared/makeRequest.test.ts\` — 6 new cases:

- bare hostname (current behaviour)
- full https URL
- full http URL with explicit port (the issue #21 reproduction)
- malformed input (\`not://a-url\`, \`ftp://...\`)
- IPv6 literal (documented edge case, not on the supported-input table today)
- empty / undefined input

40/40 tests pass. \`bun run check\` green across all packages.

## Backwards compatibility

Anyone using \`OBSIDIAN_HOST\` as a bare hostname (the documented form) keeps working unchanged. Anyone who was using a URL form was hitting the bug — now they work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)