### PR TITLE
port(0.4): forward #19 + #20 fixes from 0.3.12 + design note

### DIFF
--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -542,12 +542,31 @@ export default class McpToolsPlugin extends Plugin {
       // Restore original functions generator
       templater.functions_generator.generate_object = oldGenerateObject;
 
-      // Create new file if requested
+      // Create new file if requested.
+      //
+      // `path` in the response reflects what THIS handler operated on
+      // (`params.targetPath`), not where Templater may have moved the
+      // file via `tp.file.move()` in the template's prelude — that's a
+      // side effect of the rendering pass and produces a separate file
+      // at the move target. `app.vault.create` here is the only
+      // operation that creates the file the caller asked for, so the
+      // returned `path` correctly tracks that operation.
+      //
+      // If a future refactor delegates to
+      // `templater.create_new_note_from_template(...)`, the same field
+      // would naturally carry the post-move destination by reading
+      // `tp.config.target_file.path`. The contract stays "the path
+      // this handler operated on", semantically forward-compatible.
+      //
+      // Design rationale + worked example (folotp's note on the
+      // `tp.file.move()` semantics seam):
+      //   https://github.com/istefox/obsidian-mcp-connector/issues/20#issuecomment-4335497942
       if (params.createFile && params.targetPath) {
         await this.app.vault.create(params.targetPath, processedContent);
         res.json({
           message: "Prompt executed and file created successfully",
           content: processedContent,
+          path: params.targetPath,
         });
         return;
       }
@@ -557,12 +576,14 @@ export default class McpToolsPlugin extends Plugin {
         content: processedContent,
       });
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       logger.error("Prompt execution error:", {
-        error: error instanceof Error ? error.message : error,
+        error: message,
         body: req.body,
       });
       res.status(503).json({
         error: "An error occurred while processing the prompt",
+        message,
       });
       return;
     }


### PR DESCRIPTION
## Summary

Port-forward of the 0.3.12 fixes for #19 and #20 into the 0.4.0 line, so the HTTP-embedded plugin doesn't ship a regression vs 0.3.x stable. @folotp verified both fixes end-to-end on 0.3.12 and contributed a useful design note on \`tp.file.move()\` semantics that gets anchored inline.

## Changes

\`packages/obsidian-plugin/src/main.ts\` — three things, one diff:

1. **\`message\` field in 503 catch block** (#19) — \`String(error)\` fallback handles non-Error throws.
2. **\`path\` field in createFile success** (#20) — only on the \`createFile: true\` branch.
3. **Inline design note** at the \`createFile\` site explaining that \`path\` reflects what the handler operated on, **not** where Templater may have moved the file via \`tp.file.move()\` in the prelude. Forward-compatible with a future \`templater.create_new_note_from_template(...)\` refactor that would read \`tp.config.target_file.path\`. Links to [@folotp's worked example](https://github.com/istefox/obsidian-mcp-connector/issues/20#issuecomment-4335497942).

## Why a port-forward and not a separate sweep

The original fixes landed on \`main\` in 0.3.12 (#50) and the design note in #55. \`feat/http-embedded\` branched well before that, so without this PR the 0.4.0 stable cut would silently regress two fixes that already shipped. Same code, same comment — kept verbatim with the doc commit on \`main\` so a reader on either branch sees the same rationale at the point of change.

## Test plan

- [x] \`bun run check\` green for the three shipped packages (\`shared\`, \`mcp-server\`, \`obsidian-plugin\`)
- [ ] After merge: smoke-test \`/templates/execute\` end-to-end on a beta install (template throw → \`message\` propagated; \`createFile: true\` → \`path\` returned)

## Note on test-site

\`packages/test-site\` (the SvelteKit harness, not shipped) has a preexisting vite type clash on this branch. Unrelated to this change — would prevent green check on \`test-site\` regardless of what we do in \`main.ts\`. Worth fixing in a separate PR before the stable cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)