### PR TITLE
ci: split release.yml into release-line-aware steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,21 @@
 name: Release
 
+# Release-line-aware workflow:
+#
+# - Plugin artifacts (manifest.json, main.js, obsidian-plugin-*.zip)
+#   are built and uploaded for EVERY tag, on both the 0.3.x and 0.4.x
+#   release lines.
+#
+# - mcp-server cross-platform binaries are built and uploaded ONLY for
+#   tags on the 0.3.x line. The 0.4.x line ships an in-process MCP
+#   server inside the plugin (no platform binary). Discrimination is
+#   by tag name prefix — `0.3.` matches the bug-fix line, anything
+#   else (`0.4.`, `0.4.0-*`, `0.5.`, …) is plugin-only.
+#
+# This keeps the protected 0.3.x hotfix line shipping its full asset
+# set (the BRAT users on `main` rely on it) while letting the 0.4.0
+# stable cut and beyond ship cleanly with no binary in the release.
+
 on:
   push:
     tags:
@@ -23,6 +39,17 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Determine release line
+        id: release_line
+        run: |
+          if [[ "${{ github.ref_name }}" == 0.3.* ]]; then
+            echo "ships_binary=true" >> "$GITHUB_OUTPUT"
+            echo "Release line: 0.3.x — will build mcp-server cross-platform binaries"
+          else
+            echo "ships_binary=false" >> "$GITHUB_OUTPUT"
+            echo "Release line: 0.4.x+ — plugin-only, no mcp-server binary"
+          fi
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v3
@@ -34,16 +61,23 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run Release Script
+      - name: Build plugin (always)
         env:
+          # The 0.3.x plugin reads GITHUB_DOWNLOAD_URL at bundle time to
+          # know where to fetch the mcp-server binary from. The 0.4.x
+          # plugin no longer downloads a binary, but we keep these env
+          # vars wired so the same workflow handles both lines without
+          # branching.
           GITHUB_DOWNLOAD_URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
-        run: bun run release
+        run: bun --filter '@obsidian-mcp-tools/obsidian-plugin' release
 
-      - name: Zip Release Artifacts
-        run: bun run zip
+      - name: Build mcp-server binaries (0.3.x line only)
+        if: steps.release_line.outputs.ships_binary == 'true'
+        run: bun --filter '@obsidian-mcp-tools/mcp-server' release
 
-      - name: Generate artifact attestation for MCP server binaries
+      - name: Generate artifact attestation for MCP server binaries (0.3.x line only)
+        if: steps.release_line.outputs.ships_binary == 'true'
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: "packages/mcp-server/dist/*"
@@ -61,7 +95,7 @@ jobs:
             });
             return release.data.body || '';
 
-      - name: Upload Release Artifacts
+      - name: Upload plugin artifacts (always)
         env:
           GH_WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         uses: ncipollo/release-action@v1
@@ -73,10 +107,20 @@ jobs:
           # component CSS into main.js, no separate stylesheet is
           # emitted by this build. ncipollo/release-action errors out
           # if a literal (non-glob) artifact is missing.
-          artifacts: "packages/obsidian-plugin/releases/obsidian-plugin-*.zip,main.js,manifest.json,packages/mcp-server/dist/mcp-server-*"
+          artifacts: "packages/obsidian-plugin/releases/obsidian-plugin-*.zip,main.js,manifest.json"
           body: |
             ${{ steps.get_release_body.outputs.result }}
 
             ---
-            ✨ This release includes attested build artifacts.
-            📝 View attestation details in the [workflow run](${{ env.GH_WORKFLOW_URL }})
+            ${{ steps.release_line.outputs.ships_binary == 'true' && '✨ This release includes attested build artifacts.' || '' }}
+            ${{ steps.release_line.outputs.ships_binary == 'true' && format('📝 View attestation details in the [workflow run]({0})', env.GH_WORKFLOW_URL) || '' }}
+
+      - name: Upload mcp-server binaries (0.3.x line only)
+        if: steps.release_line.outputs.ships_binary == 'true'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          omitName: true
+          omitBody: true
+          tag: ${{ github.ref_name }}
+          artifacts: "packages/mcp-server/dist/mcp-server-*"


### PR DESCRIPTION
## Summary

The 0.4.0 line ships no mcp-server binary — the server is in-process inside the plugin. The 0.3.x line still ships cross-platform binaries (BRAT users on \`main\` rely on them; the protected hotfix line is the canonical place for any 0.3.x patch release).

This PR splits \`.github/workflows/release.yml\` so:

- **Plugin artifacts** (\`manifest.json\`, \`main.js\`, \`obsidian-plugin-*.zip\`) are built and uploaded for **every tag**, on both lines.
- **mcp-server cross-platform binaries** are built, attested, and uploaded **only for tags starting with \`0.3.\`**.

## Mechanism

A new \`Determine release line\` step parses \`github.ref_name\`:

\`\`\`bash
if [[ "\${{ github.ref_name }}" == 0.3.* ]]; then
  ships_binary=true
else
  ships_binary=false
fi
\`\`\`

The binary-build, attestation, and binary-upload steps gate on \`steps.release_line.outputs.ships_binary == 'true'\`.

## Side effects

- The plugin build step now runs \`bun --filter '@obsidian-mcp-tools/obsidian-plugin' release\` directly instead of the root \`bun run release\` (which fanned out to both packages).
- The standalone \`bun run zip\` step is gone — \`release\` on the plugin package already invokes \`run-s build zip\` so the zip is produced inline.
- The release body's "attested build artifacts" footer appears only on releases that actually carry attested binaries (0.3.x). Plugin-only releases get the plain notes.
- A **second upload step** appends the binaries to the same release tag (using \`omitName: true\` and \`omitBody: true\` so it does not clobber the title or body the first upload step already wrote).
- \`GITHUB_DOWNLOAD_URL\` and \`GITHUB_REF_NAME\` stay wired on the plugin build step. The 0.4.x plugin no longer reads them, but the 0.3.x plugin's bundle-time \`define\` still does — keeping them avoids a branch on something that costs nothing to leave in.

## Test plan

- [x] YAML syntactically valid (verified locally)
- [ ] After merge: confirm the existing 0.3.12 tag still builds correctly (should be untouched — no re-release needed; this is forward-only). The next 0.3.x hotfix tag will be the first practical test of the binary path under the new workflow.
- [ ] After merge: when 0.4.0 stable is tagged, confirm the workflow uploads only the plugin artifacts (no mcp-server binaries), and the release body has no "attested build artifacts" footer.

## Ship target

0.4.0 stable cut — same window as the rest of the deferred-to-stable items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)