### PR TITLE
fix(0.4): #73 + #74 — templates compat shim + registry isError hoist (beta.3)

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -463,6 +463,21 @@ Per validazioni locali in vault TEST/Lab durante un'eventuale beta.3 o pre-cut s
 6. **In Claude Desktop**: "lista i tool MCP disponibili" → atteso 20 tool. Verifica `get_active_file`, `search_vault_simple`, `execute_template`, `search_vault_smart` (semantic native, primo uso scarica MiniLM ~25MB).
 7. **Logging**: console developer Obsidian `Cmd+Opt+I`. 401 = token sbagliato; 403 Origin = origin non loopback.
 
+### G — 🟡 Gotcha operativo 0.4.0: port drift + Claude Desktop config staleness
+
+Verificato dal vault TEST il 2026-04-29 sera — sintomo: Claude Desktop al startup mostra "MCP mcp-tools-istefox: Server disconnected" + "Could not attach to MCP server", log `~/Library/Logs/Claude/mcp-server-mcp-tools-istefox.log` riporta `ECONNREFUSED 127.0.0.1:27201`.
+
+**Causa primaria (sempre)**: il server HTTP del plugin 0.4.0 vive **dentro il processo Obsidian**. Senza Obsidian aperto sul vault dove il plugin è attivo, la porta è chiusa e `mcp-remote` (lo shim stdio→HTTP usato da Claude Desktop) non ha nulla a cui attaccarsi. Fix: aprire Obsidian, attendere ~3-5s che il plugin binde la porta, riavviare la connessione MCP in Claude Desktop (Settings → Developer → Restart, oppure quit+relaunch).
+
+**Gotcha secondario (port drift, da verificare se già gestito)**: il plugin usa `bindWithFallback` su `27200-27205` (`packages/obsidian-plugin/src/features/mcp-transport/services/port.ts`), itera in ordine. Se al primo avvio 27200 è occupata, sale a 27201 e (con auto-write toggle ON) `updateClaudeDesktopConfig` riscrive `claude_desktop_config.json` con la nuova porta. Al successivo avvio Obsidian, se 27200 è libera, il plugin **torna a 27200**. Conseguenze:
+
+1. **Auto-write deve girare a ogni `setup()`**, non solo on-toggle: da verificare in `setup.ts` se `updateClaudeDesktopConfig(currentPort)` è invocato post-bind con auto-write ON. Se sì → drift autorisolto. Se no → config Claude Desktop stale finché user non clicca "Auto-write" manualmente.
+2. **Claude Desktop non ricarica live la config**: legge `claude_desktop_config.json` solo al startup. Se è già aperto quando il plugin si sposta porta (es. plugin disable+enable a vault aperto), `mcp-remote` continua a usare il target vecchio fino al prossimo restart di Claude Desktop. Limitation client-side, non risolvibile lato plugin.
+
+**Mitigazioni candidate per 0.4.1 (post-T14, non blocking T14)**: audit `setup.ts` per chiudere il punto 1; bind preferenziale **sticky** (persisti la porta dell'ultima sessione in `data.json`, prova quella prima del range); settings UI warning quando porta corrente differisce dalla porta scritta nella config Claude Desktop più recente; doc lato user.
+
+Issue dedicata da aprire post-T14.
+
 ---
 
 ## 7. File chiave da conoscere

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/templatesCompat.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/templatesCompat.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { handleTemplatesExecuteCompat } from "./templatesCompat";
+import { mockApp, mockPlugin, resetMockVault, setMockFile } from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+// ---------------------------------------------------------------------------
+// Helpers — mirrors `executeTemplate.test.ts`. Kept local instead of shared
+// because the helper is small and the test surface is different (LRA shape
+// vs in-process tool shape).
+// ---------------------------------------------------------------------------
+
+type FakeTemplaterCall = {
+  method: string;
+  templatePath: string;
+  processedContent: string;
+};
+
+function makeFakeTemplater(renderedContent = "RENDERED") {
+  const calls: FakeTemplaterCall[] = [];
+
+  const fakeTemplater = {
+    _calls: calls,
+    functions_generator: {
+      generate_object: async (
+        _config: unknown,
+        _mode: unknown,
+      ): Promise<Record<string, unknown>> => {
+        return {};
+      },
+    },
+    create_running_config: (
+      templateFile: unknown,
+      _targetFile: unknown,
+      _runMode: unknown,
+    ) => {
+      return { template_file: templateFile, target_file: templateFile };
+    },
+    read_and_parse_template: async (config: {
+      template_file: { path: string };
+    }) => {
+      calls.push({
+        method: "read_and_parse_template",
+        templatePath: config.template_file.path,
+        processedContent: renderedContent,
+      });
+      return renderedContent;
+    },
+  };
+
+  return fakeTemplater;
+}
+
+function mockPluginWithTemplater(
+  fakeTemplater: ReturnType<typeof makeFakeTemplater> | undefined,
+) {
+  const app = mockApp();
+  (
+    app as unknown as {
+      plugins: {
+        plugins: Record<string, { templater?: unknown }>;
+      };
+    }
+  ).plugins = {
+    plugins: {
+      "templater-obsidian": fakeTemplater ? { templater: fakeTemplater } : {},
+    },
+  };
+
+  return mockPlugin({ app } as never);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("templatesCompat — handleTemplatesExecuteCompat", () => {
+  test("returns 400 on invalid request body (missing required `name`)", async () => {
+    const plugin = mockPluginWithTemplater(makeFakeTemplater());
+
+    const result = await handleTemplatesExecuteCompat(plugin, {
+      // `name` missing — schema requires it
+      arguments: { foo: "bar" },
+    });
+
+    expect(result.status).toBe(400);
+    if (result.status === 400) {
+      expect(result.payload.error).toBe("Invalid request body");
+      expect(result.payload.summary).toBeDefined();
+    }
+  });
+
+  test("returns 400 on completely malformed body", async () => {
+    const plugin = mockPluginWithTemplater(makeFakeTemplater());
+
+    const result = await handleTemplatesExecuteCompat(plugin, "not an object");
+
+    expect(result.status).toBe(400);
+  });
+
+  test("returns 503 when Templater plugin is not installed", async () => {
+    const plugin = mockPluginWithTemplater(undefined);
+
+    const result = await handleTemplatesExecuteCompat(plugin, {
+      name: "Templates/foo.md",
+      arguments: {},
+    });
+
+    expect(result.status).toBe(503);
+    if (result.status === 503) {
+      expect(result.payload.error).toMatch(/templater.*not installed/i);
+    }
+  });
+
+  test("returns 404 when template file does not exist in vault", async () => {
+    const plugin = mockPluginWithTemplater(makeFakeTemplater());
+
+    const result = await handleTemplatesExecuteCompat(plugin, {
+      name: "Templates/does-not-exist.md",
+      arguments: {},
+    });
+
+    expect(result.status).toBe(404);
+    if (result.status === 404) {
+      expect(result.payload.error).toContain("Templates/does-not-exist.md");
+    }
+  });
+
+  test("returns 200 with rendered content when createFile is omitted", async () => {
+    setMockFile("Templates/foo.md", "Hello {{name}}");
+    const fakeTemplater = makeFakeTemplater("Hello World");
+    const plugin = mockPluginWithTemplater(fakeTemplater);
+
+    const result = await handleTemplatesExecuteCompat(plugin, {
+      name: "Templates/foo.md",
+      arguments: { name: "World" },
+    });
+
+    expect(result.status).toBe(200);
+    if (result.status === 200) {
+      expect(result.payload.content).toBe("Hello World");
+      expect(result.payload.message).toMatch(/without creating/i);
+      // `path` should NOT be present when createFile is omitted/false
+      expect(result.payload.path).toBeUndefined();
+    }
+  });
+
+  test("returns 200 with rendered content when createFile=false explicitly", async () => {
+    setMockFile("Templates/foo.md", "Hello");
+    const plugin = mockPluginWithTemplater(makeFakeTemplater("Hello"));
+
+    const result = await handleTemplatesExecuteCompat(plugin, {
+      name: "Templates/foo.md",
+      arguments: {},
+      createFile: false,
+    });
+
+    expect(result.status).toBe(200);
+    if (result.status === 200) {
+      expect(result.payload.content).toBe("Hello");
+      expect(result.payload.path).toBeUndefined();
+    }
+  });
+
+  test("returns 200 with `path` when createFile=true and targetPath is provided", async () => {
+    setMockFile("Templates/foo.md", "Hello");
+    const plugin = mockPluginWithTemplater(makeFakeTemplater("Hello rendered"));
+
+    const result = await handleTemplatesExecuteCompat(plugin, {
+      name: "Templates/foo.md",
+      arguments: {},
+      createFile: true,
+      targetPath: "Notes/output.md",
+    });
+
+    expect(result.status).toBe(200);
+    if (result.status === 200) {
+      expect(result.payload.content).toBe("Hello rendered");
+      expect(result.payload.message).toMatch(/created/i);
+      expect(result.payload.path).toBe("Notes/output.md");
+    }
+  });
+
+  test("maps boolean createFile (LRA shape) to string '\"true\"' (in-process tool shape) — file is created", async () => {
+    setMockFile("Templates/foo.md", "Hello");
+    const fakeTemplater = makeFakeTemplater("Hello rendered");
+    const plugin = mockPluginWithTemplater(fakeTemplater);
+
+    const result = await handleTemplatesExecuteCompat(plugin, {
+      name: "Templates/foo.md",
+      arguments: {},
+      createFile: true,
+      targetPath: "Notes/output.md",
+    });
+
+    // The vault.create call would have been made by executeTemplateHandler
+    // — verified indirectly by the success status + path echo. The
+    // mapping itself is what we care about: a boolean `true` from the
+    // LRA shape must produce `path` in the response (which only
+    // happens on the createFile branch of the in-process handler).
+    expect(result.status).toBe(200);
+    if (result.status === 200) {
+      expect(result.payload.path).toBe("Notes/output.md");
+    }
+  });
+
+  test("forwards arguments map to the template prompt accessor", async () => {
+    setMockFile("Templates/foo.md", "Hello");
+    const fakeTemplater = makeFakeTemplater("Hello rendered");
+    const plugin = mockPluginWithTemplater(fakeTemplater);
+
+    const result = await handleTemplatesExecuteCompat(plugin, {
+      name: "Templates/foo.md",
+      arguments: { greeting: "ciao", name: "Stefano" },
+    });
+
+    // The arguments path is exercised by the in-process handler's
+    // generate_object override; here we just ensure the call succeeds
+    // and the templater's read_and_parse_template was invoked.
+    expect(result.status).toBe(200);
+    expect(fakeTemplater._calls).toHaveLength(1);
+  });
+
+  test("returns 500 when the template execution itself throws", async () => {
+    setMockFile("Templates/foo.md", "Hello");
+    const failingTemplater = makeFakeTemplater();
+    failingTemplater.read_and_parse_template = async () => {
+      throw new Error("Templater rendering exploded mid-flight");
+    };
+    const plugin = mockPluginWithTemplater(failingTemplater);
+
+    const result = await handleTemplatesExecuteCompat(plugin, {
+      name: "Templates/foo.md",
+      arguments: {},
+    });
+
+    expect(result.status).toBe(500);
+    if (result.status === 500) {
+      expect(result.payload.error).toContain(
+        "Templater rendering exploded mid-flight",
+      );
+    }
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/templatesCompat.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/templatesCompat.ts
@@ -1,0 +1,189 @@
+import { type } from "arktype";
+import type { Request, Response } from "express";
+import { LocalRestAPI } from "shared";
+import type McpToolsPlugin from "$/main";
+import { logger } from "$/shared";
+import { executeTemplateHandler } from "../tools/executeTemplate";
+
+/**
+ * Backward-compatibility shim for the legacy `POST /templates/execute`
+ * Local REST API route.
+ *
+ * Why this exists: 0.3.x shipped a standalone `mcp-server` binary that
+ * called back into the plugin via three LRA-mounted endpoints, including
+ * `/templates/execute`. The 0.4.0 pivot moved tool execution in-process
+ * and de-registered those routes (they were dead code from the in-process
+ * server's perspective). However, users who upgrade silently — keeping
+ * a pre-existing custom-id MCP server entry in `claude_desktop_config.json`
+ * that still spawns the 0.3.x binary — get an HTTP 404 on every
+ * `execute_template` call. The migration only cleans up the canonical
+ * `obsidian-mcp-tools` legacy id and rewrites `mcp-tools-istefox`; it
+ * does not touch arbitrary custom ids.
+ *
+ * This shim re-registers the route as a thin proxy onto the in-process
+ * `executeTemplateHandler`, so 0.3.x binary callers keep working without
+ * a code path of their own. Once the 0.4.1 migration learns to detect
+ * and remove residual binary entries, this shim becomes a pure safety
+ * net and could in principle be removed — but the cost of keeping it is
+ * negligible (one route, one proxy function), so the plan is to leave
+ * it indefinitely as a compatibility commitment.
+ *
+ * Reported by @folotp on issue #73 (2026-05-01) during 0.4.0-beta.2 soak.
+ */
+
+/**
+ * Discriminated result type for the compat handler. Status code is part
+ * of the contract — the route handler maps it directly to `res.status()`.
+ */
+export type TemplatesCompatResult =
+  | {
+      status: 200;
+      payload: {
+        message: string;
+        content: string;
+        // Optional `path` echo for callers that chain off it (Issue #20
+        // pattern). Not part of the original 0.3.x response shape, but
+        // added as an additional field; legacy clients ignore unknown
+        // properties.
+        path?: string;
+      };
+    }
+  | {
+      status: 400 | 404 | 500 | 503;
+      payload: {
+        error: string;
+        body?: unknown;
+        summary?: string;
+      };
+    };
+
+/**
+ * Pure logic for the `/templates/execute` compat endpoint, isolated from
+ * the Express req/res wiring so it can be unit-tested without spinning up
+ * a route registration. Maps the LRA request shape to the in-process
+ * `executeTemplateHandler` arguments and translates the tool's
+ * `isError`-flagged result back into appropriate HTTP status codes.
+ */
+export async function handleTemplatesExecuteCompat(
+  plugin: McpToolsPlugin,
+  body: unknown,
+): Promise<TemplatesCompatResult> {
+  // Validate body using the same ArkType schema 0.3.x used. Keeps the
+  // wire contract stable for legacy clients.
+  const params = LocalRestAPI.ApiTemplateExecutionParams(body);
+  if (params instanceof type.errors) {
+    return {
+      status: 400,
+      payload: {
+        error: "Invalid request body",
+        body,
+        summary: params.summary,
+      },
+    };
+  }
+
+  // Map LRA shape (`name`, `createFile` boolean) to the in-process tool
+  // shape (`templatePath`, `createFile` as `"true"`/`"false"` string). The
+  // string-typed boolean on the in-process side is a belt-and-suspenders
+  // workaround for older MCP clients that serialize booleans as strings;
+  // here we always pass the canonical string form.
+  const result = await executeTemplateHandler({
+    arguments: {
+      templatePath: params.name,
+      targetPath: params.targetPath,
+      createFile: params.createFile === true ? "true" : "false",
+      arguments: params.arguments,
+    },
+    app: plugin.app,
+    plugin,
+  });
+
+  const errorText = result.content[0]?.text ?? "Unknown error";
+
+  if (result.isError === true) {
+    // The in-process handler signals error categories through specific
+    // message prefixes. Map them to the HTTP status codes the legacy
+    // 0.3.x handler used, so binary callers see identical envelopes.
+    if (errorText.startsWith("Templater plugin is not installed")) {
+      return { status: 503, payload: { error: errorText } };
+    }
+    if (errorText.startsWith("Template not found:")) {
+      return { status: 404, payload: { error: errorText } };
+    }
+    // Default: 500 for "Template execution failed: …" and any other
+    // surfaced error. Matches the 0.3.x behaviour for runtime failures.
+    return { status: 500, payload: { error: errorText } };
+  }
+
+  // Success path: the in-process handler returns its payload as
+  // JSON.stringify'd text inside `content[0].text`. Parse it back to a
+  // structured object to expose `message`/`content`/`path` as fields on
+  // the LRA response (matching `LocalRestAPI.ApiTemplateExecutionResponse`).
+  let parsed: { message?: string; content?: string; path?: string };
+  try {
+    parsed = JSON.parse(errorText) as typeof parsed;
+  } catch (parseError) {
+    logger.error("Templates compat — failed to parse handler payload", {
+      payload: errorText,
+      error: parseError instanceof Error ? parseError.message : String(parseError),
+    });
+    return {
+      status: 500,
+      payload: {
+        error: "Internal error: handler returned malformed payload",
+      },
+    };
+  }
+
+  return {
+    status: 200,
+    payload: {
+      message: parsed.message ?? "",
+      content: parsed.content ?? "",
+      ...(parsed.path !== undefined ? { path: parsed.path } : {}),
+    },
+  };
+}
+
+/**
+ * Mounts the compat route onto the Local REST API plugin. Idempotent
+ * relative to a single plugin lifecycle: LRA's `addRoute` does not
+ * deduplicate, so callers must invoke this exactly once per `setup()`.
+ *
+ * Skips cleanly if LRA is not installed; the in-process MCP server
+ * still serves `execute_template` over HTTP/27200 to MCP-aware clients.
+ */
+export function registerTemplatesCompatRoute(plugin: McpToolsPlugin): void {
+  const api = plugin.localRestApi.api;
+  if (!api) {
+    logger.debug(
+      "Templates compat route skipped — Local REST API not available",
+    );
+    return;
+  }
+
+  api
+    .addRoute("/templates/execute")
+    .post(async (req: Request, res: Response) => {
+      try {
+        const result = await handleTemplatesExecuteCompat(plugin, req.body);
+        res.status(result.status).json(result.payload);
+      } catch (error: unknown) {
+        // Defensive: any unexpected throw past the pure handler escapes
+        // here. The pure handler already wraps its own errors, so this
+        // only fires on programming errors (e.g. Express middleware
+        // failure). Log + 500 to keep the connection healthy.
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error("Templates compat route — unexpected error", {
+          error: message,
+        });
+        res.status(500).json({
+          error: `Internal error: ${message}`,
+        });
+      }
+    });
+
+  logger.info(
+    "Templates compat route registered: POST /templates/execute → in-process executeTemplateHandler",
+  );
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { type } from "arktype";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { normalizeInputSchema, ToolRegistryClass } from "./toolRegistry";
 
 /**
@@ -187,16 +188,27 @@ describe("ToolRegistry enable/disable", () => {
     expect(tools.list().tools.map((t) => t.name)).toEqual(["beta"]);
   });
 
-  test("dispatch() on a disabled tool throws Unknown tool", async () => {
+  test("dispatch() on a disabled tool returns isError: true with Unknown tool message", async () => {
     const { tools, alphaSchema } = buildRegistryWithTwoTools();
 
     tools.disable(alphaSchema);
 
     // A disabled tool must be indistinguishable from an unregistered
     // one — otherwise `list()` and `dispatch()` would disagree.
-    await expect(
-      tools.dispatch({ name: "alpha", arguments: {} }, fakeContext),
-    ).rejects.toThrow(/Unknown tool: alpha/);
+    //
+    // After issue #74, the registry no longer throws the McpError up to
+    // the transport layer (which would cause downstream clients to
+    // double-prefix the message); it surfaces the error via the MCP
+    // `isError: true` envelope. The semantic distinction is the same —
+    // the caller learns the tool is not available — but the wire format
+    // is the cleaner single-prefix one.
+    const result = (await tools.dispatch(
+      { name: "alpha", arguments: {} },
+      fakeContext,
+    )) as { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/Unknown tool: alpha/);
   });
 
   test("dispatch() still works for other enabled tools after one is disabled", async () => {
@@ -230,5 +242,116 @@ describe("ToolRegistry enable/disable", () => {
     expect(result).toBe(false);
     // Both tools still listed.
     expect(tools.list().tools.map((t) => t.name)).toEqual(["alpha", "beta"]);
+  });
+});
+
+/**
+ * Issue #74 — registry-level isError envelope for thrown errors.
+ *
+ * Background: in PR #69 the `executeTemplate.ts` handler was changed to
+ * return `{ content, isError: true }` instead of throwing McpError, to
+ * avoid the cosmetic `MCP error -<code>: MCP error -<code>: <text>`
+ * double-prefix that downstream MCP clients (mcp-remote bridging
+ * stdio↔HTTP) prepend to thrown McpErrors. That fix was local to one
+ * handler. Folotp's 0.4.0-beta.2 retest (issue #74) showed the same
+ * double-prefix is still visible on every other tool that throws —
+ * `patch_vault_file`, `patch_active_file`, etc.
+ *
+ * Fix: hoist the same `isError: true` pattern up to the `dispatch()`
+ * catch in `ToolRegistry`, so it applies uniformly to every tool that
+ * throws. The handler-side fix in `executeTemplate.ts` becomes a
+ * defence-in-depth safety net (kept for explicit clarity).
+ */
+describe("ToolRegistry — issue #74 (registry-level isError envelope)", () => {
+  test("handler throwing McpError surfaces as isError: true with the original message", async () => {
+    const tools = new ToolRegistryClass();
+    const schema = type({
+      name: '"throwing-tool"',
+      arguments: {},
+    }).describe("Tool that throws an McpError");
+
+    tools.register(schema, () => {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Refusing to overwrite array with scalar",
+      );
+    });
+
+    const result = (await tools.dispatch(
+      { name: "throwing-tool", arguments: {} },
+      fakeContext,
+    )) as { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe(
+      "MCP error -32602: Refusing to overwrite array with scalar",
+    );
+    // Crucially: NOT the double-prefixed form (`MCP error -32602: MCP error -32602: ...`).
+    expect(result.content[0]?.text).not.toMatch(
+      /MCP error -\d+:\s+MCP error -\d+:/,
+    );
+  });
+
+  test("handler throwing a plain Error is wrapped to InternalError and surfaced as isError: true", async () => {
+    const tools = new ToolRegistryClass();
+    const schema = type({
+      name: '"plain-throw"',
+      arguments: {},
+    }).describe("Tool that throws a plain Error");
+
+    tools.register(schema, () => {
+      throw new Error("Templater rendering exploded");
+    });
+
+    const result = (await tools.dispatch(
+      { name: "plain-throw", arguments: {} },
+      fakeContext,
+    )) as { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Templater rendering exploded");
+    // formatMcpError wraps plain Error as InternalError (-32603)
+    expect(result.content[0]?.text).toMatch(/^MCP error -32603:/);
+    // No double-prefix
+    expect(result.content[0]?.text).not.toMatch(
+      /MCP error -\d+:\s+MCP error -\d+:/,
+    );
+  });
+
+  test("handler returning normally is unaffected (success path is not wrapped as isError)", async () => {
+    const { tools } = buildRegistryWithTwoTools();
+
+    const result = await tools.dispatch(
+      { name: "alpha", arguments: {} },
+      fakeContext,
+    );
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "alpha-ok" }],
+    });
+    // The success path did not gain a spurious isError flag.
+    expect((result as { isError?: boolean }).isError).toBeUndefined();
+  });
+
+  test("handler returning isError: true normally (e.g. executeTemplate.ts pattern) is passed through unchanged", async () => {
+    const tools = new ToolRegistryClass();
+    const schema = type({
+      name: '"already-isError"',
+      arguments: {},
+    }).describe("Tool that returns isError: true without throwing");
+
+    tools.register(schema, () => ({
+      content: [{ type: "text", text: "Template not found: foo.md" }],
+      isError: true,
+    }));
+
+    const result = (await tools.dispatch(
+      { name: "already-isError", arguments: {} },
+      fakeContext,
+    )) as { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+
+    // Handler-side isError envelope is forwarded byte-for-byte.
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe("Template not found: foo.md");
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
@@ -247,6 +247,23 @@ export class ToolRegistryClass<
         `Unknown tool: ${params.name}`,
       );
     } catch (error) {
+      // Surface tool failures via the MCP `isError: true` envelope
+      // instead of throwing the McpError up to the transport layer.
+      //
+      // Why: the transport's outer serializer (and at least one client
+      // shim, e.g. mcp-remote when bridging stdio↔HTTP) prepends its
+      // own `MCP error -<code>:` prefix to the message of any thrown
+      // McpError, producing the cosmetic `MCP error -32603: MCP error
+      // -32603: <text>` double-prefix folotp observed during the
+      // 0.4.0-beta.2 retest on issue #74. Returning the result as
+      // `isError: true` keeps the path that does NOT add a prefix —
+      // the message reaches the client clean. The `executeTemplate.ts`
+      // local fix in PR #69 was the same shape; this lifts the pattern
+      // up so it applies uniformly to every tool that throws.
+      //
+      // Logging stays on `logger.error` because we still want full
+      // diagnostic context (stack, error, params) for the operator
+      // even when the client-facing surface is the cleaner envelope.
       const formattedError = formatMcpError(error);
       logger.error(`Error handling ${params.name}`, {
         ...formattedError,
@@ -255,7 +272,12 @@ export class ToolRegistryClass<
         error,
         params,
       });
-      throw formattedError;
+      return {
+        content: [
+          { type: "text" as const, text: formattedError.message },
+        ],
+        isError: true,
+      };
     }
   };
 }

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -35,6 +35,7 @@ import {
 // imported by `tool-toggle/components/ToolToggleSettings.svelte` in a
 // branch that no longer fires in 0.4.0). T14 retires it for good.
 // import { setup as setupMcpServerInstall } from "./features/mcp-server-install";
+import { registerTemplatesCompatRoute } from "./features/mcp-tools/services/templatesCompat";
 import { setupMigration } from "./features/migration";
 import {
   setup as semanticSearchSetup,
@@ -440,20 +441,27 @@ export default class McpToolsPlugin extends Plugin {
     // In 0.3.x the binary mcp-server called back into the plugin via
     // three LRA-mounted endpoints (/search/smart, /templates/execute,
     // /mcp-tools/command-permission/). In 0.4.0 the MCP server runs
-    // in-process and calls Obsidian APIs directly — those endpoints are
-    // dead and intentionally not registered.
+    // in-process and calls Obsidian APIs directly — most of those
+    // endpoints are dead. One exception: `/templates/execute` is
+    // re-registered as a thin compat shim onto the in-process
+    // `executeTemplateHandler`, because users who upgrade silently can
+    // keep a residual custom-id MCP server entry in their Claude
+    // Desktop config that still spawns the 0.3.x binary, and that
+    // binary's only path to render a template is the LRA route. See
+    // `features/mcp-tools/services/templatesCompat.ts` and issue #73.
     //
-    // The single LRA consumer that survives is the `search_vault` tool
-    // (DQL / JsonLogic via Dataview), which uses LRA's `/search/`
-    // endpoint with an apiKey. If LRA is not installed, that tool
-    // returns an actionable error to the MCP client; the rest of the
-    // 19 tools work without LRA. Hence: load best-effort, log debug,
-    // never show a "required" Notice.
+    // The single LRA consumer that survives directly is the
+    // `search_vault` tool (DQL / JsonLogic via Dataview), which uses
+    // LRA's `/search/` endpoint with an apiKey. If LRA is not
+    // installed, that tool returns an actionable error to the MCP
+    // client; the rest of the 19 tools work without LRA. Hence: load
+    // best-effort, log debug, never show a "required" Notice.
     lastValueFrom(loadLocalRestAPI(this))
       .then((localRestApi) => {
         this.localRestApi = localRestApi;
         if (this.localRestApi.api) {
           logger.info("Local REST API detected — `search_vault` is available");
+          registerTemplatesCompatRoute(this);
         } else {
           logger.debug(
             "Local REST API not installed — `search_vault` will return an actionable error if invoked; the other 19 tools are unaffected",


### PR DESCRIPTION
## Summary

Two folotp-soak findings against `0.4.0-beta.2`, bundled for the `0.4.0-beta.3` cut.

- **#73** (regression, blocking): `POST /templates/execute` returns HTTP 404 — re-register the route as a compat shim that proxies into the in-process `executeTemplateHandler`. Restores `execute_template` for users still holding a 0.3.x `mcp-server` binary entry under a custom id in `claude_desktop_config.json` that the migration didn't touch.
- **#74** (cosmetic, structural): hoist the `isError` envelope from `executeTemplate.ts` (PR #69 local fix) up to the `ToolRegistry` dispatch catch. Closes the `MCP error -<code>: MCP error -<code>:` double-prefix leak across every tool that throws (`patch_vault_file`, `patch_active_file`, ...).

Diagnosis + plan agreed in the [#73 triage thread](https://github.com/istefox/obsidian-mcp-connector/issues/73). The compat shim is backward-compatible (legacy `ApiTemplateExecutionResponse` shape preserved with optional `path` echo); the registry hoist preserves logging on the operator side and only changes the client-visible wire format.

## Changes

| Area | Files | Tests |
|---|---|---|
| #73 compat shim | `services/templatesCompat.ts` (new pure handler) + `main.ts` route registration | `services/templatesCompat.test.ts` — 10 cases (mapping, status code translation, all error/success paths) |
| #74 registry hoist | `services/toolRegistry.ts` dispatch catch | `services/toolRegistry.test.ts` — 4 new cases + 1 updated (disabled-tool semantic preserved) |

Total: 449 LOC (#73) + 155 LOC (#74) = 604 LOC, of which ~390 are tests.

## Test plan

- [x] `bun run check` — typecheck green
- [x] `bun test` (from `packages/obsidian-plugin`) on both files — 31/31 pass
- [x] CI `check-and-test` — green
- [ ] Smoke E2E in vault TEST: `execute_template` from 0.3.x binary path returns HTTP 200, in-process tool path unaffected
- [ ] Smoke E2E: `patch_vault_file` array-replace fail-loud now surfaces single-prefix `Error: MCP error -32602: Refusing to replace ...` (was double-prefix on beta.2)
- [ ] Folotp re-soak round 3 on beta.3 BRAT pin (closes #73, #74, unblocks #19/#20 verification)

## Notes

- `port.test.ts` fails 3/3 environmentally when Obsidian binds `127.0.0.1:27200`; pre-existing on `feat/http-embedded`, not touched by this PR.
- Handler-side `isError` envelope in `executeTemplate.ts` (PR #69) kept as defence-in-depth.
- After merge: cut `0.4.0-beta.3` → ping @folotp in #54 thread for re-soak.

Closes #73.
Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)