### PR TITLE
fix(0.4): #88 — delete_vault_directory ENOTEMPTY error suppresses absolute host path

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.test.ts
@@ -122,6 +122,46 @@ describe("delete_vault_directory tool", () => {
     expect(result.content[0].text).toMatch(/failed to delete/i);
   });
 
+  // Regression guard for #88 — the ENOTEMPTY branch must produce a
+  // vault-relative, caller-actionable message and never bubble the
+  // absolute filesystem path that Node's `fs.rmdir` embeds in its
+  // error message (which would expose $HOME / cloud-sync identifiers
+  // / vault folder name to the MCP client).
+  test("ENOTEMPTY error is errno-keyed and suppresses the absolute host path", async () => {
+    setMockFolder("Notes");
+    setMockFile("Notes/a.md", "x");
+    const app = mockApp();
+    const result = await deleteVaultDirectoryHandler({
+      arguments: { path: "Notes" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    // Errno-keyed actionable shape: the caller learns that recursive=true
+    // is the way out.
+    expect(result.content[0].text).toContain('use recursive: "true"');
+    // No absolute-path trailer ("rmdir '<abs>'" segment from Node).
+    expect(result.content[0].text).not.toContain("rmdir '");
+    // Belt-and-suspenders: no obvious absolute-path indicators of any
+    // platform shape (macOS, Linux, Windows).
+    expect(result.content[0].text).not.toMatch(/\/Users\/|\/home\/|C:\\/);
+  });
+
+  // Sister regression guard: the ENOENT branch was already vault-relative
+  // in spirit (mock used the `<vault>/${path}` placeholder) but with a
+  // realistic absolute-path mock the handler must still suppress the
+  // trailer.
+  test("ENOENT error is errno-keyed and suppresses the absolute host path", async () => {
+    const app = mockApp();
+    const result = await deleteVaultDirectoryHandler({
+      arguments: { path: "ghost" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("does not exist");
+    expect(result.content[0].text).not.toContain("rmdir '");
+    expect(result.content[0].text).not.toMatch(/\/Users\/|\/home\/|C:\\/);
+  });
+
   // Covers the `String(e)` branch of `e instanceof Error ? e.message : String(e)`.
   // Existing tests only trigger the Error-class branch (rmdir throws an Error
   // with ENOENT/ENOTEMPTY). A real adapter could reject with a non-Error value

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.ts
@@ -67,7 +67,21 @@ export async function deleteVaultDirectoryHandler(
       }
     ).rmdir(trimmed, recursive);
   } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
+    // Map known Node fs errno codes to vault-relative messages so the
+    // raw Node "rmdir '<absolute-host-path>'" trailer never reaches the
+    // MCP client (it would expose $HOME / cloud-sync identifiers / vault
+    // folder name). Unknown errors fall through to the original shape.
+    const errno = (e as NodeJS.ErrnoException | undefined)?.code;
+    const msg =
+      errno === "ENOTEMPTY"
+        ? 'directory not empty (use recursive: "true" to delete it together with its contents)'
+        : errno === "ENOENT"
+          ? "directory does not exist"
+          : errno === "EACCES" || errno === "EPERM"
+            ? "permission denied"
+            : e instanceof Error
+              ? e.message
+              : String(e);
     return {
       content: [
         { type: "text", text: `Failed to delete directory ${trimmed}: ${msg}` },

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -281,6 +281,14 @@ type MockVaultState = {
   fileStats: Map<string, { ctime: number; mtime: number }>;
 };
 
+// Synthetic absolute filesystem prefix used by the mock `adapter.rmdir`
+// to mirror the path embedded in real Node `fs.rmdir` errors. Tests
+// assert that handler code suppresses this trailer before surfacing
+// errors to the MCP client (regression guard for #88 absolute-path
+// leak). Kept in `/Users/...` shape so the regression check works on
+// macOS- and Linux-like fixtures alike.
+const MOCK_VAULT_ABS_PREFIX = "/Users/test/Obsidian/MockVault";
+
 const _mockState: MockVaultState = {
   files: new Map(),
   folders: new Set(),
@@ -635,12 +643,20 @@ export function mockApp(): App {
     off: () => {},
     adapter: {
       // Recursive rmdir over the mock vault: removes the folder, every
-      // descendant folder, and every descendant file.
+      // descendant folder, and every descendant file. Errors mirror the
+      // real Node `fs.rmdir` shape (absolute host path embedded in the
+      // message + `.code` set on the Error instance) so handler tests
+      // can assert that the production code suppresses the absolute
+      // path before surfacing it to the MCP client (regression guard
+      // for fork issue #88).
       rmdir: async (path: string, recursive: boolean): Promise<void> => {
+        const absPath = `${MOCK_VAULT_ABS_PREFIX}/${path}`;
         if (!_mockState.folders.has(path)) {
-          throw new Error(
-            `ENOENT: no such file or directory, rmdir '<vault>/${path}'`,
+          const err: NodeJS.ErrnoException = new Error(
+            `ENOENT: no such file or directory, rmdir '${absPath}'`,
           );
+          err.code = "ENOENT";
+          throw err;
         }
         const prefix = `${path}/`;
         const childFiles = Array.from(_mockState.files.keys()).filter((p) =>
@@ -650,7 +666,11 @@ export function mockApp(): App {
           p.startsWith(prefix),
         );
         if (!recursive && (childFiles.length > 0 || childFolders.length > 0)) {
-          throw new Error(`ENOTEMPTY: directory not empty, rmdir '${path}'`);
+          const err: NodeJS.ErrnoException = new Error(
+            `ENOTEMPTY: directory not empty, rmdir '${absPath}'`,
+          );
+          err.code = "ENOTEMPTY";
+          throw err;
         }
         for (const f of childFiles) _mockState.files.delete(f);
         for (const d of childFolders) _mockState.folders.delete(d);


### PR DESCRIPTION
Closes #88.

## Summary

The ENOTEMPTY branch of `delete_vault_directory(recursive:false)` was the only error path in the directory-tool family that bubbled the raw Node `fs.rmdir` error message — which embeds the full **absolute host filesystem path** and exposes `\$HOME`, cloud-sync identifiers, and the local vault folder name to the MCP client. Reported by @folotp during the 0.4.5 round-6 verify on #86.

The fix maps known fs errno codes (ENOTEMPTY / ENOENT / EACCES / EPERM) to vault-relative messages with the **same shape as the existing sibling error paths** in the same handler (`deleteVaultDirectory.ts:35` empty-root, `:55` file-path, `createVaultDirectory.ts:51` collision). Unknown errors fall through to the original `e.message` / `String(e)` envelope, preserving the "surfaces non-Error thrown values" branch coverage.

Bonus on the ENOTEMPTY branch: the new message hints at the way out (`use recursive: "true" to delete it together with its contents`) instead of just echoing Node's raw error string — caller-actionable without needing prior context.

## Mock realism update

`test-setup.ts` `adapter.rmdir` now sets `.code` on the thrown `Error` and embeds a synthetic absolute path (`MOCK_VAULT_ABS_PREFIX = "/Users/test/Obsidian/MockVault"`) in both ENOENT and ENOTEMPTY error messages, mirroring real Node behaviour. The previous mock used a vault-relative shape — which is exactly why the bug slipped past 0.4.5's pre-cut tests.

## Test plan

- [x] `bun run check` clean across all packages
- [x] `bun test src/features/mcp-tools/tools/deleteVaultDirectory.test.ts` — 12/12 pass (was 10, +2 regression-locked)
- [x] `bun test` (full plugin suite) — **749 pass / 3 fail / 1 error** vs. baseline **747 pass / 3 fail / 1 error**: +2 net pass from new regression-locked tests, identical fail/error count (the 3 fails are the pre-existing `bindWithFallback` env-flake on ports 27200/27201 from the vault TEST plugin, unchanged across the branch tree).

Two new regression-locked tests:
- **ENOTEMPTY**: errno-keyed shape + no `rmdir '<abs>'` trailer + no cross-platform absolute-path indicator (`/Users/`, `/home/`, `C:\\`).
- **ENOENT** (sister): same shape with `directory does not exist` message; locks the symmetric error path.

## Out of scope

Folotp's cosmetic observation #2 — `create_vault_directory("")` returning `-32603` — is the arktype JSON-RPC schema layer rejecting at the protocol envelope **before** the handler runs, distinct from the "0 prefix layers on HTTP-embedded" property which scopes to handler-thrown errors. Not actionable on the handler side; documented as a layer-disambiguation caveat in the #88 issue body and the #86 round-6 ack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)