### PR TITLE
test(0.4.5): backfill coverage for directory tools + tools/list registry assertion

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultDirectory.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultDirectory.test.ts
@@ -81,4 +81,40 @@ describe("create_vault_directory tool", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/file already exists/i);
   });
+
+  // Test-as-spec: locks in the current behavior on path-traversal input.
+  // Today the handler does NOT sanitise '..' segments — it forwards them to
+  // ensureFolderExists, which in turn delegates to the Obsidian Vault API.
+  // The mock vault accepts the literal string and creates a folder named '..'
+  // (a sibling of the vault root in the in-memory map). On a real Obsidian
+  // vault the same input would either no-op or surface an adapter-level
+  // error. If a future change adds explicit traversal rejection upstream of
+  // ensureFolderExists, this test will fail and the behavior change becomes
+  // a deliberate signal rather than a silent regression.
+  test("documents current behavior on path traversal '../escape'", async () => {
+    const app = mockApp();
+    const result = await createVaultDirectoryHandler({
+      arguments: { path: "../escape" },
+      app,
+    });
+    // No isError surfaced today — the handler treats '..' as a regular segment.
+    expect(result.isError).toBeUndefined();
+    // The mock records the literal segments as folders.
+    expect(getMockFolders()).toContain("../escape");
+  });
+
+  // Test-as-spec: the top-level regex `/^\/+|\/+$/g` only collapses leading
+  // and trailing slashes, but ensureFolderExists downstream splits on '/' and
+  // discards empty segments — so 'A//B' resolves to the same folder list as
+  // 'A/B'. Locked in so a future normaliser change (or a regression that
+  // surfaces literal '' segments) shows up here.
+  test("collapses internal double slashes 'A//B' to 'A/B'", async () => {
+    const app = mockApp();
+    const result = await createVaultDirectoryHandler({
+      arguments: { path: "A//B" },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(getMockFolders()).toEqual(["A", "A/B"]);
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.test.ts
@@ -104,4 +104,48 @@ describe("delete_vault_directory tool", () => {
     expect(result.isError).toBeUndefined();
     expect(getMockFolders()).toEqual([]);
   });
+
+  // Test-as-spec: locks in the current behavior on path-traversal input.
+  // Today the handler does NOT sanitise '..' segments — it forwards the
+  // trimmed path to vault.adapter.rmdir. The mock raises ENOENT because no
+  // folder named '../escape' exists; on a real adapter the call would either
+  // resolve outside the vault root or fail with a permission error. Either
+  // way, no implicit accept-and-delete occurs, but a future explicit
+  // traversal-rejection branch should surface here rather than silently.
+  test("documents current behavior on path traversal '../escape'", async () => {
+    const app = mockApp();
+    const result = await deleteVaultDirectoryHandler({
+      arguments: { path: "../escape" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/failed to delete/i);
+  });
+
+  // Covers the `String(e)` branch of `e instanceof Error ? e.message : String(e)`.
+  // Existing tests only trigger the Error-class branch (rmdir throws an Error
+  // with ENOENT/ENOTEMPTY). A real adapter could reject with a non-Error value
+  // (e.g. a raw string from a native binding); without this test that branch
+  // is dead code from the test runner's perspective.
+  test("surfaces non-Error thrown values from rmdir", async () => {
+    setMockFolder("locked");
+    const app = mockApp();
+    // Override the mock adapter's rmdir to throw a non-Error value.
+    (
+      app.vault.adapter as unknown as {
+        rmdir: (path: string, recursive: boolean) => Promise<void>;
+      }
+    ).rmdir = async () => {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw "raw string rejection from native binding";
+    };
+    const result = await deleteVaultDirectoryHandler({
+      arguments: { path: "locked" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "raw string rejection from native binding",
+    );
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -53,6 +53,74 @@ describe("end-to-end: HTTP → McpServer", () => {
     }
   });
 
+  test("tools/list exposes the full registry (regression-guards every tool name)", async () => {
+    // Lock in the exact set of registered tools. Catches the silent-regression
+    // class where a refactor in mcp-tools/index.ts drops a registry.register()
+    // call: the affected tool's own unit tests keep passing in isolation, but
+    // the tool stops being exposed via MCP. A failure here means either the
+    // registry shrunk (missing tool) or grew (new tool needs the list updated).
+    const { startHttpServer } = await import("./httpServer");
+    const svc = await createMcpService({ app: mockApp(), plugin: mockPlugin(), pluginVersion: "0.4.0-alpha.1" });
+    active.push(svc);
+
+    const server = await startHttpServer({
+      bearerToken: "t".repeat(32),
+      requestHandler: svc.handleRequest,
+    });
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${"t".repeat(32)}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/list",
+          params: {},
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const tools = body?.result?.tools ?? [];
+      const names = (tools as Array<{ name: string }>).map((t) => t.name).sort();
+      expect(names).toEqual([
+        "append_to_active_file",
+        "append_to_vault_file",
+        "create_vault_directory",
+        "create_vault_file",
+        "delete_active_file",
+        "delete_vault_directory",
+        "delete_vault_file",
+        "execute_obsidian_command",
+        "execute_template",
+        "fetch",
+        "get_active_file",
+        "get_backlinks",
+        "get_files_by_tag",
+        "get_outgoing_links",
+        "get_server_info",
+        "get_vault_file",
+        "list_obsidian_commands",
+        "list_tags",
+        "list_vault_files",
+        "patch_active_file",
+        "patch_vault_file",
+        "search_vault",
+        "search_vault_simple",
+        "search_vault_smart",
+        "show_file_in_obsidian",
+        "update_active_file",
+      ]);
+      expect(names).toHaveLength(26);
+    } finally {
+      await new Promise<void>((r) => server.server.close(() => r()));
+    }
+  });
+
   test("tools/call get_server_info returns health payload", async () => {
     const { startHttpServer } = await import("./httpServer");
     const svc = await createMcpService({ app: mockApp(), plugin: mockPlugin(), pluginVersion: "0.4.0-alpha.1" });


### PR DESCRIPTION
## Summary

Additive test coverage for the two directory tools shipped in 0.4.5 (`create_vault_directory`, `delete_vault_directory`) plus a registry-level regression guard for the full 26-tool surface. **Zero production code change.**

## What this adds

### `mcpServer.test.ts` — full registry assertion via `tools/list`
The existing end-to-end test only asserted `names.toContain("get_server_info")`. A refactor that silently drops a `registry.register()` call from `mcp-tools/index.ts` would not be caught: the affected tool's own unit tests pass in isolation, but the tool stops being exposed via MCP. The new test pins the exact 26-name set + count.

### `createVaultDirectory.test.ts` — two test-as-spec additions
- **Path traversal `../escape`**: locks in current behavior (handler does not sanitise `..`; mock vault accepts the literal segment).
- **Internal double slashes `A//B`**: surfaced a surprising-good behavior — the top-level regex `/^\/+|\/+$/g` doesn't collapse internal slashes, but `ensureFolderExists` downstream splits on `/` and discards empty segments, so `A//B` resolves identically to `A/B`. Pinned so a future regression that surfaces literal `''` segments shows up.

### `deleteVaultDirectory.test.ts` — two additions
- **Path traversal `../escape`**: locks in current behavior (ENOENT from `rmdir`, no implicit accept).
- **Non-Error throw**: exercises the `String(e)` branch of `e instanceof Error ? e.message : String(e)` by overriding `app.vault.adapter.rmdir` to throw a raw string. Previously dead code from the test runner's perspective — only Error-class throws were hit.

## Why now (during community store review)

This is **fully additive** (no production code touched, no version bump, no behavior change). It does not impact \`obsidianmd/obsidian-releases#11919\` because the artifact under review is unchanged.

## Test plan

- [x] \`bun test\` (touched files only): 23 pass, 0 fail
- [x] \`bun test\` (full plugin package suite): +5 pass / +0 fail vs \`feat/http-embedded\` baseline. The 3 pre-existing \`bindWithFallback\` failures are full-suite port-contention flakes, unchanged by this PR.
- [x] \`bun run check\` (root): all packages clean, 0 errors / 0 warnings
- [ ] Verify CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)