### PR TITLE
feat(0.4): add rename_vault_file MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ### Added
 
+- **`rename_vault_file` tool** — renames or moves a vault file via
+  `app.fileManager.renameFile`, preserving link integrity across the
+  vault (wikilinks, markdown links, embeds, and frontmatter aliases
+  pointing at the source path are rewritten atomically by Obsidian).
+  Schema: `{ from, to }`, both required, both vault-root relative.
+  Response on success: `{ ok: true, path: <to> }`. Closes the gap
+  whereby an MCP client could only emulate rename via
+  `read + create + delete`, which destroys every backlink to the file
+  on every move.
+
+  Error semantics, all surfaced as `isError: true` with a descriptive
+  message:
+  - `from` does not resolve → "Source file not found: …"
+  - `to` already exists → "Destination already exists: …" (no overwrite)
+  - destination parent directory does not exist → "Destination parent
+    directory does not exist: …" (fail-loud, NOT auto-created — mirrors
+    the unresolved-target bias of `patch_*_file` from #6 / #58)
+  - `from === to` → "Source and destination are identical: …"
+  - underlying `renameFile` rejection → echoed verbatim as
+    "Failed to rename: …"
+
+  Authorization gate matches `delete_vault_file` / `create_vault_file`
+  (no per-tool allowlist). Out of scope: folder rename and heading
+  rename (the latter tracked separately in #68).
+
+  Pinned by 8 cases in `renameVaultFile.test.ts` (schema name, root
+  rename + JSON response shape, cross-directory move, all five error
+  branches). Mock surface in `test-setup.ts` extended additively with
+  `app.fileManager.renameFile` (migrates content, metadata cache,
+  stats, and active-file pointer).
+
+  Proposed and triage-accepted by @istefox in
+  [#67](https://github.com/istefox/obsidian-mcp-connector/issues/67).
+
 - **`get_server_info` now surfaces the in-process listen address.**
   Adds a `localTransport: { protocol, host, port, path }` field to the
   response when the HTTP server is bound, omitted otherwise. Doubles

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Starting with **0.4.0**, the plugin hosts the MCP server **in-process inside Obs
 - **HTTP-native MCP clients** (Claude Code, Cursor, Cline, Continue, Windsurf, VS Code) connect directly to the local HTTP endpoint.
 - **Claude Desktop** (which speaks only stdio MCP) connects through the official `npx mcp-remote` bridge — a two-line config the plugin generates for you.
 - **Native semantic search** runs entirely on-device via Transformers.js + `Xenova/all-MiniLM-L6-v2` (~25 MB, downloaded once and cached). No cloud, no Smart Connections requirement.
-- **Local REST API is now optional**: only the `search_vault` tool (Dataview DQL / JsonLogic queries) needs it, and that tool returns an actionable error if it isn't installed. The other 25 tools work without it. [^4]
+- **Local REST API is now optional**: only the `search_vault` tool (Dataview DQL / JsonLogic queries) needs it, and that tool returns an actionable error if it isn't installed. The other 26 tools work without it. [^4]
 
 ## Features
 
 When connected to an MCP-compatible client, this plugin enables:
 
-- **Vault access** — read, write, and patch notes through 16 typed tools (`get_vault_file`, `create_vault_file`, `patch_vault_file`, `list_vault_files`, `create_vault_directory`, `delete_vault_directory`, …) with native binary content for images and audio. Missing parent directories on a `create`/`append` path are auto-created.
+- **Vault access** — read, write, and patch notes through 17 typed tools (`get_vault_file`, `create_vault_file`, `patch_vault_file`, `rename_vault_file`, `list_vault_files`, `create_vault_directory`, `delete_vault_directory`, …) with native binary content for images and audio. Missing parent directories on a `create`/`append` path are auto-created. `rename_vault_file` preserves link integrity across the vault via `app.fileManager.renameFile`.
 - **Native semantic search** — `search_vault_smart` over an on-device MiniLM index, with optional fallback to Smart Connections if it is installed. Provider tri-state setting (`auto` / `native` / `smart-connections`) under the plugin settings.
 - **Plain-text + structured search** — `search_vault_simple` (text + context windows) and `search_vault` (DQL / JsonLogic via Local REST API).
 - **Template execution** — invoke Templater templates as MCP tool calls with dynamic parameters.
@@ -40,7 +40,7 @@ When connected to an MCP-compatible client, this plugin enables:
 - **Tag-filtered file lookup** — `get_files_by_tag` returns every file tagged with a given tag, with per-file occurrence count for relevance ranking. Optional `includeNested` to match `#project` against `#project/active`, `#project/archived`, etc. (mirrors Obsidian's tag pane).
 - **Graph navigation** — `get_outgoing_links` returns the body, embed, and frontmatter links emanating from a file (with resolved `targetPath` and `resolved` flag); `get_backlinks` returns every file that links to a given target, with per-source count. Both read-only, both backed by `app.metadataCache.resolvedLinks` / `getFirstLinkpathDest`.
 
-26 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
+27 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
 
 ## Prerequisites
 
@@ -134,7 +134,7 @@ Click **Copy config for streamable-http clients**. The snippet uses the generic 
 
 ### Verifying the setup
 
-Once configured, your client should expose **26 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
+Once configured, your client should expose **27 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
 
 To verify the connection works end-to-end, ask the agent to call `get_server_info`. A successful response confirms the client can reach the in-process server and the bearer token is correct. For deeper inspection (request/response logs, tool schema inspection without an LLM in the loop), use [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector):
 
@@ -397,4 +397,4 @@ See [GitHub Releases on this fork](https://github.com/istefox/obsidian-mcp-conne
 [^1]: For information about Claude data privacy and security, see [Claude AI's data usage policy](https://support.anthropic.com/en/articles/8325621-i-would-like-to-input-sensitive-data-into-free-claude-ai-or-claude-pro-who-can-view-my-conversations).
 [^2]: For more information about the Model Context Protocol, see [MCP Introduction](https://modelcontextprotocol.io/introduction).
 [^3]: For a list of available MCP Clients, see [MCP Example Clients](https://modelcontextprotocol.io/clients).
-[^4]: Local REST API was a hard requirement on the 0.3.x line. Starting with 0.4.0 it is optional and only enables the `search_vault` tool (DQL / JsonLogic queries). The other 25 tools work without it; `search_vault` returns an actionable error if it isn't installed. As of `0.4.5`, `search_vault` reads the LRA host and port from the plugin's live settings instead of a hardcoded `127.0.0.1:27124`, so reconfiguring LRA's listen port no longer requires a plugin restart.
+[^4]: Local REST API was a hard requirement on the 0.3.x line. Starting with 0.4.0 it is optional and only enables the `search_vault` tool (DQL / JsonLogic queries). The other 26 tools work without it; `search_vault` returns an actionable error if it isn't installed. As of `0.4.5`, `search_vault` reads the LRA host and port from the plugin's live settings instead of a hardcoded `127.0.0.1:27124`, so reconfiguring LRA's listen port no longer requires a plugin restart.

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -46,6 +46,10 @@ import {
   deleteVaultFileSchema,
 } from "./tools/deleteVaultFile";
 import {
+  renameVaultFileHandler,
+  renameVaultFileSchema,
+} from "./tools/renameVaultFile";
+import {
   createVaultDirectoryHandler,
   createVaultDirectorySchema,
 } from "./tools/createVaultDirectory";
@@ -158,6 +162,9 @@ export async function registerTools(
   );
   registry.register(deleteVaultFileSchema, async ({ arguments: args }) =>
     deleteVaultFileHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(renameVaultFileSchema, async ({ arguments: args }) =>
+    renameVaultFileHandler({ arguments: args, app: ctx.app }),
   );
   registry.register(createVaultDirectorySchema, async ({ arguments: args }) =>
     createVaultDirectoryHandler({ arguments: args, app: ctx.app }),

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  renameVaultFileHandler,
+  renameVaultFileSchema,
+} from "./renameVaultFile";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockFolder,
+} from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+describe("rename_vault_file tool", () => {
+  test("schema declares the tool name", () => {
+    expect(renameVaultFileSchema.get("name")?.toString()).toContain(
+      "rename_vault_file",
+    );
+  });
+
+  test("renames file at root level", async () => {
+    setMockFile("old.md", "content");
+    const app = mockApp();
+    const result = await renameVaultFileHandler({
+      arguments: { from: "old.md", to: "new.md" },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(app.vault.getAbstractFileByPath("old.md")).toBeNull();
+    const moved = app.vault.getAbstractFileByPath("new.md");
+    expect(moved).not.toBeNull();
+    expect(await app.vault.read(moved as never)).toBe("content");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, path: "new.md" });
+  });
+
+  test("moves file across existing directories", async () => {
+    setMockFolder("Source");
+    setMockFolder("Dest");
+    setMockFile("Source/note.md", "x");
+    const app = mockApp();
+    const result = await renameVaultFileHandler({
+      arguments: { from: "Source/note.md", to: "Dest/note.md" },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(app.vault.getAbstractFileByPath("Source/note.md")).toBeNull();
+    expect(app.vault.getAbstractFileByPath("Dest/note.md")).not.toBeNull();
+  });
+
+  test("returns error when source does not exist", async () => {
+    const app = mockApp();
+    const result = await renameVaultFileHandler({
+      arguments: { from: "missing.md", to: "wherever.md" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/source file not found/i);
+  });
+
+  test("returns error when destination already exists", async () => {
+    setMockFile("a.md", "old");
+    setMockFile("b.md", "blocking");
+    const app = mockApp();
+    const result = await renameVaultFileHandler({
+      arguments: { from: "a.md", to: "b.md" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/destination already exists/i);
+    // Source untouched, destination untouched
+    expect(app.vault.getAbstractFileByPath("a.md")).not.toBeNull();
+    const aFile = app.vault.getAbstractFileByPath("a.md");
+    expect(await app.vault.read(aFile as never)).toBe("old");
+    const bFile = app.vault.getAbstractFileByPath("b.md");
+    expect(await app.vault.read(bFile as never)).toBe("blocking");
+  });
+
+  test("returns error when destination parent does not exist (no auto-create)", async () => {
+    setMockFile("note.md", "x");
+    const app = mockApp();
+    const result = await renameVaultFileHandler({
+      arguments: { from: "note.md", to: "Missing/Folder/note.md" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/parent directory does not exist/i);
+    // Source untouched, no folder auto-created
+    expect(app.vault.getAbstractFileByPath("note.md")).not.toBeNull();
+    expect(app.vault.getAbstractFileByPath("Missing")).toBeNull();
+    expect(app.vault.getAbstractFileByPath("Missing/Folder")).toBeNull();
+  });
+
+  test("returns error when source and destination are identical", async () => {
+    setMockFile("note.md", "x");
+    const app = mockApp();
+    const result = await renameVaultFileHandler({
+      arguments: { from: "note.md", to: "note.md" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/identical/i);
+    // File untouched
+    expect(app.vault.getAbstractFileByPath("note.md")).not.toBeNull();
+  });
+
+  test("surfaces fileManager.renameFile rejection verbatim", async () => {
+    setMockFile("a.md", "x");
+    const app = mockApp();
+    (
+      app.fileManager as unknown as {
+        renameFile: (...args: unknown[]) => Promise<void>;
+      }
+    ).renameFile = async () => {
+      throw new Error("simulated obsidian failure");
+    };
+    const result = await renameVaultFileHandler({
+      arguments: { from: "a.md", to: "b.md" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/simulated obsidian failure/i);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.ts
@@ -1,0 +1,102 @@
+import { type } from "arktype";
+import type { App, TAbstractFile } from "obsidian";
+
+export const renameVaultFileSchema = type({
+  name: '"rename_vault_file"',
+  arguments: {
+    from: type("string>0").describe(
+      "Vault-relative path of the source file, including extension (e.g. 'Notes/old.md').",
+    ),
+    to: type("string>0").describe(
+      "Vault-relative destination path, including extension (e.g. 'Notes/new.md'). Parent directory must already exist — missing ancestors are NOT auto-created.",
+    ),
+  },
+}).describe(
+  "Renames or moves a vault file via app.fileManager.renameFile, preserving link integrity (wikilinks, markdown links, embeds, and frontmatter aliases referencing the file are rewritten across the vault). Source must exist, destination must not exist, destination parent directory must already exist.",
+);
+
+export type RenameVaultFileContext = {
+  arguments: { from: string; to: string };
+  app: App;
+};
+
+export async function renameVaultFileHandler(
+  ctx: RenameVaultFileContext,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const { from, to } = ctx.arguments;
+
+  if (from === to) {
+    return {
+      content: [
+        { type: "text", text: `Source and destination are identical: ${from}` },
+      ],
+      isError: true,
+    };
+  }
+
+  const source = ctx.app.vault.getAbstractFileByPath(from);
+  if (!source) {
+    return {
+      content: [{ type: "text", text: `Source file not found: ${from}` }],
+      isError: true,
+    };
+  }
+
+  if (ctx.app.vault.getAbstractFileByPath(to)) {
+    return {
+      content: [{ type: "text", text: `Destination already exists: ${to}` }],
+      isError: true,
+    };
+  }
+
+  // Fail-loud on missing destination parent. Mirrors the bias established
+  // for unresolved targets in patch_*_file (#6, #58) — auto-creating the
+  // parent here would silently mask caller mistakes (typos in the
+  // destination path) and leave orphan directories behind.
+  const slash = to.lastIndexOf("/");
+  if (slash > 0) {
+    const parent = to.slice(0, slash);
+    if (!ctx.app.vault.getAbstractFileByPath(parent)) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Destination parent directory does not exist: ${parent}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  // Delegate to fileManager so wikilinks, markdown links, embeds, and
+  // frontmatter aliases pointing at the source file are rewritten
+  // atomically across the vault. `fileManager` is on `App` at runtime
+  // but absent from the published type signature, hence the cast.
+  try {
+    await (
+      ctx.app.fileManager as unknown as {
+        renameFile: (file: TAbstractFile, newPath: string) => Promise<void>;
+      }
+    ).renameFile(source, to);
+  } catch (e) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to rename: ${e instanceof Error ? e.message : String(e)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [
+      { type: "text", text: JSON.stringify({ ok: true, path: to }, null, 2) },
+    ],
+  };
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -109,13 +109,14 @@ describe("end-to-end: HTTP → McpServer", () => {
         "list_vault_files",
         "patch_active_file",
         "patch_vault_file",
+        "rename_vault_file",
         "search_vault",
         "search_vault_simple",
         "search_vault_smart",
         "show_file_in_obsidian",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(26);
+      expect(names).toHaveLength(27);
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -765,6 +765,41 @@ export function mockApp(): App {
       cache.frontmatter = fm;
       _mockState.metadataCache.set(path, cache);
     },
+    /**
+     * Mock of `app.fileManager.renameFile`. The real Obsidian
+     * implementation also rewrites every wikilink / markdown link /
+     * embed / frontmatter alias pointing at the source path; here we
+     * only migrate the file's own state (content, metadata cache,
+     * stats, active-file pointer) since `rename_vault_file` tests
+     * exercise the handler's branching, not link-rewrite fidelity.
+     * Folder rename is out of scope (the handler rejects it via the
+     * existing API surface — TFolder cannot be passed as `from`).
+     */
+    renameFile: async (
+      file: TAbstractFile,
+      newPath: string,
+    ): Promise<void> => {
+      const path = (file as unknown as MockTFile).path;
+      if (!_mockState.files.has(path)) {
+        throw new Error(`File not found: ${path}`);
+      }
+      const content = _mockState.files.get(path) ?? "";
+      _mockState.files.delete(path);
+      _mockState.files.set(newPath, content);
+      const meta = _mockState.metadataCache.get(path);
+      if (meta) {
+        _mockState.metadataCache.delete(path);
+        _mockState.metadataCache.set(newPath, meta);
+      }
+      const stat = _mockState.fileStats.get(path);
+      if (stat) {
+        _mockState.fileStats.delete(path);
+        _mockState.fileStats.set(newPath, stat);
+      }
+      if (_mockState.activeFilePath === path) {
+        _mockState.activeFilePath = newPath;
+      }
+    },
   };
 
   const commands = {


### PR DESCRIPTION
## Summary

Adds the `rename_vault_file` MCP tool, implementing the design accepted in your triage on issue [#67](https://github.com/istefox/obsidian-mcp-connector/issues/67) (2026-04-29 *"Accepted as proposed"* — confirmed intact in your 2026-05-04 update *"Design contract stato: Intact"*). Implementation site, schema shape, error semantics, authorization gate, and out-of-scope boundaries land verbatim from those two comments.

## Why

Without this tool, an MCP client wanting to rename or move a vault file has only one workaround: read the source, create a new file at the destination, delete the source. That sequence destroys every backlink to the file on every move — `app.vault.create` and `app.vault.delete` go through the file system, not through the link-aware `fileManager` API, so wikilinks, markdown links, embeds, and frontmatter aliases pointing at the old path silently break across the vault. `rename_vault_file` closes that gap by delegating to `app.fileManager.renameFile`, which Obsidian uses internally for its own rename UI and which rewrites every reference atomically.

## Tool surface

**Schema** (ArkType):

```json
{
  "name": "rename_vault_file",
  "arguments": {
    "from": "string>0",  // vault-relative source path
    "to":   "string>0"   // vault-relative destination path
  }
}
```

Both required, both vault-root relative.

**Response on success**:

```json
{ "ok": true, "path": "<to>" }
```

**Error semantics** (all `isError: true`, descriptive text — no structured `errorCode` field, matching the existing patterns of `delete_vault_file` / `executeObsidianCommand` / `deleteVaultDirectory`):

| Condition | Surfaced text |
|---|---|
| `from === to` | `Source and destination are identical: <path>` |
| `from` does not resolve | `Source file not found: <path>` |
| `to` already exists | `Destination already exists: <path>` |
| Destination parent directory does not exist | `Destination parent directory does not exist: <parent>` |
| `app.fileManager.renameFile` rejects | `Failed to rename: <e.message>` |

The `invalid-destination` branch fails loud rather than auto-creating the parent directory, mirroring the unresolved-target bias `patch_*_file` ended up with in 0.3.7 / 0.4.0 ([#6](https://github.com/istefox/obsidian-mcp-connector/issues/6), [#58](https://github.com/istefox/obsidian-mcp-connector/issues/58)) — silent auto-create would mask caller typos in the destination path.

Authorization gate matches `delete_vault_file` / `create_vault_file` (no per-tool allowlist).

## Files

- `packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.ts` — schema + handler (ArkType, ~95 LOC including comments).
- `packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.test.ts` — 8 cases, all branches covered.
- `packages/obsidian-plugin/src/features/mcp-tools/index.ts` — import + register in the *Vault file ops* section, between `delete_vault_file` and `create_vault_directory`.
- `packages/obsidian-plugin/src/test-setup.ts` — additive mock of `app.fileManager.renameFile`. Migrates content, metadata cache, file stats, and the active-file pointer when the source matches; folder rename out of scope (handler doesn't exercise it).
- `CHANGELOG.md` — entry under `[Unreleased]` / `### Added`.
- `README.md` — bumped four counters consistently: `16 → 17 typed tools` (file-ops bullet), `26 → 27 MCP tools in total` (features summary), `26 → 27 MCP tools` (verifying-the-setup section), and the `19 → 20 tools work without LRA` cross-references in both the Architecture bullet and footnote `[^4]` (the new tool uses `app.fileManager` directly, no LRA dependency).

## Test plan

```bash
# scoped
bun test src/features/mcp-tools/tools/renameVaultFile.test.ts
# -> 8/8 pass, 0 fail, 26 expect() calls

# regression sweep on the whole tools/ directory
bun test src/features/mcp-tools/tools/
# -> 217/217 pass, 0 fail

# type checking — root
bun run check
# -> shared / mcp-server / obsidian-plugin / test-server: all 0 errors, 0 warnings

# build — packages/obsidian-plugin
bun run build
# -> Build successful
```

The 7 environmental tests in `mcp-transport/services/{port,httpServer,mcpServer}.test.ts` that bind localhost ports were excluded as usual — they flake when Obsidian is running locally with the connector active. They pass in CI and were not touched by this change.

## Design notes

- **Why `app.fileManager.renameFile` and not `app.vault.rename`**. `app.vault.rename` exists and would move the file, but it does **not** trigger the link-rewrite pass — that pass lives in `fileManager`, which is what Obsidian's own rename UI invokes. Picking the lower-level `vault.rename` would have shipped a tool that silently broke backlinks on every call, which is exactly the gap this tool is meant to close.
- **Why fail-loud on missing destination parent**. Auto-creating the ancestor chain would make typos in `to` permanent (orphan directories left behind on the next ls) and silently mask caller mistakes. The fail-loud bias of `patch_*_file` ([#6](https://github.com/istefox/obsidian-mcp-connector/issues/6), [#58](https://github.com/istefox/obsidian-mcp-connector/issues/58)) is the established precedent on the 0.4.x line. If callers want auto-create, `create_vault_directory` is one MCP call away and remains explicit.
- **Why no overwrite flag**. The triage didn't ask for one and adding it would force callers to think about a branch they likely don't want — silent overwrite of an unrelated file at the destination is high-risk for vault data. If a follow-up issue surfaces a real workflow that needs it, an `overwrite: boolean` opt-in can be added without breaking the current schema.
- **`fileManager` cast**. `App` from the public `obsidian.d.ts` does not declare `fileManager.renameFile` even though the runtime API has carried it since the early days. Cast through `unknown` at the call site, same pattern `listObsidianCommands.ts` uses for `app.commands.listCommands`.
- **Mock additive surface**. `test-setup.ts` only gained a new method on the existing `fileManager` stub plus content/metadata/stats migration logic. No existing test had to change, no shape was repurposed.

## Out of scope

- **Folder rename**. `app.fileManager.renameFile` accepts a `TFolder` and recursively rewrites links inside, but the semantics around partial failure (some children renamable, others locked) deserve their own design pass. Tracked for a separate proposal.
- **Heading rename**. Already covered by your accepted Option-A path on [#68](https://github.com/istefox/obsidian-mcp-connector/issues/68); independent tool.

Closes [#67](https://github.com/istefox/obsidian-mcp-connector/issues/67).