### PR TITLE
feat(0.4): add list_tags MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ## [Unreleased]
 
+### Added
+
+- **`list_tags` tool** — lists all tags used across the vault with their
+  aggregated usage counts. Backed directly by
+  `app.metadataCache.getTags()`, so it includes both inline `#tags` and
+  frontmatter tags, deduplicated per file, with no plugin dependency
+  (Dataview is not required). Optional `sort` argument:
+  `"count"` (default, descending) or `"name"` (alphabetical). Output
+  shape:
+
+  ```json
+  {
+    "totalTags": 3,
+    "tags": [
+      { "tag": "#project", "count": 23 },
+      { "tag": "#daily", "count": 19 },
+      { "tag": "#idea", "count": 1 }
+    ]
+  }
+  ```
+
+  Useful for agents discovering content categories before deciding what
+  to read or query. Always read-only.
+
+  Pinned by 7 cases in `listTags.test.ts` (schema name, empty vault,
+  default count-desc sort, name-asc sort, explicit count sort, nested
+  tag paths preserved verbatim).
+
+  Mock surface extended in `test-setup.ts`: `setMockTags()` helper +
+  `metadataCache.getTags()` mock; reusable by future tag-related tools
+  without further bootstrap.
+
 ## [0.4.3] — 2026-05-05
 
 ### Fixed
@@ -132,7 +164,6 @@ post-store-accept.
   (`mcp__obsidian-mcp-tools__*` legacy vs. `mcp__mcp-tools-istefox__*`
   HTTP-embedded). First-line check for any future soak round so chain-
   mismatch is caught at the report shape, not three rounds in.
