### PR TITLE
fix(0.4): hide toolToggle UI — registry gating not wired yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ This entry consolidates the four alpha pre-releases and the beta. The full per-t
 
 ### Known limitations
 
-- **`Disabled MCP tools` (toolToggle) UI persists the list but does not gate the registry in 0.4.0** (the binary's env-var-based filter is gone). Tools cannot be disabled client-side yet; tracked as a follow-up post-stable.
+- **`Disabled MCP tools` (toolToggle) UI hidden in 0.4.0.** On 0.3.x the toggle wrote `OBSIDIAN_DISABLED_TOOLS` into the binary's env and the binary read it at startup to filter the registered tools. The 0.4.0 in-process registry has no equivalent gating path yet, so showing the UI would be misleading — the user could "disable" a tool that would still be reachable on the next call. The persisted `toolToggle.disabled` slice in `data.json` is left intact, so future installs can read it back without losing data; a 0.4.x follow-up will wire registry gating and re-mount the UI.
 
 ### References
 

--- a/packages/obsidian-plugin/src/features/core/components/SettingsTab.svelte
+++ b/packages/obsidian-plugin/src/features/core/components/SettingsTab.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { FeatureSettings as CommandPermissionsSettings } from "src/features/command-permissions";
-  import { FeatureSettings as ToolToggleSettings } from "src/features/tool-toggle";
   import { FeatureSettings as SemanticSearchSettings } from "src/features/semantic-search";
   import { AccessControlSection } from "src/features/mcp-transport";
   import { ClientConfigSection } from "src/features/mcp-client-config";
@@ -14,13 +13,23 @@
   // the tree as a rollback safety net until 0.4.0 stable cuts; T14
   // retires it for good. See `docs/plans/0.4.0-phase-4-…` T12.b.
 
+  // The `tool-toggle` UI is also hidden in 0.4.0. On 0.3.x the toggle
+  // wrote `OBSIDIAN_DISABLED_TOOLS` into the binary's env, and the
+  // binary read it at startup to filter the registered tools. The
+  // 0.4.0 in-process registry has no equivalent gating path yet, so
+  // showing the UI would be misleading — the user could "disable" a
+  // tool that would still be reachable on the next call. The
+  // persisted `toolToggle.disabled` slice in `data.json` is left
+  // intact so future installs can read it back without losing data;
+  // a 0.4.x follow-up will wire the registry gating and re-mount the
+  // UI. Until then: hidden, not deleted.
+
   export let plugin: McpServerPlugin;
 </script>
 
 <div class="settings-container">
   <AccessControlSection {plugin} />
   <ClientConfigSection {plugin} />
-  <ToolToggleSettings {plugin} />
   <CommandPermissionsSettings {plugin} />
   <SemanticSearchSettings {plugin} />
 </div>


### PR DESCRIPTION
## Summary

The 0.4.0 in-process MCP server has no equivalent of the 0.3.x binary's env-var-based tool filter (\`OBSIDIAN_DISABLED_TOOLS\`). Showing the toolToggle UI without the gating wired up was misleading: the user could "disable" a tool from the settings tab and the next \`tools/call\` would still reach it. That mismatch between settings state and runtime behaviour is worse than the missing feature.

## Changes

- \`packages/obsidian-plugin/src/features/core/components/SettingsTab.svelte\` — drop the \`<ToolToggleSettings>\` mount and its import. New comment block in the script explains the rationale and the 0.4.x follow-up plan.
- \`CHANGELOG.md\` → \`[0.4.0]\` → Known limitations — updated to describe the new "UI hidden, persistence preserved" state instead of the old "UI shown but does not gate" framing.

## What stays

- \`features/tool-toggle/\` module is **not deleted** — kept in the tree so a 0.4.x follow-up that wires registry gating can re-mount the same component without shape changes.
- The persisted \`toolToggle.disabled\` slice in \`data.json\` is preserved on existing installs. Users don't lose the list; settings code still reads it via the existing helpers.

## Decision rationale

The 0.4.0 stable cut is on the critical path for the community-store entry. Implementing registry gating cleanly (unit tests for the filter, edge cases around tool registration order, settings-change-triggers-restart semantics) is ~3h. Hiding the UI is ~30min that preserves data and lets the stable ship without a regression masquerading as a feature. The follow-up wiring lands in 0.4.x without a breaking-change cycle.

## Test plan

- [x] \`bun run check\` green on the 3 shipped packages (\`shared\`, \`mcp-server\`, \`obsidian-plugin\`)
- [ ] After merge: smoke-check the settings tab on a beta install — only Access Control, Quick setup for clients, Command execution, and Semantic search sections should be visible. No "Disabled MCP tools" section.
- [ ] After merge: load a vault that already has \`toolToggle.disabled = […]\` in \`data.json\` — the data should survive plugin enable/disable cycles untouched.

(test-site has the preexisting vite type clash unrelated to this change.)

## Ship target

0.4.0 stable cut — same window as the rest of the deferred-to-stable items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)