### PR TITLE
fix(0.4): folotp post-beta.1 batch — #12, #13, #19, #20 + heading blank-line + stat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,18 +100,91 @@ This entry consolidates the four alpha pre-releases and the beta. The full per-t
 - **`OBSIDIAN_HOST` accepts URL forms** (carried forward from 0.3.12): bare hostname (the documented form) and full URL with protocol+port both work; the wrapper detects `://` and parses via `parseApiUrl` (#21, originally upstream `jacksteamdev/obsidian-mcp-tools#84`).
 - **0.3.x install surface retired** in 0.4.0 settings (`mcp-server-install/components/McpServerInstallSettings.svelte` no longer mounted; kept in tree for rollback safety; full removal in a follow-up).
 
+### Fixed (post-`0.4.0-beta.1` batch — folotp soak)
+
+The `0.4.0-beta.1` end-to-end soak by @folotp (macOS arm64, Obsidian
+1.12.7, Local REST API 3.6.1) surfaced four regressions in the
+in-process tool handlers vs the 0.3.x stable line. The in-process
+patcher and `executeTemplate` tool were fresh writes, not 1:1 ports;
+the hardening that 0.3.8 / 0.3.12 had added against the same call
+shapes was not carried forward.
+
+- **`patch_*_file` `targetType: "frontmatter"`, `operation: "replace"`,
+  scalar content against an array-valued field** used to return HTTP
+  200 while silently coercing the field from array to scalar (#12).
+  `tags: [alpha, beta]` patched with `content: "gamma"` became
+  `tags: gamma`, destroying the array structure with no signal to the
+  caller. The branch now dispatches through a pure
+  `planFrontmatterReplace` helper: when the existing field is an array,
+  content must JSON-decode to an array (`'["new"]'`,
+  `'["a","b"]'`) or `null` (clears the field); anything else returns
+  `isError: true` with an actionable message naming the JSON forms.
+  Mirrors the 0.3.8 `detectFrontmatterReplaceArrayMismatch` policy
+  adapted to the in-process flow that no longer carries `contentType`.
+- **`patch_*_file` `targetType: "frontmatter"`, `operation:
+  "append"` / `"prepend"` against an array-valued field** used to
+  flatten the array via `String(existing) + content`, producing
+  comma-joined corruption like
+  `tags: existing,new-tag"new-tag-040"` (#13). The branch now
+  dispatches through a pure `planFrontmatterAppend` helper: when the
+  existing field is an array, content is JSON-decoded if possible (a
+  parsed array is spread; a parsed scalar is pushed as one element)
+  and otherwise the raw content is pushed as a single string element
+  (DWIM for naive callers that don't JSON-encode). Mirrors 0.3.8's
+  `coerceFrontmatterAppendArrayContent`.
+- **`execute_template` createFile success response was missing
+  `path`** (#20). The 0.3.12 fix was already ported to
+  `main.ts:handleTemplateExecution` in commit `03331b0`, but in 0.4.0
+  that LRA endpoint is dead code: the in-process MCP server reaches
+  Templater directly via `features/mcp-tools/tools/executeTemplate.ts`,
+  which had been written fresh and missed the fix. The createFile
+  success branch now returns `{ message, content, path:
+  ctx.arguments.targetPath }`. The semantic contract is "the path
+  this handler operated on" (not where Templater may have moved the
+  file via `tp.file.move()`), forward-compatible with a future
+  delegation to `templater.create_new_note_from_template(...)`.
+- **`execute_template` errors were double-prefixed as
+  `MCP error -32603: MCP error -32603: <text>`** in some clients
+  (#19). The handler now catches Templater failures and surfaces them
+  through the `isError: true` result shape with the underlying message
+  verbatim, instead of throwing up to the registry's catch (which
+  wraps in `McpError`, then the client wraps again). Matches the
+  convention used by the other vault tools.
+
+Bonus polish in the same batch:
+
+- **`patch_*_file` heading `replace` consumed the blank line between
+  the patched section and the next sibling/parent heading**, producing
+  `## A\n<body>\n## B` instead of `## A\n<body>\n\n## B`. Re-emits the
+  separator when the tail starts with a heading and the body does not
+  already end blank.
+- **`get_vault_file format: "json"` was missing the `stat` field**
+  declared by the upstream `ApiNoteJson` contract
+  (`packages/shared/src/types/plugin-local-rest-api.ts:31`). The
+  response now includes `stat: { ctime, mtime, size }` populated from
+  the `TFile`.
+
+Internal: `patchActiveFile.ts` carries its own duplicate of
+`applyPatch` (parallel to the one in
+`services/patchHelpers.ts:applyPatch`); both are now wired through the
+new `planFrontmatter*` helpers so the policy stays in one place.
+Consolidating the two call sites is a separate refactor.
+
 ### Continuous integration
 
 - New `.github/workflows/ci.yml` runs `bun run check` + per-package `bun test` on every push to `main` and `feat/http-embedded`, plus on every PR targeting either branch. Cancels in-flight runs for the same ref when a new push lands.
 
 ### Tests
 
-528+ unit + integration tests pass across the four phases:
+599+ unit + integration tests pass across the plugin package (528+
+through `0.4.0-beta.1`, +28 added in the post-beta.1 fix batch covering
+the frontmatter / `execute_template` / heading-replace regressions
+above):
 
 - 87 across `features/migration/` and `features/mcp-client-config/` (Phase 4).
 - 123 across `features/semantic-search/` (Phase 3).
 - 244 across `features/mcp-transport/`, `features/core/`, `features/access-control/`, settings (Phase 1).
-- The remaining baseline carried forward from 0.3.x: tool registry, command-permissions, mcp-server-install, plus the patch / smart-search / templates regression suites.
+- The remaining baseline carried forward from 0.3.x: tool registry, command-permissions, mcp-server-install, plus the patch / smart-search / templates regression suites — augmented with 17 unit cases on the new `planFrontmatter*` helpers and 11 integration cases on the patch tools.
 
 ### Known limitations
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.test.ts
@@ -4,6 +4,8 @@ import {
   normalizeAppendBody,
   findBlockReferenceInContent,
   findBlockPositionFromCache,
+  planFrontmatterReplace,
+  planFrontmatterAppend,
 } from "./patchHelpers";
 
 describe("resolveHeadingPath", () => {
@@ -84,5 +86,136 @@ describe("findBlockPositionFromCache", () => {
   test("returns null when cache has no blocks property", () => {
     const cache = {};
     expect(findBlockPositionFromCache(cache as { blocks?: Record<string, unknown> }, "x")).toBeNull();
+  });
+});
+
+// ─── Frontmatter planners (issues #12, #13) ────────────────────────────────
+
+describe("planFrontmatterReplace", () => {
+  test("scalar existing → ok-string (legacy assign-as-string)", () => {
+    expect(planFrontmatterReplace("draft", "published", "status")).toEqual({
+      kind: "ok-string",
+    });
+  });
+
+  test("missing existing → ok-string", () => {
+    expect(planFrontmatterReplace(undefined, "x", "any")).toEqual({
+      kind: "ok-string",
+    });
+    expect(planFrontmatterReplace(null, "x", "any")).toEqual({
+      kind: "ok-string",
+    });
+  });
+
+  test("array existing + JSON array content → ok with parsed array", () => {
+    expect(planFrontmatterReplace(["a", "b"], '["c","d"]', "tags")).toEqual({
+      kind: "ok",
+      value: ["c", "d"],
+    });
+  });
+
+  test("array existing + JSON null → ok with value=null (clears the field)", () => {
+    expect(planFrontmatterReplace(["a"], "null", "tags")).toEqual({
+      kind: "ok",
+      value: null,
+    });
+  });
+
+  test("issue #12: array existing + plain string content → reject", () => {
+    const result = planFrontmatterReplace(["alpha", "beta"], "gamma", "tags");
+    expect(result.kind).toBe("reject");
+    if (result.kind === "reject") {
+      expect(result.message).toContain("tags");
+      expect(result.message).toMatch(/array/i);
+      expect(result.message).toMatch(/JSON/i);
+    }
+  });
+
+  test("array existing + JSON scalar content → reject (would still flatten)", () => {
+    const result = planFrontmatterReplace(["a"], '"single"', "tags");
+    expect(result.kind).toBe("reject");
+  });
+
+  test("array existing + JSON object content → reject", () => {
+    const result = planFrontmatterReplace(["a"], '{"k":"v"}', "tags");
+    expect(result.kind).toBe("reject");
+  });
+
+  test("array existing + empty content → reject (empty is not valid JSON)", () => {
+    const result = planFrontmatterReplace(["a"], "", "tags");
+    expect(result.kind).toBe("reject");
+  });
+
+  test("nested array assignment is preserved", () => {
+    expect(
+      planFrontmatterReplace(["a"], '[["nested"],["array"]]', "matrix"),
+    ).toEqual({
+      kind: "ok",
+      value: [["nested"], ["array"]],
+    });
+  });
+});
+
+describe("planFrontmatterAppend", () => {
+  test("scalar existing → string-concat (legacy)", () => {
+    expect(planFrontmatterAppend("draft", " v2")).toEqual({
+      kind: "string-concat",
+    });
+  });
+
+  test("missing existing → string-concat", () => {
+    expect(planFrontmatterAppend(undefined, "x")).toEqual({
+      kind: "string-concat",
+    });
+    expect(planFrontmatterAppend(null, "x")).toEqual({
+      kind: "string-concat",
+    });
+  });
+
+  test("array existing + plain string content → push as single string element", () => {
+    // The DWIM branch: an LLM caller that doesn't know about JSON encoding
+    // sends the bare tag, and it lands as an array element.
+    expect(planFrontmatterAppend(["existing"], "new-tag")).toEqual({
+      kind: "array-push",
+      values: ["new-tag"],
+    });
+  });
+
+  test("issue #13: array existing + JSON scalar content → push parsed scalar", () => {
+    // Was the original failure: 0.3.x returned 500, 0.4.0 corrupted via
+    // String(["existing"]) + content. The plan splits the scalar onto its
+    // own array element.
+    expect(planFrontmatterAppend(["existing"], '"new-tag"')).toEqual({
+      kind: "array-push",
+      values: ["new-tag"],
+    });
+  });
+
+  test("array existing + JSON array content → spread parsed array elements", () => {
+    expect(planFrontmatterAppend(["a"], '["b","c"]')).toEqual({
+      kind: "array-push",
+      values: ["b", "c"],
+    });
+  });
+
+  test("array existing + JSON number → push parsed number", () => {
+    expect(planFrontmatterAppend([1, 2], "3")).toEqual({
+      kind: "array-push",
+      values: [3],
+    });
+  });
+
+  test("array existing + JSON null → push null as element", () => {
+    expect(planFrontmatterAppend(["a"], "null")).toEqual({
+      kind: "array-push",
+      values: [null],
+    });
+  });
+
+  test("array existing + malformed JSON → push raw content as string element", () => {
+    expect(planFrontmatterAppend(["a"], "[unclosed")).toEqual({
+      kind: "array-push",
+      values: ["[unclosed"],
+    });
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
@@ -155,6 +155,149 @@ export function findBlockPositionFromCache(
   };
 }
 
+// === Frontmatter plan helpers (shared by T6 and T13) ============================
+//
+// Pure / synchronous decision functions that decide what to do when a
+// `targetType: "frontmatter"` patch lands on a field. They exist as separate,
+// unit-testable helpers because the frontmatter branch of `applyPatch` is a
+// known regression hotspot (issues #12 / #13 on the istefox fork): the 0.3.x
+// line had to add hardening against silent array→scalar coercion and against
+// HTTP-500-on-JSON-scalar; the 0.4.0 in-process port was a fresh write and
+// missed both. Putting the policy in pure helpers keeps the regression tests
+// simple and the production branch a thin dispatch.
+
+/**
+ * Decision returned by `planFrontmatterReplace`.
+ *
+ * - `ok` — caller should assign `value` (which is either `null` or an array)
+ *   to the frontmatter field.
+ * - `ok-string` — existing field is not array-shaped, so the safe behaviour
+ *   is to assign `args.content` verbatim (the legacy scalar-replace path).
+ * - `reject` — refuse the call with `message`. Used for the array+scalar
+ *   mismatch that previously corrupted data silently.
+ */
+export type FrontmatterReplacePlan =
+  | { kind: "ok"; value: unknown }
+  | { kind: "ok-string" }
+  | { kind: "reject"; message: string };
+
+/**
+ * Decide what `replace` should do against an existing frontmatter value.
+ *
+ * Policy (reverse-engineered from the 0.3.8 hardening + adapted to the
+ * in-process flow that no longer carries a `contentType` parameter):
+ *
+ * - existing is **not array** → caller assigns `content` as a string.
+ * - existing **is array** + `content` is JSON-decodable as `null` or an
+ *   array → caller assigns the parsed value (preserves array shape, or
+ *   clears the field via `null`).
+ * - existing **is array** + anything else → reject with an actionable
+ *   message that names the JSON forms the caller should use.
+ *
+ * Closes folotp's #12: prior to this, `replace` on an array-valued field
+ * with a plain string content silently coerced the field to a scalar and
+ * destroyed the array.
+ *
+ * Args:
+ *   existing: The current value of `fm[target]` as read by `processFrontMatter`.
+ *   content: The raw `content` string supplied by the MCP caller.
+ *   target: The frontmatter key — only used to build the rejection message.
+ *
+ * Returns:
+ *   A `FrontmatterReplacePlan` describing the next step.
+ */
+export function planFrontmatterReplace(
+  existing: unknown,
+  content: string,
+  target: string,
+): FrontmatterReplacePlan {
+  if (!Array.isArray(existing)) {
+    return { kind: "ok-string" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return { kind: "reject", message: arrayMismatchMessage(target) };
+  }
+  if (parsed === null || Array.isArray(parsed)) {
+    return { kind: "ok", value: parsed };
+  }
+  return { kind: "reject", message: arrayMismatchMessage(target) };
+}
+
+function arrayMismatchMessage(target: string): string {
+  return (
+    `Refusing to replace array-valued frontmatter field "${target}" ` +
+    `with a scalar value: this would silently destroy the existing array ` +
+    `structure. Pass content as a JSON-encoded value — for example ` +
+    `'["new"]' to set a single-element array, ` +
+    `'["a","b"]' for multiple elements, or ` +
+    `'null' to clear the field.`
+  );
+}
+
+/**
+ * Decision returned by `planFrontmatterAppend`.
+ *
+ * - `array-push` — existing field is array; `values` should be pushed
+ *   (`append`) or unshifted (`prepend`) into a copy of it.
+ * - `string-concat` — existing field is scalar/null/undefined; the caller
+ *   falls back to the legacy `String(existing) + content` path.
+ */
+export type FrontmatterAppendPlan =
+  | { kind: "array-push"; values: unknown[] }
+  | { kind: "string-concat" };
+
+/**
+ * Decide what `append` / `prepend` should do against an existing frontmatter
+ * value. Symmetric to `planFrontmatterReplace`, but never rejects: append on
+ * an array has one reasonable interpretation in every input shape.
+ *
+ * Policy:
+ *
+ * - existing is **not array** → caller falls back to string concatenation.
+ * - existing **is array** + `content` is JSON-decodable as an array →
+ *   spread the parsed array's elements.
+ * - existing **is array** + `content` is JSON-decodable as a scalar →
+ *   push that single parsed scalar (matches the 0.3.8 auto-wrap fix from
+ *   `coerceFrontmatterAppendArrayContent`).
+ * - existing **is array** + `content` is **not** valid JSON → push the raw
+ *   content as a single string element. This is the "DWIM where there is
+ *   one reasonable interpretation" branch: an LLM caller that does not
+ *   know about JSON encoding will just send `"new-tag"` and reasonably
+ *   expect it to land in the array.
+ *
+ * Closes folotp's #13: prior to this, append/prepend on an array-valued
+ * field flattened the array via `String(existing) + content`, producing
+ * comma-joined corruption like `tags: existing,new-tag"new-tag"`.
+ *
+ * Args:
+ *   existing: The current value of `fm[target]` as read by `processFrontMatter`.
+ *   content: The raw `content` string supplied by the MCP caller.
+ *
+ * Returns:
+ *   A `FrontmatterAppendPlan` describing the next step.
+ */
+export function planFrontmatterAppend(
+  existing: unknown,
+  content: string,
+): FrontmatterAppendPlan {
+  if (!Array.isArray(existing)) {
+    return { kind: "string-concat" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return { kind: "array-push", values: [content] };
+  }
+  if (Array.isArray(parsed)) {
+    return { kind: "array-push", values: parsed };
+  }
+  return { kind: "array-push", values: [parsed] };
+}
+
 // === PatchArgs type and applyPatch function (shared by T6 and T13) ===
 
 export type PatchArgs = {
@@ -178,7 +321,11 @@ export type PatchArgs = {
  *   fallback. Returns an error if not found and `createTargetIfMissing` is
  *   false (the default for blocks — see upstream issue #71).
  * - **frontmatter**: uses `app.fileManager.processFrontMatter` to mutate the
- *   requested key according to the operation.
+ *   requested key. Array-typed values are handled structurally via the
+ *   `planFrontmatterReplace` / `planFrontmatterAppend` helpers — `replace`
+ *   on an array rejects scalar input rather than corrupting the structure
+ *   (issue #12); `append` / `prepend` on an array push elements
+ *   structurally, JSON-decoding the content when valid (issue #13).
  *
  * Args:
  *   app: Obsidian App instance.
@@ -200,20 +347,52 @@ export async function applyPatch(
   const createIfMissing = args.createTargetIfMissing ?? defaultCreate;
 
   // ── frontmatter branch ──────────────────────────────────────────────────
+  // Dispatches through the pure planners above so the policy stays testable
+  // without needing the full `processFrontMatter` machinery. `rejection` is
+  // captured out of the closure because `processFrontMatter` returns void —
+  // we cannot bubble an Error back without aborting the write entirely (and
+  // some Obsidian versions still rewrite the YAML even on throw, which would
+  // produce a confusing partial-update). Setting a flag and skipping the
+  // mutation keeps the file untouched while letting us return a typed error.
   if (args.targetType === "frontmatter") {
+    let rejection: string | null = null;
     await app.fileManager.processFrontMatter(file, (fm) => {
       const existing = fm[args.target];
       if (args.operation === "replace") {
-        fm[args.target] = args.content;
-      } else if (args.operation === "append") {
-        fm[args.target] =
-          existing != null ? String(existing) + args.content : args.content;
-      } else {
-        // prepend
-        fm[args.target] =
-          existing != null ? args.content + String(existing) : args.content;
+        const plan = planFrontmatterReplace(existing, args.content, args.target);
+        if (plan.kind === "reject") {
+          rejection = plan.message;
+          return;
+        }
+        fm[args.target] = plan.kind === "ok" ? plan.value : args.content;
+        return;
       }
+      // append / prepend
+      const plan = planFrontmatterAppend(existing, args.content);
+      if (plan.kind === "array-push") {
+        const arr = (existing as unknown[]).slice();
+        if (args.operation === "append") arr.push(...plan.values);
+        else arr.unshift(...plan.values);
+        fm[args.target] = arr;
+        return;
+      }
+      // string-concat: existing is scalar / null / undefined — keep the
+      // legacy concatenation semantics for backward compatibility.
+      if (existing == null) {
+        fm[args.target] = args.content;
+        return;
+      }
+      fm[args.target] =
+        args.operation === "append"
+          ? String(existing) + args.content
+          : args.content + String(existing);
     });
+    if (rejection !== null) {
+      return {
+        content: [{ type: "text", text: rejection }],
+        isError: true,
+      };
+    }
     return { content: [{ type: "text", text: "File patched successfully" }] };
   }
 
@@ -272,11 +451,23 @@ export async function applyPatch(
     // We want to insert content just before sectionEnd (append) or just after
     // headingLine (prepend) or replace the whole body (replace).
     const body = normalizeAppendBody(args.content, args.operation);
+    // For `replace`, the original section body absorbed the trailing blank
+    // line that visually separated the heading we're patching from the next
+    // sibling/parent heading. When we splice `body` in and concatenate the
+    // tail starting at sectionEnd, that blank line disappears unless we
+    // re-emit it — producing `## A\n<body>\n## B` instead of the expected
+    // `## A\n<body>\n\n## B`. Only matters when the tail starts with another
+    // heading and `body` does not already end with a newline.
+    const tailIsHeading =
+      sectionEnd < lines.length && /^#{1,6}\s/.test(lines[sectionEnd]);
+    const bodyEndsBlank = body === "" || body.endsWith("\n");
     let newLines: string[];
     if (args.operation === "replace") {
+      const separator = tailIsHeading && !bodyEndsBlank ? [""] : [];
       newLines = [
         ...lines.slice(0, headingLine + 1),
         body,
+        ...separator,
         ...lines.slice(sectionEnd),
       ];
     } else if (args.operation === "prepend") {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.test.ts
@@ -159,6 +159,8 @@ describe("execute_template tool", () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.content).toBe("RENDERED_CONTENT");
     expect(parsed.message).toMatch(/created successfully/i);
+    // Issue #20: createFile success response includes the targetPath.
+    expect(parsed.path).toBe("Output/note.md");
 
     // Verify the file was actually created in the mock vault
     const createdFile = plugin.app.vault.getAbstractFileByPath("Output/note.md");
@@ -243,7 +245,7 @@ describe("execute_template tool", () => {
     expect((result as Record<string, unknown>).mcpTools).toBeUndefined();
   });
 
-  test("restores generate_object even when read_and_parse_template throws", async () => {
+  test("issue #19: read_and_parse_template error surfaces as isError result with verbatim message (no double prefix)", async () => {
     setMockFile("a.md", "X");
     const fakeTemplater = makeFakeTemplater("RENDERED");
     fakeTemplater.read_and_parse_template = async () => {
@@ -251,19 +253,24 @@ describe("execute_template tool", () => {
     };
     const plugin = mockPluginWithTemplater(fakeTemplater);
 
-    await expect(
-      executeTemplateHandler({
-        arguments: { templatePath: "a.md" },
-        app: plugin.app,
-        plugin,
-      }),
-    ).rejects.toThrow("Templater internal error");
+    const result = await executeTemplateHandler({
+      arguments: { templatePath: "a.md" },
+      app: plugin.app,
+      plugin,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Templater internal error");
+    // The handler must NOT wrap the message in `MCP error -<code>:` itself —
+    // the registry would then wrap again, producing the double prefix folotp
+    // reported.
+    expect(result.content[0].text).not.toMatch(/MCP error -?\d+:.*MCP error/);
 
     // generate_object must be restored to the non-injecting version
-    const result = await fakeTemplater.functions_generator.generate_object(
+    const restored = await fakeTemplater.functions_generator.generate_object(
       {} as never,
       undefined,
     );
-    expect((result as Record<string, unknown>).mcpTools).toBeUndefined();
+    expect((restored as Record<string, unknown>).mcpTools).toBeUndefined();
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
@@ -121,7 +121,19 @@ export async function executeTemplateHandler(
 
     const processedContent = await templater.read_and_parse_template(config);
 
-    // Optionally create a vault file at targetPath
+    // Optionally create a vault file at targetPath.
+    //
+    // Issue #20 (folotp, 0.3.12 → ported here): the response includes
+    // `path` so callers chaining off the response (open-in-Obsidian,
+    // follow-up patch, link-rewrite) don't have to re-track the
+    // targetPath themselves. `path` reflects what THIS handler operated
+    // on (`ctx.arguments.targetPath`), not where Templater may have
+    // moved the rendered file via `tp.file.move()` in the prelude —
+    // that's a side effect of the rendering pass and produces a
+    // separate file at the move target. The contract is "the path this
+    // handler operated on", semantically forward-compatible with a
+    // future refactor that delegates to
+    // `templater.create_new_note_from_template(...)`.
     if (createFile && ctx.arguments.targetPath) {
       await ctx.app.vault.create(ctx.arguments.targetPath, processedContent);
       return {
@@ -132,6 +144,7 @@ export async function executeTemplateHandler(
               {
                 message: "Template executed and file created successfully",
                 content: processedContent,
+                path: ctx.arguments.targetPath,
               },
               null,
               2,
@@ -155,6 +168,23 @@ export async function executeTemplateHandler(
           ),
         },
       ],
+    };
+  } catch (error) {
+    // Issue #19 (folotp): surface the underlying Templater message verbatim
+    // through the `isError`-style result instead of letting it propagate to
+    // the registry's catch — that path wraps the error in McpError, which
+    // some clients then double-prefix as `MCP error -32603: MCP error -32603:
+    // <text>`. Returning `isError: true` keeps the message clean and matches
+    // the convention used by the other vault tools.
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Template execution failed: ${message}`,
+        },
+      ],
+      isError: true,
     };
   } finally {
     // Always restore generate_object — even when an error is thrown — to

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.test.ts
@@ -27,7 +27,7 @@ describe("get_vault_file tool", () => {
     expect(result.content[0].text).toBe("# Hello");
   });
 
-  test("returns JSON shape when format=json with frontmatter+tags", async () => {
+  test("returns JSON shape when format=json with frontmatter+tags+stat", async () => {
     setMockFile("a.md", "---\ntags: [foo]\n---\n# Body");
     setMockMetadata("a.md", {
       frontmatter: { tags: ["foo"] },
@@ -41,6 +41,12 @@ describe("get_vault_file tool", () => {
     expect(parsed.path).toBe("a.md");
     expect(parsed.frontmatter).toEqual({ tags: ["foo"] });
     expect(parsed.tags).toEqual(["foo"]);
+    // ApiNoteJson contract — `stat` was missing in the initial 0.4.0 port.
+    expect(parsed.stat).toEqual({
+      ctime: 0,
+      mtime: 0,
+      size: "---\ntags: [foo]\n---\n# Body".length,
+    });
   });
 
   test("returns image content block for .png file", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
@@ -125,7 +125,10 @@ export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
 
   // ── JSON format ────────────────────────────────────────────────────────────
   // Explicit format=json: read text content and attach metadata regardless of
-  // extension. This mirrors the upstream ApiNoteJson contract.
+  // extension. This mirrors the upstream ApiNoteJson contract:
+  // `{ path, content, frontmatter, tags, stat: { ctime, mtime, size } }`.
+  // The `stat` field was missing in the initial 0.4.0 port — folotp flagged
+  // the drift between the description and the actual response.
   if (ctx.arguments.format === "json") {
     const text = await ctx.app.vault.read(file);
     const cache = ctx.app.metadataCache.getFileCache(file);
@@ -133,13 +136,18 @@ export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
     const tags = Array.isArray(frontmatter.tags)
       ? (frontmatter.tags as string[])
       : [];
+    const stat = {
+      ctime: file.stat?.ctime ?? 0,
+      mtime: file.stat?.mtime ?? 0,
+      size: file.stat?.size ?? 0,
+    };
 
     return {
       content: [
         {
           type: "text",
           text: JSON.stringify(
-            { path: file.path, content: text, frontmatter, tags },
+            { path: file.path, content: text, frontmatter, tags, stat },
             null,
             2,
           ),

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.test.ts
@@ -121,6 +121,89 @@ describe("patch_active_file tool", () => {
     expect(final).toContain("Tail content");
   });
 
+  // ── Frontmatter regression coverage (issues #12, #13) ─────────────────
+
+  test("issue #12: replace on array-valued frontmatter with scalar content → typed reject, file untouched", async () => {
+    setMockFile("a.md", "---\ntags:\n  - alpha\n  - beta\n---\nbody\n");
+    setMockActiveFile("a.md");
+    setMockMetadata("a.md", { frontmatter: { tags: ["alpha", "beta"] } });
+    const app = mockApp();
+
+    const result = await patchActiveFileHandler({
+      arguments: {
+        operation: "replace",
+        targetType: "frontmatter",
+        target: "tags",
+        content: "gamma",
+      },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/array/i);
+    const cache = app.metadataCache.getFileCache(app.workspace.getActiveFile()!);
+    expect(cache?.frontmatter?.tags).toEqual(["alpha", "beta"]);
+  });
+
+  test("issue #13: append on array-valued frontmatter with JSON scalar pushes parsed scalar", async () => {
+    setMockFile("a.md", "---\ntags:\n  - existing\n---\n");
+    setMockActiveFile("a.md");
+    setMockMetadata("a.md", { frontmatter: { tags: ["existing"] } });
+    const app = mockApp();
+
+    const result = await patchActiveFileHandler({
+      arguments: {
+        operation: "append",
+        targetType: "frontmatter",
+        target: "tags",
+        content: '"new-tag"',
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const cache = app.metadataCache.getFileCache(app.workspace.getActiveFile()!);
+    expect(cache?.frontmatter?.tags).toEqual(["existing", "new-tag"]);
+  });
+
+  test("issue #13: append on array-valued frontmatter with plain string pushes as element", async () => {
+    setMockFile("a.md", "---\ntags:\n  - existing\n---\n");
+    setMockActiveFile("a.md");
+    setMockMetadata("a.md", { frontmatter: { tags: ["existing"] } });
+    const app = mockApp();
+
+    const result = await patchActiveFileHandler({
+      arguments: {
+        operation: "append",
+        targetType: "frontmatter",
+        target: "tags",
+        content: "new-tag",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const cache = app.metadataCache.getFileCache(app.workspace.getActiveFile()!);
+    expect(cache?.frontmatter?.tags).toEqual(["existing", "new-tag"]);
+  });
+
+  test("regression: heading replace preserves blank line before next heading", async () => {
+    setMockFile("a.md", "## A\nold\n\n## B\n");
+    setMockActiveFile("a.md");
+    const app = mockApp();
+
+    const result = await patchActiveFileHandler({
+      arguments: {
+        operation: "replace",
+        targetType: "heading",
+        target: "A",
+        content: "new",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.workspace.getActiveFile()!;
+    const final = await app.vault.read(file);
+    expect(final).toContain("## A\nnew\n\n## B");
+  });
+
   test("returns error when no active file", async () => {
     setMockActiveFile(null);
     const result = await patchActiveFileHandler({

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
@@ -4,6 +4,8 @@ import {
   resolveHeadingPath,
   findBlockPositionFromCache,
   normalizeAppendBody,
+  planFrontmatterReplace,
+  planFrontmatterAppend,
   type PatchOperation,
 } from "$/features/mcp-tools/services/patchHelpers";
 
@@ -80,31 +82,49 @@ export async function applyPatch(
   const delimiter = args.targetDelimiter ?? "::";
 
   // --- frontmatter branch ---
+  // Mirrors the frontmatter logic in services/patchHelpers.ts:applyPatch
+  // (used by patch_vault_file). Both call sites share planFrontmatter*
+  // helpers so the policy stays in one place — see issues #12 / #13 for
+  // why this was non-trivial. Note: the two `applyPatch` functions are
+  // currently duplicated; consolidating them is a separate refactor.
   if (args.targetType === "frontmatter") {
+    let rejection: string | null = null;
     await app.fileManager.processFrontMatter(file, (fm) => {
+      const existing = fm[args.target];
       if (args.operation === "replace") {
-        fm[args.target] = args.content;
-      } else if (args.operation === "append") {
-        const existing = fm[args.target];
-        if (Array.isArray(existing)) {
-          existing.push(args.content);
-        } else if (typeof existing === "string") {
-          fm[args.target] = existing + args.content;
-        } else {
-          fm[args.target] = args.content;
+        const plan = planFrontmatterReplace(existing, args.content, args.target);
+        if (plan.kind === "reject") {
+          rejection = plan.message;
+          return;
         }
-      } else {
-        // prepend
-        const existing = fm[args.target];
-        if (Array.isArray(existing)) {
-          existing.unshift(args.content);
-        } else if (typeof existing === "string") {
-          fm[args.target] = args.content + existing;
-        } else {
-          fm[args.target] = args.content;
-        }
+        fm[args.target] = plan.kind === "ok" ? plan.value : args.content;
+        return;
       }
+      // append / prepend
+      const plan = planFrontmatterAppend(existing, args.content);
+      if (plan.kind === "array-push") {
+        const arr = (existing as unknown[]).slice();
+        if (args.operation === "append") arr.push(...plan.values);
+        else arr.unshift(...plan.values);
+        fm[args.target] = arr;
+        return;
+      }
+      // string-concat: existing is scalar / null / undefined.
+      if (existing == null) {
+        fm[args.target] = args.content;
+        return;
+      }
+      fm[args.target] =
+        args.operation === "append"
+          ? String(existing) + args.content
+          : args.content + String(existing);
     });
+    if (rejection !== null) {
+      return {
+        content: [{ type: "text", text: rejection }],
+        isError: true,
+      };
+    }
     return { content: [{ type: "text", text: "OK" }] };
   }
 
@@ -167,7 +187,24 @@ export async function applyPatch(
       lines.splice(headingLine + 1, 0, args.content);
     } else {
       // replace: swap out the section body between this heading and the next.
-      lines.splice(headingLine + 1, sectionEnd - headingLine - 1, args.content);
+      // The original body absorbed the blank line that visually separated the
+      // section from the next sibling/parent heading; without re-emitting it
+      // here we'd produce `## A\n<content>\n## B` instead of the expected
+      // `## A\n<content>\n\n## B`. Only relevant when the tail starts with
+      // another heading and `args.content` does not already end blank.
+      const tailIsHeading =
+        sectionEnd < lines.length && /^#{1,6}\s/.test(lines[sectionEnd]);
+      const contentEndsBlank =
+        args.content === "" || args.content.endsWith("\n");
+      const replacement =
+        tailIsHeading && !contentEndsBlank
+          ? [args.content, ""]
+          : [args.content];
+      lines.splice(
+        headingLine + 1,
+        sectionEnd - headingLine - 1,
+        ...replacement,
+      );
     }
 
     await app.vault.modify(file, lines.join("\n"));

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.test.ts
@@ -70,6 +70,198 @@ describe("patch_vault_file tool", () => {
     expect(result.content[0].text).toMatch(/not found/i);
   });
 
+  // ── Frontmatter regression coverage (issues #12, #13) ─────────────────
+
+  test("issue #12: replace on array-valued frontmatter with scalar content → typed reject, file untouched", async () => {
+    setMockFile("Notes/x.md", "---\ntags:\n  - alpha\n  - beta\n---\nbody\n");
+    setMockMetadata("Notes/x.md", {
+      frontmatter: { tags: ["alpha", "beta"] },
+    });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "replace",
+        targetType: "frontmatter",
+        target: "tags",
+        content: "gamma",
+      },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/array/i);
+    expect(result.content[0].text).toContain("tags");
+
+    // File frontmatter must remain intact — no silent coercion to scalar.
+    const file = app.vault.getAbstractFileByPath("Notes/x.md");
+    const cache = app.metadataCache.getFileCache(file as never);
+    expect(cache?.frontmatter?.tags).toEqual(["alpha", "beta"]);
+  });
+
+  test("replace on array-valued frontmatter with JSON array content succeeds", async () => {
+    setMockFile("Notes/x.md", "---\ntags:\n  - a\n---\nbody\n");
+    setMockMetadata("Notes/x.md", { frontmatter: { tags: ["a"] } });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "replace",
+        targetType: "frontmatter",
+        target: "tags",
+        content: '["b","c"]',
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/x.md");
+    const cache = app.metadataCache.getFileCache(file as never);
+    expect(cache?.frontmatter?.tags).toEqual(["b", "c"]);
+  });
+
+  test("replace on array-valued frontmatter with JSON null clears the field", async () => {
+    setMockFile("Notes/x.md", "---\ntags:\n  - a\n---\n");
+    setMockMetadata("Notes/x.md", { frontmatter: { tags: ["a"] } });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "replace",
+        targetType: "frontmatter",
+        target: "tags",
+        content: "null",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/x.md");
+    const cache = app.metadataCache.getFileCache(file as never);
+    expect(cache?.frontmatter?.tags).toBeNull();
+  });
+
+  test("issue #13: append on array-valued frontmatter with plain string pushes as element", async () => {
+    setMockFile("Notes/x.md", "---\ntags:\n  - existing\n---\n");
+    setMockMetadata("Notes/x.md", { frontmatter: { tags: ["existing"] } });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "append",
+        targetType: "frontmatter",
+        target: "tags",
+        content: "new-tag",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/x.md");
+    const cache = app.metadataCache.getFileCache(file as never);
+    expect(cache?.frontmatter?.tags).toEqual(["existing", "new-tag"]);
+  });
+
+  test("issue #13: append on array-valued frontmatter with JSON scalar content pushes parsed scalar", async () => {
+    setMockFile("Notes/x.md", "---\ntags:\n  - existing\n---\n");
+    setMockMetadata("Notes/x.md", { frontmatter: { tags: ["existing"] } });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "append",
+        targetType: "frontmatter",
+        target: "tags",
+        content: '"new-tag"',
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/x.md");
+    const cache = app.metadataCache.getFileCache(file as never);
+    expect(cache?.frontmatter?.tags).toEqual(["existing", "new-tag"]);
+  });
+
+  test("append on array-valued frontmatter with JSON array content spreads elements", async () => {
+    setMockFile("Notes/x.md", "---\ntags:\n  - a\n---\n");
+    setMockMetadata("Notes/x.md", { frontmatter: { tags: ["a"] } });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "append",
+        targetType: "frontmatter",
+        target: "tags",
+        content: '["b","c"]',
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/x.md");
+    const cache = app.metadataCache.getFileCache(file as never);
+    expect(cache?.frontmatter?.tags).toEqual(["a", "b", "c"]);
+  });
+
+  test("prepend on array-valued frontmatter unshifts the parsed value", async () => {
+    setMockFile("Notes/x.md", "---\ntags:\n  - tail\n---\n");
+    setMockMetadata("Notes/x.md", { frontmatter: { tags: ["tail"] } });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "prepend",
+        targetType: "frontmatter",
+        target: "tags",
+        content: '"head"',
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/x.md");
+    const cache = app.metadataCache.getFileCache(file as never);
+    expect(cache?.frontmatter?.tags).toEqual(["head", "tail"]);
+  });
+
+  test("append on missing frontmatter field with plain content creates the scalar", async () => {
+    // existing is undefined → string-concat path → assigns content verbatim
+    setMockFile("Notes/x.md", "---\n---\n");
+    setMockMetadata("Notes/x.md", { frontmatter: {} });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "append",
+        targetType: "frontmatter",
+        target: "status",
+        content: "draft",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/x.md");
+    const cache = app.metadataCache.getFileCache(file as never);
+    expect(cache?.frontmatter?.status).toBe("draft");
+  });
+
+  // ── Heading-replace blank-line preservation ───────────────────────────
+
+  test("regression: replace on heading section preserves blank line before next heading", async () => {
+    setMockFile("Notes/h.md", "## A\nold\n\n## B\n");
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/h.md",
+        operation: "replace",
+        targetType: "heading",
+        target: "A",
+        content: "new",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/h.md");
+    if (!file) throw new Error("expected file");
+    const final = await app.vault.read(file as never);
+    // Must keep the blank line between the patched section and ## B.
+    expect(final).toContain("## A\nnew\n\n## B");
+  });
+
   test("regression: block target with createTargetIfMissing=false on table-located block fails loud", async () => {
     // Simulates upstream #71: block id ^X exists in markdown table cell,
     // but Obsidian's metadataCache.blocks does NOT index blocks inside tables.


### PR DESCRIPTION
## Summary

Closes the four regressions @folotp surfaced in his end-to-end soak of
`0.4.0-beta.1` (macOS arm64, Obsidian 1.12.7, Local REST API 3.6.1) plus
two non-blocking polish items he flagged in the same report.

The in-process patcher and `executeTemplate` tool were fresh writes in
0.4.0, not 1:1 ports — the hardening that 0.3.8 / 0.3.12 had added
against the same call shapes was not carried forward. This batch
re-establishes feature parity with the 0.3.x stable line for the call
paths folotp exercised.

## Fixes

- **#12** — `replace` on array-valued frontmatter with scalar content
  used to silently coerce array → scalar. Now rejects with
  `isError: true` and an actionable JSON-form message.
- **#13** — `append` / `prepend` on array-valued frontmatter used to
  flatten via `String(existing) + content`. Now pushes elements
  structurally (JSON-decoded when valid, raw string otherwise — DWIM
  for naive callers).
- **#19** — `execute_template` errors were double-prefixed as
  `MCP error -32603: MCP error -32603: <text>`. Handler now catches
  Templater failures and returns `isError: true` with verbatim message.
- **#20** — `execute_template` createFile success response was missing
  `path`. The 0.3.12 port at commit `03331b0` had landed on the LRA
  endpoint in `main.ts`, which is dead code in 0.4.0; the in-process
  tool at `features/mcp-tools/tools/executeTemplate.ts` is what
  callers actually reach, and that one had been written fresh and
  missed the fix.

Plus two polish items folotp flagged as non-blocking:

- Heading `replace` consumed the blank line between the patched section
  and the next sibling/parent heading. Both `applyPatch`
  implementations now re-emit the separator.
- `get_vault_file format: "json"` was missing the `stat` field
  declared by the upstream `ApiNoteJson` contract. Now populated from
  the `TFile`.

## Implementation notes

- New pure planners `planFrontmatterReplace` / `planFrontmatterAppend`
  in `services/patchHelpers.ts` carry the policy. 17 unit cases cover
  the decision matrix.
- Both `applyPatch` call sites dispatch through them: `patch_vault_file`
  via `services/patchHelpers.ts`, and `patch_active_file` via its own
  duplicate of `applyPatch` in `tools/patchActiveFile.ts`. The two
  copies are still duplicated — consolidating them is a separate
  refactor, called out with an inline comment.
- `processFrontMatter` returns void, so the rejection path captures the
  message via a closure-scoped flag and skips the mutation, keeping
  the file untouched on reject.

## Tests

- 599 pass / 0 fail across the plugin package (was 528+, +28 new).
- 159 pass on mcp-server, 17 pass on shared — unchanged.
- `bun run check` clean across all four workspace packages.

## Three logical commits + one docs commit

- `ab906a1` — patch-path frontmatter + heading blank-line (#12, #13)
- `3966ff4` — execute_template clean error surface + path (#19, #20)
- `d5e58ac` — get_vault_file stat field per ApiNoteJson contract
- `9c21e53` — CHANGELOG entries

## Out of scope

- 0.4.0-beta.2 version bump + tag — to be done on `feat/http-embedded`
  after this merges, since the version script doesn't support
  pre-release bumps and the tag triggers the CI release workflow.
- Consolidating the two `applyPatch` implementations.
- Updating the body of #54 to fix the doc-vs-impl drift on the
  `search_vault_smart` `provider` parameter — that edit happens on
  GitHub, not in code.

## Test plan

- [ ] CI green on `bun run check` and per-package `bun test`
- [ ] Manual smoke via `bun run link` into a vault with array-valued
      `tags` frontmatter — repro folotp's #12 + #13 cases and verify
      the new behaviour
- [ ] `execute_template` with `createFile: "true"` returns `path` in
      the response
- [ ] `execute_template` with a throw-template surfaces the error
      message verbatim, no double prefix
- [ ] `get_vault_file format: "json"` returns `stat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)