-
 ## [0.4.1] — 2026-05-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ When connected to an MCP-compatible client, this plugin enables:
 - **Prompt library** — author MCP prompts as markdown files in your vault's `Prompts/` folder, with parameters defined inline via Templater syntax. See [Using prompts](#using-prompts) below.
 - **Command execution** (opt-in) — authorize the agent to run specific Obsidian commands (e.g. `editor:toggle-bold`, `graph:open`) from a per-vault allowlist. Disabled by default; every invocation is audited. See [Command execution](#command-execution) below.
 - **Web fetch** — `fetch` tool retrieves arbitrary URLs and returns Markdown via Turndown, with pagination for long pages.
+- **Tag listing** — `list_tags` returns every tag in the vault with its usage count, sourced from `app.metadataCache.getTags()`. Inline `#tags` and frontmatter tags both included; no plugin dependency.
 
-20 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
+21 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
 
 ## Prerequisites
 
@@ -131,7 +132,7 @@ Click **Copy config for streamable-http clients**. The snippet uses the generic 
 
 ### Verifying the setup
 
-Once configured, your client should expose **20 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
+Once configured, your client should expose **21 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
 
 To verify the connection works end-to-end, ask the agent to call `get_server_info`. A successful response confirms the client can reach the in-process server and the bearer token is correct. For deeper inspection (request/response logs, tool schema inspection without an LLM in the loop), use [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector):
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -67,6 +67,7 @@ import {
   executeTemplateHandler,
   executeTemplateSchema,
 } from "./tools/executeTemplate";
+import { listTagsHandler, listTagsSchema } from "./tools/listTags";
 
 export type RegisterToolsContext = {
   app: App;
@@ -121,6 +122,11 @@ export async function registerTools(
   );
   registry.register(deleteVaultFileSchema, async ({ arguments: args }) =>
     deleteVaultFileHandler({ arguments: args, app: ctx.app }),
+  );
+
+  // Metadata
+  registry.register(listTagsSchema, async ({ arguments: args }) =>
+    listTagsHandler({ arguments: args, app: ctx.app }),
   );
 
   // Search

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { listTagsHandler, listTagsSchema } from "./listTags";
+import { mockApp, resetMockVault, setMockTags } from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+describe("list_tags tool", () => {
+  test("schema declares the tool name", () => {
+    expect(listTagsSchema.get("name")?.toString()).toContain("list_tags");
+  });
+
+  test("returns empty result when vault has no tags", async () => {
+    const r = await listTagsHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data).toEqual({ totalTags: 0, tags: [] });
+  });
+
+  test("returns all tags with counts when vault has tags", async () => {
+    setMockTags({ "#project": 5, "#daily": 12, "#idea": 1 });
+    const r = await listTagsHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.totalTags).toBe(3);
+    expect(data.tags).toHaveLength(3);
+    expect(data.tags.map((t: { tag: string }) => t.tag).sort()).toEqual([
+      "#daily",
+      "#idea",
+      "#project",
+    ]);
+  });
+
+  test("default sort is by count descending", async () => {
+    setMockTags({ "#a": 1, "#b": 10, "#c": 5 });
+    const r = await listTagsHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.tags).toEqual([
+      { tag: "#b", count: 10 },
+      { tag: "#c", count: 5 },
+      { tag: "#a", count: 1 },
+    ]);
+  });
+
+  test("sort by name returns alphabetical order", async () => {
+    setMockTags({ "#zebra": 1, "#apple": 100, "#mango": 5 });
+    const r = await listTagsHandler({
+      arguments: { sort: "name" },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.tags.map((t: { tag: string }) => t.tag)).toEqual([
+      "#apple",
+      "#mango",
+      "#zebra",
+    ]);
+  });
+
+  test("explicit sort by count matches default behaviour", async () => {
+    setMockTags({ "#a": 3, "#b": 7 });
+    const r = await listTagsHandler({
+      arguments: { sort: "count" },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.tags[0]).toEqual({ tag: "#b", count: 7 });
+    expect(data.tags[1]).toEqual({ tag: "#a", count: 3 });
+  });
+
+  test("preserves nested tag paths verbatim", async () => {
+    setMockTags({
+      "#project/active": 4,
+      "#project/archived": 2,
+      "#project": 1,
+    });
+    const r = await listTagsHandler({
+      arguments: { sort: "name" },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.tags.map((t: { tag: string }) => t.tag)).toEqual([
+      "#project",
+      "#project/active",
+      "#project/archived",
+    ]);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.ts
@@ -1,0 +1,48 @@
+import { type } from "arktype";
+import type { App } from "obsidian";
+
+export const listTagsSchema = type({
+  name: '"list_tags"',
+  arguments: {
+    "sort?": type('"name" | "count"').describe(
+      "Sort by tag name (alphabetical, ascending) or by usage count (descending). Defaults to 'count'.",
+    ),
+  },
+}).describe(
+  "Lists all tags used across the vault with their usage counts. Aggregates both inline `#tags` and frontmatter tags via Obsidian's metadata cache. Useful for discovering content categories, finding related notes, and understanding vault organization. Always read-only.",
+);
+
+export type ListTagsContext = {
+  arguments: { sort?: "name" | "count" };
+  app: App;
+};
+
+export async function listTagsHandler(
+  ctx: ListTagsContext,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  // `MetadataCache.getTags()` returns a `Record<string, number>` keyed by
+  // tag (with the leading `#`), value = aggregated count across the vault.
+  // The signature is part of Obsidian's public API but the cast through
+  // `unknown` keeps us aligned with the codebase pattern used for other
+  // metadata-cache accessors that the bundled `obsidian.d.ts` does not
+  // surface directly (see listObsidianCommands.ts).
+  const tagCounts = (
+    ctx.app.metadataCache as unknown as {
+      getTags: () => Record<string, number>;
+    }
+  ).getTags();
+
+  const sortMode = ctx.arguments.sort ?? "count";
+  const sorted = Object.entries(tagCounts).sort((a, b) =>
+    sortMode === "name" ? a[0].localeCompare(b[0]) : b[1] - a[1],
+  );
+
+  const output = {
+    totalTags: sorted.length,
+    tags: sorted.map(([tag, count]) => ({ tag, count })),
+  };
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(output, null, 2) }],
+  };
+}

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -192,6 +192,7 @@ type MockVaultState = {
   >;
   commands: Array<{ id: string; name: string }>;
   executedCommands: string[];
+  tags: Record<string, number>;
   requestUrlResponses: Map<
     string,
     {
@@ -209,6 +210,7 @@ const _mockState: MockVaultState = {
   metadataCache: new Map(),
   commands: [],
   executedCommands: [],
+  tags: {},
   requestUrlResponses: new Map(),
 };
 
@@ -218,6 +220,7 @@ export function resetMockVault(): void {
   _mockState.metadataCache.clear();
   _mockState.commands = [];
   _mockState.executedCommands = [];
+  _mockState.tags = {};
   _mockState.requestUrlResponses.clear();
 }
 
@@ -263,6 +266,15 @@ export function setMockCommands(
 
 export function getExecutedCommands(): string[] {
   return [..._mockState.executedCommands];
+}
+
+/**
+ * Set the tag→count map returned by `app.metadataCache.getTags()`.
+ * Mirrors Obsidian's API shape: keys include the leading `#`, values
+ * are aggregated counts across the vault.
+ */
+export function setMockTags(tags: Record<string, number>): void {
+  _mockState.tags = { ...tags };
 }
 
 export function setMockRequestUrl(
@@ -418,6 +430,7 @@ export function mockApp(): App {
       const path = (file as unknown as MockTFile).path;
       return _mockState.metadataCache.get(path) ?? null;
     },
+    getTags: (): Record<string, number> => ({ ..._mockState.tags }),
   };
 
   const fileManager = {


### PR DESCRIPTION
## Summary

Adds a `list_tags` MCP tool that returns every tag used across the vault with its
aggregated usage count, sourced directly from `app.metadataCache.getTags()`.

Proposed in the inventory thread on
jacksteamdev/obsidian-mcp-tools#69 (comment-4371427847) as one of the lightweight
warm-up candidates.

## Why

Agents working over a vault routinely need to discover the tag taxonomy before
deciding what to read or query. Without this tool, the only paths today are:

1. Read multiple files via `get_vault_file` and parse `frontmatter.tags` +
   inline `#tags` per file. O(notes) calls per query.
2. `search_vault_simple "#"` — broad, noisy, returns a context window per match
   rather than a deduplicated tag list with counts.

`MetadataCache.getTags()` is the canonical Obsidian-internal source of truth for
this and is already maintained by Obsidian for its own tag-pane view, so the
implementation is one accessor + a sort.

## Tool surface

```json
{
  "name": "list_tags",
  "arguments": {
    "sort": "count" | "name"
  }
}
```

`sort` is optional; defaults to `"count"` (descending).

Response:

```json
{
  "totalTags": 3,
  "tags": [
    { "tag": "#project", "count": 23 },
    { "tag": "#daily", "count": 19 },
    { "tag": "#idea", "count": 1 }
  ]
}
```

Both inline `#tags` and frontmatter tags are included (Obsidian deduplicates
per-file before counting). No plugin dependency — works in any vault.

## Files

- `tools/listTags.ts` — schema + handler (~48 lines)
- `tools/listTags.test.ts` — 7 cases (schema name, empty vault, default sort,
  name sort, explicit count sort, nested tag paths preserved)
- `mcp-tools/index.ts` — register in a new "Metadata" section
- `test-setup.ts` — extends the metadataCache mock with `getTags()` and adds
  a `setMockTags()` helper. Additive, reusable for future tag-related tools
  (a `get_files_by_tag` would slot in cleanly without further bootstrap)
- `CHANGELOG.md` — `[Unreleased]` entry, Keep-a-Changelog format
- `README.md` — bullet in the features list, tool count 20 → 21

## Test plan

- [x] `bun test src/features/mcp-tools/tools/listTags.test.ts` — 7/7 pass
- [x] `bun test src/features/mcp-tools/tools/` — 121/121 pass (no regression in
      sibling tools after the test-setup mock extension)
- [ ] End-to-end smoke against a populated vault via Claude (recommend reviewer
      smoke-tests on a vault with non-trivial tag count)

## Design notes

- **Why no `folder` argument.** My downstream Taiko fork's `list_tags` had a
  `folder` filter that scoped the result to a subtree. Dropped here to keep the
  PR surface minimal — `getTags()` is vault-wide and a folder-scoped variant
  would require iterating `app.vault.getMarkdownFiles()` and reading per-file
  metadata, doubling the implementation. Happy to follow-up if useful.
- **Cast through `unknown` for `getTags()`.** Mirrors the pattern already used
  by `listObsidianCommands.ts` for `commands.listCommands()`. `getTags()` is
  documented in Obsidian's public TypeScript API but the cast keeps the
  accessor pattern consistent across the file.
- **Sort default of `count` desc** matches the most common discovery use-case
  (which categories dominate this vault?). `name` asc is provided for stable
  enumeration when the caller wants a deterministic order.