### PR TITLE
docs(plugin): pin /templates/execute path semantics for future refactor

### DIFF
--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -153,7 +153,25 @@ export default class McpToolsPlugin extends Plugin {
       // Restore original functions generator
       templater.functions_generator.generate_object = oldGenerateObject;
 
-      // Create new file if requested
+      // Create new file if requested.
+      //
+      // `path` in the response reflects what THIS handler operated on
+      // (`params.targetPath`), not where Templater may have moved the
+      // file via `tp.file.move()` in the template's prelude — that's a
+      // side effect of the rendering pass and produces a separate file
+      // at the move target. `app.vault.create` here is the only
+      // operation that creates the file the caller asked for, so the
+      // returned `path` correctly tracks that operation.
+      //
+      // If a future refactor delegates to
+      // `templater.create_new_note_from_template(...)`, the same field
+      // would naturally carry the post-move destination by reading
+      // `tp.config.target_file.path`. The contract stays "the path
+      // this handler operated on", semantically forward-compatible.
+      //
+      // Design rationale + worked example (folotp's note on the
+      // `tp.file.move()` semantics seam):
+      //   https://github.com/istefox/obsidian-mcp-connector/issues/20#issuecomment-4335497942
       if (params.createFile && params.targetPath) {
         await this.app.vault.create(params.targetPath, processedContent);
         res.json({


### PR DESCRIPTION
## Summary

Comment-only change. Anchors the design rationale that landed in #20 (with @folotp's [\`tp.file.move()\` observation](https://github.com/istefox/obsidian-mcp-connector/issues/20#issuecomment-4335497942)) directly at the point of change in \`handleTemplateExecution\`.

## What the comment says

- **Why** \`path\` in the response reflects \`params.targetPath\` (what the handler operated on), **not** where Templater may have moved the file via \`tp.file.move()\` in the template prelude.
- **Forward-compat note**: if a future refactor delegates to \`templater.create_new_note_from_template(...)\`, reading \`tp.config.target_file.path\` keeps the same semantic contract — \"the path this handler operated on\" — without changing the field name.
- Direct link to folotp's comment with the worked example.

## Why

Issue threads rot. A future reader staring at \`path: params.targetPath\` should see the rationale immediately, not have to dig the issue out of git blame.

## Test plan

- [x] \`bun run check\` green across all packages (no code change)
- [x] \`main.ts\` reads cleanly with the new comment block

🤖 Generated with [Claude Code](https://claude.com/claude-code)