### PR TITLE
fix(0.4): #58 flip Create-Target-If-Missing default to false for heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to **MCP Connector** (formerly `obsidian-mcp-tools`) are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- **Default `createTargetIfMissing: false` for `targetType: "heading"`**
+  on `patch_active_file` / `patch_vault_file` (#58, reported by
+  @folotp). Mirrors the v0.3.7 (#6) flip for `block` targets.
+
+  Rationale: an unresolvable heading target (typo on the leaf,
+  missing parent H1, stale heading reference) used to fall through
+  to silent EOF append. In the dominant agent-caller use case the
+  HTTP 200 is indistinguishable from a successful in-place patch
+  without a post-write read, so silent-create is data corruption.
+  The flip closes the residual silent-corruption surface that
+  `detectOrphanRootHeading` (v0.3.9, #16) only partially covered.
+
+  After the flip, per-target-type defaults are: `heading` →
+  `false` (changed), `block` → `false` (unchanged from v0.3.7),
+  `frontmatter` → `true` (unchanged; frontmatter keys rarely
+  produce silent-corruption footguns and Templater-backed flows
+  depend on key creation as intent).
+
+  Callers that genuinely want the permissive create-on-missing
+  behaviour for headings (rare — typically a migration script that
+  creates section markers on first run) opt in explicitly with
+  `createTargetIfMissing: true`. The wrapper-side
+  `detectOrphanRootHeading` carve-out stays as defence-in-depth on
+  the explicit opt-in path: the orphan-root H2+ shape is genuinely
+  unresolvable regardless of opt-in intent and should still fail
+  loud with `McpError(InvalidParams, …)`.
+
+  Pinned by 7 cases in `patchVaultFile.test.ts` (default flip,
+  explicit-true opt-in, explicit-false idempotence, frontmatter
+  unchanged, block unchanged + its two opt-in cases). The
+  `detectOrphanRootHeading` test surface from v0.3.9 stays intact.
+
+  Breaking-change scope is symmetric to v0.3.7 (#6): only callers
+  who today rely on `patch_*_file` with `targetType: "heading"`
+  and an *unresolvable* `target` silently creating a heading at
+  EOF are affected. That behaviour is the data-corruption path the
+  surrounding fixes have been progressively closing — this flip is
+  the final closure on the heading axis.
+
 ## [0.4.0-beta.1] — 2026-04-27
 
 First beta of the 0.4.0 line. Closes Phase 4 of the

--- a/packages/mcp-server/src/features/local-rest-api/index.ts
+++ b/packages/mcp-server/src/features/local-rest-api/index.ts
@@ -27,19 +27,33 @@ export function buildPatchHeaders(
   resolvedTarget: string,
 ): Record<string, string> {
   // Default behavior of Create-Target-If-Missing per target type:
-  //   heading     → true  (upstream 0.2.x compatibility; most callers expect
-  //                        a missing heading to be silently appended at EOF)
-  //   frontmatter → true  (same upstream default; frontmatter keys rarely
-  //                        produce silent-corruption footguns)
+  //   heading     → false (issue #58, 0.4.0). Mirrors the block flip in
+  //                        v0.3.7 (#6). An unresolvable heading target
+  //                        (typo on the leaf, missing parent, stale
+  //                        reference) used to fall through to silent
+  //                        EOF append; in the dominant agent-caller use
+  //                        case the HTTP 200 is indistinguishable from
+  //                        a successful in-place patch without a post-
+  //                        write read, so silent-create is data
+  //                        corruption. `detectOrphanRootHeading` from
+  //                        v0.3.9 (#16) stays as defence-in-depth on the
+  //                        explicit opt-in path.
   //   block       → false (safer: when a block `^id` cannot be located —
   //                        especially when the id lives inside a markdown
   //                        table cell, where markdown-patch's block indexer
   //                        does not search — permissive silent EOF append
   //                        corrupts callers expecting atomic patch-or-fail.
-  //                        Callers can explicitly opt back in with
-  //                        createTargetIfMissing: true. Fixes upstream
-  //                        issue #71's block-in-table gap.)
-  const defaultCreateTargetIfMissing = args.targetType !== "block";
+  //                        Unchanged from v0.3.7 (#6).)
+  //   frontmatter → true  (frontmatter keys rarely produce silent-
+  //                        corruption footguns; missing keys can be
+  //                        legitimately created — that's the intent for
+  //                        many Templater-backed flows. Unchanged.)
+  //
+  // Callers that genuinely want the permissive create-on-missing path
+  // for heading/block (e.g. a migration script that creates section
+  // markers on first run) opt in explicitly with
+  // createTargetIfMissing: true. Explicit is better than implicit.
+  const defaultCreateTargetIfMissing = args.targetType === "frontmatter";
   const headers: Record<string, string> = {
     Operation: args.operation,
     "Target-Type": args.targetType,
@@ -424,11 +438,13 @@ export function registerLocalRestApiTools(tools: ToolRegistry) {
       // Step 1: resolve partial heading names to full hierarchical paths.
       // Local REST API's markdown-patch indexer keys headings by their full
       // ancestor path (e.g. "Top Level::Section A"). When the caller supplies
-      // just a leaf name ("Section A"), the lookup fails and — because
-      // Create-Target-If-Missing is on by default — a new heading is silently
-      // appended at EOF instead of patching the intended one. To prevent this,
-      // fetch the file once, parse its heading tree, and expand the partial
-      // name to a full path before issuing the PATCH.
+      // just a leaf name ("Section A"), the lookup fails. Under the v0.4.0
+      // default (`createTargetIfMissing: false` for heading targets, #58),
+      // the LRA returns a 404 and the caller learns immediately. Under the
+      // explicit opt-in path (`createTargetIfMissing: true`), a new heading
+      // would be silently appended at EOF instead of patching the intended
+      // one — so we still expand the partial name first to make the in-place
+      // path the dominant outcome regardless of the create-on-missing flag.
       const targetDelimiter = args.targetDelimiter ?? "::";
       let resolvedTarget = args.target;
 

--- a/packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts
+++ b/packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts
@@ -129,18 +129,24 @@ describe("buildPatchHeaders — issue #78 (non-ASCII) + wiring", () => {
     expect(headers.Target).toBe("Top%20Level%3A%3ASection%20A");
   });
 
-  test("defaults Create-Target-If-Missing to 'true' when unset", () => {
-    // Backward-compatible default: upstream 0.2.x hardcoded true. We keep
-    // that default but now expose the flag so callers can opt into strict
-    // mode with createTargetIfMissing: false.
+  test("stringifies createTargetIfMissing: true for explicit opt-in on heading", () => {
+    // Explicit opt-in for the permissive create-on-missing path — the
+    // header reflects the caller's choice verbatim. The opt-in path is
+    // typically a migration script that creates section markers on first
+    // run; rare in agent-caller traffic. Per-target-type defaults are
+    // pinned in the issue #71 + #58 block below.
     const headers = buildPatchHeaders(
-      { operation: "append", targetType: "heading" },
+      {
+        operation: "append",
+        targetType: "heading",
+        createTargetIfMissing: true,
+      },
       "X",
     );
     expect(headers["Create-Target-If-Missing"]).toBe("true");
   });
 
-  test("stringifies createTargetIfMissing: false for strict mode", () => {
+  test("stringifies createTargetIfMissing: false for explicit strict mode", () => {
     const headers = buildPatchHeaders(
       {
         operation: "replace",
@@ -220,31 +226,35 @@ describe("buildPatchHeaders — issue #78 (non-ASCII) + wiring", () => {
   });
 });
 
-describe("buildPatchHeaders — issue #71 (block-in-table gap, per-target-type default)", () => {
-  test("block target defaults Create-Target-If-Missing to 'false' (safer)", () => {
+describe("buildPatchHeaders — issues #71 + #58 (per-target-type Create-Target-If-Missing defaults)", () => {
+  test("heading target defaults Create-Target-If-Missing to 'false' (issue #58, 0.4.0)", () => {
+    // Rationale: an unresolvable heading target (typo on the leaf, missing
+    // parent H1, stale reference) used to fall through to silent EOF append.
+    // In the dominant agent-caller use case the HTTP 200 is indistinguishable
+    // from a successful in-place patch without a post-write read, so silent-
+    // create is data corruption. The flip mirrors the v0.3.7 (#6) `block`
+    // flip rationale: fail loud, agent caller can react, callers who
+    // genuinely want the permissive path opt in explicitly.
+    const headers = buildPatchHeaders(
+      { operation: "append", targetType: "heading" },
+      "Section A",
+    );
+    expect(headers["Create-Target-If-Missing"]).toBe("false");
+  });
+
+  test("block target defaults Create-Target-If-Missing to 'false' (issue #71, v0.3.7)", () => {
     // Rationale: a block `^id` that cannot be located — especially one
     // inside a markdown table cell, which markdown-patch's block indexer
     // does not search — must fail loud instead of silently appending the
     // caller's content at EOF. Silent EOF append on a missing block is
     // data corruption: the caller gets HTTP 200 but the vault is now in
     // an unexpected shape, with the "patch" accumulated at file end rather
-    // than in place.
+    // than in place. Unchanged from v0.3.7.
     const headers = buildPatchHeaders(
       { operation: "replace", targetType: "block" },
       "block-id-42",
     );
     expect(headers["Create-Target-If-Missing"]).toBe("false");
-  });
-
-  test("heading target default remains 'true' (no regression)", () => {
-    // Pins the backwards-compatible default for heading targets, which is
-    // the load-bearing shape for upstream 0.2.x parity. If this flips, any
-    // caller relying on "create heading if missing" behavior breaks.
-    const headers = buildPatchHeaders(
-      { operation: "append", targetType: "heading" },
-      "Section A",
-    );
-    expect(headers["Create-Target-If-Missing"]).toBe("true");
   });
 
   test("frontmatter target default remains 'true' (no regression)", () => {
@@ -257,6 +267,39 @@ describe("buildPatchHeaders — issue #71 (block-in-table gap, per-target-type d
       "aliases",
     );
     expect(headers["Create-Target-If-Missing"]).toBe("true");
+  });
+
+  test("heading target with createTargetIfMissing: true explicitly overrides the safe default", () => {
+    // Opt-in for callers who genuinely want the permissive behaviour on
+    // headings (rare — typically a migration script that creates section
+    // markers on first run). Explicit is better than implicit. The
+    // wrapper-side `detectOrphanRootHeading` from v0.3.9 (#16) still fires
+    // on the orphan-root H2+ shape regardless of this flag, as defence-
+    // in-depth.
+    const headers = buildPatchHeaders(
+      {
+        operation: "append",
+        targetType: "heading",
+        createTargetIfMissing: true,
+      },
+      "Section A",
+    );
+    expect(headers["Create-Target-If-Missing"]).toBe("true");
+  });
+
+  test("heading target with createTargetIfMissing: false explicitly is idempotent with the new default", () => {
+    // Idempotence: explicit `false` on a heading target is the same as the
+    // 0.4.0 default. No surprise; pinning the path so a future refactor
+    // can't drift the explicit-opt-in semantics.
+    const headers = buildPatchHeaders(
+      {
+        operation: "replace",
+        targetType: "heading",
+        createTargetIfMissing: false,
+      },
+      "Section A",
+    );
+    expect(headers["Create-Target-If-Missing"]).toBe("false");
   });
 
   test("block target with createTargetIfMissing: true explicitly overrides the safe default", () => {
@@ -284,21 +327,6 @@ describe("buildPatchHeaders — issue #71 (block-in-table gap, per-target-type d
         createTargetIfMissing: false,
       },
       "block-id",
-    );
-    expect(headers["Create-Target-If-Missing"]).toBe("false");
-  });
-
-  test("heading target with createTargetIfMissing: false explicitly is 'false'", () => {
-    // Strict-mode opt-in still works on heading targets — this is the
-    // existing safety hatch for callers that want patch-or-fail
-    // semantics across all target types.
-    const headers = buildPatchHeaders(
-      {
-        operation: "replace",
-        targetType: "heading",
-        createTargetIfMissing: false,
-      },
-      "Section A",
     );
     expect(headers["Create-Target-If-Missing"]).toBe("false");
   });


### PR DESCRIPTION
Closes #58 (reported by @folotp). Mirrors the v0.3.7 (#6) flip for \`block\` targets and closes the residual silent-corruption surface that \`detectOrphanRootHeading\` (v0.3.9, #16) only partially covered.

## Summary

After the flip, per-target-type defaults on \`patch_active_file\` / \`patch_vault_file\`:

| \`targetType\`  | Default | Status |
|---|---|---|
| \`heading\` | **\`false\`** | **Changed** by this PR. |
| \`block\` | \`false\` | Unchanged from v0.3.7 (#6). |
| \`frontmatter\` | \`true\` | Unchanged. Templater key-creation flows depend on this. |

Callers that genuinely want permissive create-on-missing behaviour for headings opt in explicitly with \`createTargetIfMissing: true\` (rare — typically migration scripts).

## Why this flip is safe

The unresolvable-heading cases (leaf typo, missing parent H1, stale heading reference) that previously fell through to silent EOF append now fail loud with the LRA's standard 404. In the dominant agent-caller use case, an HTTP 200 EOF append is indistinguishable from a successful in-place patch without a post-write read — that's the data-corruption path the surrounding fixes have been progressively closing, and this is the final closure on the heading axis.

The wrapper-side \`detectOrphanRootHeading\` from v0.3.9 stays as defence-in-depth on the explicit opt-in path: the orphan-root H2+ shape is genuinely unresolvable regardless of opt-in intent and still fails loud with \`McpError(InvalidParams, …)\`.

## Files changed

- \`packages/mcp-server/src/features/local-rest-api/index.ts\` — the \`defaultCreateTargetIfMissing\` line + the inline rationale block. Also updates the \`patch_active_file\` registration comment that referenced the old "create-on-missing on by default" semantics.
- \`packages/mcp-server/src/features/local-rest-api/patchVaultFile.test.ts\` — reorganises the per-target-type default block as "issues #71 + #58", with 7 cases pinning the new default + opt-in paths + the unchanged frontmatter/block defaults.
- \`CHANGELOG.md\` — \`[Unreleased]\` entry under \`Changed\` (rolls into the 0.4.0 stable cut).

## Test plan

- [x] \`bun test\` on \`patchVaultFile.test.ts\`: 33/33 pass
- [x] \`bun test\` on the full mcp-server suite: 159/159 pass
- [x] \`bun run check\` green on the 3 shipped packages (\`shared\`, \`mcp-server\`, \`obsidian-plugin\`)
- [ ] After merge: smoke-test \`patch_*_file\` end-to-end on a beta install (heading + missing target → 404 instead of EOF append; explicit opt-in path still works)

## Note on test-site

\`packages/test-site\` (SvelteKit harness, not shipped) has a preexisting vite plugin type clash on this branch, unrelated to this PR. Worth fixing in a separate PR before the stable cut.

## Ship target

0.4.0 stable cut — symmetric to the v0.3.7 (#6) flip, which shipped without a beta gate. The change is small, well-bounded, has 7 regression tests, and the breaking-change scope is the same data-corruption path the v0.3.7 flip closed.

cc @folotp for review of the regression test coverage matrix vs the proposal in #58 — the test names match the cases you outlined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)