### PR TITLE
feat(0.4): add get_recent_files MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ## [Unreleased]
 
+### Added
+
+- **`get_recent_files` tool** — returns the most recently modified
+  markdown files in the vault, ordered by `mtime` descending. Useful
+  agent-recency context (proposed by @istefox in
+  [#69 upstream comment](https://github.com/jacksteamdev/obsidian-mcp-tools/pull/69#issuecomment-4371427847)
+  as a "smallest-wins-first" candidate; confirmed as NEXT after the
+  PR #93 merge in
+  [#93 close-out](https://github.com/istefox/obsidian-mcp-connector/pull/93#issuecomment-4418358887)).
+
+  Schema: `{ limit?: number }`. `limit` is an arktype-validated integer
+  in `[1, 100]` (default 20). Out-of-range values, zero, negatives, and
+  non-integers are rejected at schema-validation time — fail-loud, no
+  silent clamping, matching the validation bias of the rest of the
+  tool surface.
+
+  Response shape:
+  ```json
+  {
+    "totalFiles": 250,
+    "files": [
+      { "path": "Notes/today.md", "mtime": 1715432100000, "ctime": 1715000000000, "size": 1234 }
+    ]
+  }
+  ```
+  Timestamps are Unix epoch milliseconds (raw `TFile.stat.mtime` /
+  `TFile.stat.ctime`); `size` is the file's byte length. `totalFiles`
+  counts the full visible (post-exclusion) markdown set before the
+  recency slice, matching the contract of `get_files_by_tag` so callers
+  can detect whether `limit` truncated the result.
+
+  Honours Obsidian's `Files & Links → Excluded files` configuration via
+  the runtime `MetadataCache.isUserIgnored(path)` accessor. The cast
+  through `unknown` mirrors the pattern used by `list_tags` for
+  `metadataCache.getTags` (both methods exist at runtime but are not
+  surfaced by the bundled `obsidian.d.ts`). Markdown-only via
+  `vault.getMarkdownFiles()`; non-markdown files are not surfaced.
+
+  Authorization gate matches `list_tags` / `get_files_by_tag` — no
+  per-tool allowlist, no plugin dependency, read-only. Out of scope
+  (deferred for a follow-up if user demand surfaces): folder-scoped
+  filtering, sort key parameter, non-markdown surface.
+
+  Pinned by 10 cases in `getRecentFiles.test.ts` (schema name,
+  empty-vault response, mtime ordering, default limit of 20, explicit
+  limit, limit > totalFiles graceful path, full per-entry shape
+  including `size`, non-markdown filter, `isUserIgnored` exclusion, and
+  arktype boundary validation covering 0/-5/5.5/101 rejects and 1/100
+  boundary accepts). Mock surface in `test-setup.ts` extended additively
+  with `setMockIgnored(path)` + `metadataCache.isUserIgnored` (same
+  pattern that landed `setMockFileStat()` in #93 — reusable for any
+  follow-up tool that filters against the user-ignored set).
+
 ## [0.4.6] — 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Starting with **0.4.0**, the plugin hosts the MCP server **in-process inside Obs
 - **HTTP-native MCP clients** (Claude Code, Cursor, Cline, Continue, Windsurf, VS Code) connect directly to the local HTTP endpoint.
 - **Claude Desktop** (which speaks only stdio MCP) connects through the official `npx mcp-remote` bridge — a two-line config the plugin generates for you.
 - **Native semantic search** runs entirely on-device via Transformers.js + `Xenova/all-MiniLM-L6-v2` (~25 MB, downloaded once and cached). No cloud, no Smart Connections requirement.
-- **Local REST API is now optional**: only the `search_vault` tool (Dataview DQL / JsonLogic queries) needs it, and that tool returns an actionable error if it isn't installed. The other 26 tools work without it. [^4]
+- **Local REST API is now optional**: only the `search_vault` tool (Dataview DQL / JsonLogic queries) needs it, and that tool returns an actionable error if it isn't installed. The other 27 tools work without it. [^4]
 
 ## Features
 
@@ -38,9 +38,10 @@ When connected to an MCP-compatible client, this plugin enables:
 - **Web fetch** — `fetch` tool retrieves arbitrary URLs and returns Markdown via Turndown, with pagination for long pages.
 - **Tag listing** — `list_tags` returns every tag in the vault with its usage count, sourced from `app.metadataCache.getTags()`. Inline `#tags` and frontmatter tags both included; no plugin dependency.
 - **Tag-filtered file lookup** — `get_files_by_tag` returns every file tagged with a given tag, with per-file occurrence count for relevance ranking. Optional `includeNested` to match `#project` against `#project/active`, `#project/archived`, etc. (mirrors Obsidian's tag pane).
+- **Recent-file context** — `get_recent_files` returns the most recently modified markdown files in the vault (ordered by `mtime` desc, with `ctime` and `size` per entry), honouring Obsidian's `Files & Links → Excluded files` configuration. Optional `limit` (1–100, default 20, fail-loud on out-of-range). Useful for agent-recency context without screen-scraping a file picker.
 - **Graph navigation** — `get_outgoing_links` returns the body, embed, and frontmatter links emanating from a file (with resolved `targetPath` and `resolved` flag); `get_backlinks` returns every file that links to a given target, with per-source count. Both read-only, both backed by `app.metadataCache.resolvedLinks` / `getFirstLinkpathDest`.
 
-27 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
+28 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
 
 ## Prerequisites
 
@@ -134,7 +135,7 @@ Click **Copy config for streamable-http clients**. The snippet uses the generic 
 
 ### Verifying the setup
 
-Once configured, your client should expose **27 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
+Once configured, your client should expose **28 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
 
 To verify the connection works end-to-end, ask the agent to call `get_server_info`. A successful response confirms the client can reach the in-process server and the bearer token is correct. For deeper inspection (request/response logs, tool schema inspection without an LLM in the loop), use [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector):
 
@@ -397,4 +398,4 @@ See [GitHub Releases on this fork](https://github.com/istefox/obsidian-mcp-conne
 [^1]: For information about Claude data privacy and security, see [Claude AI's data usage policy](https://support.anthropic.com/en/articles/8325621-i-would-like-to-input-sensitive-data-into-free-claude-ai-or-claude-pro-who-can-view-my-conversations).
 [^2]: For more information about the Model Context Protocol, see [MCP Introduction](https://modelcontextprotocol.io/introduction).
 [^3]: For a list of available MCP Clients, see [MCP Example Clients](https://modelcontextprotocol.io/clients).
-[^4]: Local REST API was a hard requirement on the 0.3.x line. Starting with 0.4.0 it is optional and only enables the `search_vault` tool (DQL / JsonLogic queries). The other 26 tools work without it; `search_vault` returns an actionable error if it isn't installed. As of `0.4.5`, `search_vault` reads the LRA host and port from the plugin's live settings instead of a hardcoded `127.0.0.1:27124`, so reconfiguring LRA's listen port no longer requires a plugin restart.
+[^4]: Local REST API was a hard requirement on the 0.3.x line. Starting with 0.4.0 it is optional and only enables the `search_vault` tool (DQL / JsonLogic queries). The other 27 tools work without it; `search_vault` returns an actionable error if it isn't installed. As of `0.4.5`, `search_vault` reads the LRA host and port from the plugin's live settings instead of a hardcoded `127.0.0.1:27124`, so reconfiguring LRA's listen port no longer requires a plugin restart.

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -85,6 +85,10 @@ import {
   getFilesByTagSchema,
 } from "./tools/getFilesByTag";
 import {
+  getRecentFilesHandler,
+  getRecentFilesSchema,
+} from "./tools/getRecentFiles";
+import {
   getOutgoingLinksHandler,
   getOutgoingLinksSchema,
 } from "./tools/getOutgoingLinks";
@@ -179,6 +183,9 @@ export async function registerTools(
   );
   registry.register(getFilesByTagSchema, async ({ arguments: args }) =>
     getFilesByTagHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(getRecentFilesSchema, async ({ arguments: args }) =>
+    getRecentFilesHandler({ arguments: args, app: ctx.app }),
   );
 
   // Links

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { type } from "arktype";
+import {
+  getRecentFilesHandler,
+  getRecentFilesSchema,
+} from "./getRecentFiles";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockFileStat,
+  setMockIgnored,
+} from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+describe("get_recent_files tool", () => {
+  test("schema declares the tool name", () => {
+    expect(getRecentFilesSchema.get("name")?.toString()).toContain(
+      "get_recent_files",
+    );
+  });
+
+  test("returns empty result when vault has no files", async () => {
+    const r = await getRecentFilesHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data).toEqual({ totalFiles: 0, files: [] });
+  });
+
+  test("orders files by mtime descending", async () => {
+    setMockFile("old.md", "");
+    setMockFile("newest.md", "");
+    setMockFile("middle.md", "");
+    setMockFileStat("old.md", { mtime: 1000 });
+    setMockFileStat("middle.md", { mtime: 2000 });
+    setMockFileStat("newest.md", { mtime: 3000 });
+
+    const r = await getRecentFilesHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.totalFiles).toBe(3);
+    expect(data.files.map((f: { path: string }) => f.path)).toEqual([
+      "newest.md",
+      "middle.md",
+      "old.md",
+    ]);
+  });
+
+  test("default limit is 20", async () => {
+    for (let i = 0; i < 25; i++) {
+      const p = `note-${i}.md`;
+      setMockFile(p, "");
+      setMockFileStat(p, { mtime: i });
+    }
+    const r = await getRecentFilesHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    // `totalFiles` reports the full visible set, regardless of `limit`.
+    expect(data.totalFiles).toBe(25);
+    expect(data.files).toHaveLength(20);
+    // Most-recent first: indices 24, 23, …, 5.
+    expect(data.files[0].path).toBe("note-24.md");
+    expect(data.files[19].path).toBe("note-5.md");
+  });
+
+  test("respects explicit limit", async () => {
+    for (let i = 0; i < 10; i++) {
+      const p = `note-${i}.md`;
+      setMockFile(p, "");
+      setMockFileStat(p, { mtime: i });
+    }
+    const r = await getRecentFilesHandler({
+      arguments: { limit: 3 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.totalFiles).toBe(10);
+    expect(data.files).toHaveLength(3);
+    expect(data.files.map((f: { path: string }) => f.path)).toEqual([
+      "note-9.md",
+      "note-8.md",
+      "note-7.md",
+    ]);
+  });
+
+  test("limit larger than totalFiles returns all without error", async () => {
+    setMockFile("a.md", "");
+    setMockFile("b.md", "");
+    setMockFile("c.md", "");
+    setMockFileStat("a.md", { mtime: 1 });
+    setMockFileStat("b.md", { mtime: 2 });
+    setMockFileStat("c.md", { mtime: 3 });
+
+    const r = await getRecentFilesHandler({
+      arguments: { limit: 10 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.totalFiles).toBe(3);
+    expect(data.files).toHaveLength(3);
+  });
+
+  test("returns path/mtime/ctime/size per file", async () => {
+    setMockFile("doc.md", "hello world");
+    setMockFileStat("doc.md", { mtime: 5000, ctime: 1000 });
+
+    const r = await getRecentFilesHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.files).toHaveLength(1);
+    const entry = data.files[0];
+    expect(entry.path).toBe("doc.md");
+    expect(entry.mtime).toBe(5000);
+    expect(entry.ctime).toBe(1000);
+    expect(typeof entry.size).toBe("number");
+    expect(entry.size).toBeGreaterThan(0);
+  });
+
+  test("ignores non-markdown files", async () => {
+    setMockFile("note.md", "");
+    setMockFile("image.png", "");
+    setMockFileStat("note.md", { mtime: 1 });
+    setMockFileStat("image.png", { mtime: 999 });
+
+    const r = await getRecentFilesHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    // image.png is filtered out by `vault.getMarkdownFiles()` upstream,
+    // so it should not appear or count toward `totalFiles`.
+    expect(data.totalFiles).toBe(1);
+    expect(data.files).toHaveLength(1);
+    expect(data.files[0].path).toBe("note.md");
+  });
+
+  test("respects Obsidian's excluded files setting", async () => {
+    setMockFile("kept.md", "");
+    setMockFile("excluded/secret.md", "");
+    setMockFileStat("kept.md", { mtime: 1 });
+    setMockFileStat("excluded/secret.md", { mtime: 999 });
+    // Match-by-exact-path mirrors how the mock backs `isUserIgnored`.
+    // The production runtime resolves globs/regex from the user's
+    // `Files & Links → Excluded files` setting to the same per-path
+    // boolean, so the handler contract is identical.
+    setMockIgnored("excluded/secret.md");
+
+    const r = await getRecentFilesHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    // The excluded file MUST NOT appear in `files` and MUST NOT count
+    // toward `totalFiles` — exclusion is applied before the recency
+    // slice, not after.
+    expect(data.totalFiles).toBe(1);
+    expect(data.files).toHaveLength(1);
+    expect(data.files[0].path).toBe("kept.md");
+  });
+
+  test("schema rejects invalid limit values", () => {
+    // arktype-level validation: 0, negatives, floats, and >100 all
+    // bounce before reaching the handler. The MCP transport surfaces
+    // schema rejections to the client as validation errors; pinning the
+    // contract here keeps the boundary observable at the tool level.
+    //
+    // arktype returns an `ArkErrors` instance (array-like) on failure
+    // and the parsed value on success — `instanceof type.errors` is the
+    // canonical predicate.
+    const validate = (limit: unknown) =>
+      getRecentFilesSchema({
+        name: "get_recent_files",
+        arguments: { limit },
+      });
+
+    expect(validate(0) instanceof type.errors).toBe(true);
+    expect(validate(-5) instanceof type.errors).toBe(true);
+    expect(validate(5.5) instanceof type.errors).toBe(true);
+    expect(validate(101) instanceof type.errors).toBe(true);
+
+    // Boundary values pass.
+    expect(validate(1) instanceof type.errors).toBe(false);
+    expect(validate(100) instanceof type.errors).toBe(false);
+
+    // Omitted `limit` is valid (handler applies the default of 20).
+    expect(
+      getRecentFilesSchema({
+        name: "get_recent_files",
+        arguments: {},
+      }) instanceof type.errors,
+    ).toBe(false);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
@@ -1,0 +1,62 @@
+import { type } from "arktype";
+import type { App, TFile } from "obsidian";
+
+export const getRecentFilesSchema = type({
+  name: '"get_recent_files"',
+  arguments: {
+    "limit?": type("1<=number.integer<=100").describe(
+      "Maximum number of files to return (1-100, default 20). Values outside this range, zero, negative, or non-integer numbers are rejected at schema validation.",
+    ),
+  },
+}).describe(
+  "Returns the most recently modified markdown files in the vault, ordered by `mtime` descending. Each entry includes `path`, `mtime`, `ctime` (Unix epoch milliseconds), and `size` (bytes). Honours Obsidian's `Files & Links → Excluded files` configuration via `MetadataCache.isUserIgnored`; markdown-only via `vault.getMarkdownFiles()`. Useful for agent-recency context. Always read-only.",
+);
+
+export type GetRecentFilesContext = {
+  arguments: { limit?: number };
+  app: App;
+};
+
+export async function getRecentFilesHandler(
+  ctx: GetRecentFilesContext,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  const limit = ctx.arguments.limit ?? 20;
+
+  // `MetadataCache.isUserIgnored(path)` is part of Obsidian's runtime API
+  // but is not surfaced by the bundled `obsidian.d.ts`. The cast through
+  // `unknown` keeps us aligned with the codebase pattern used for other
+  // metadata-cache accessors (see listTags.ts:30). Treated as optional so
+  // tests that do not stub it keep working.
+  const isUserIgnored = (
+    ctx.app.metadataCache as unknown as {
+      isUserIgnored?: (path: string) => boolean;
+    }
+  ).isUserIgnored?.bind(ctx.app.metadataCache);
+
+  const allMarkdown = ctx.app.vault.getMarkdownFiles();
+  const visible = isUserIgnored
+    ? allMarkdown.filter((f: TFile) => !isUserIgnored(f.path))
+    : allMarkdown;
+
+  // `totalFiles` reports the size of the visible (post-exclusion) set,
+  // before the recency slice. Matches the contract of `get_files_by_tag`
+  // where `totalFiles` is the total match count, not the page size.
+  const totalFiles = visible.length;
+
+  const files = visible
+    .slice()
+    .sort((a, b) => b.stat.mtime - a.stat.mtime)
+    .slice(0, limit)
+    .map((f) => ({
+      path: f.path,
+      mtime: f.stat.mtime,
+      ctime: f.stat.ctime,
+      size: f.stat.size,
+    }));
+
+  const output = { totalFiles, files };
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(output, null, 2) }],
+  };
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -102,6 +102,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "get_backlinks",
         "get_files_by_tag",
         "get_outgoing_links",
+        "get_recent_files",
         "get_server_info",
         "get_vault_file",
         "list_obsidian_commands",
@@ -116,7 +117,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "show_file_in_obsidian",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(27);
+      expect(names).toHaveLength(28);
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -279,6 +279,11 @@ type MockVaultState = {
   // a path is absent so existing tests keep observing 0/0 — only tests
   // that need recency ordering (`get_recent_files` etc.) populate this.
   fileStats: Map<string, { ctime: number; mtime: number }>;
+  // Paths returned as `true` by `MetadataCache.isUserIgnored`. Mirrors
+  // Obsidian's `Files & Links → Excluded files` runtime behaviour without
+  // depending on the glob/regex compilation path. Empty by default so
+  // tests that don't exercise exclusion keep observing the full vault.
+  ignored: Set<string>;
 };
 
 // Synthetic absolute filesystem prefix used by the mock `adapter.rmdir`
@@ -301,6 +306,7 @@ const _mockState: MockVaultState = {
   unresolvedLinks: {},
   requestUrlResponses: new Map(),
   fileStats: new Map(),
+  ignored: new Set(),
 };
 
 export function resetMockVault(): void {
@@ -321,6 +327,7 @@ export function resetMockVault(): void {
   }
   _mockState.requestUrlResponses.clear();
   _mockState.fileStats.clear();
+  _mockState.ignored.clear();
 }
 
 export function setMockFile(path: string, content: string): void {
@@ -349,6 +356,17 @@ export function setMockFileStat(
     ctime: stat.ctime ?? 0,
     mtime: stat.mtime ?? 0,
   });
+}
+
+/**
+ * Mark a vault path as user-ignored, mirroring Obsidian's
+ * `Files & Links → Excluded files` runtime setting. Reflected by
+ * `app.metadataCache.isUserIgnored(path)` returning `true` for any
+ * registered path. Used by tools that filter against the exclusion set
+ * (`get_recent_files`, etc.).
+ */
+export function setMockIgnored(path: string): void {
+  _mockState.ignored.add(path);
 }
 
 /**
@@ -709,6 +727,9 @@ export function mockApp(): App {
       return _mockState.metadataCache.get(path) ?? null;
     },
     getTags: (): Record<string, number> => ({ ..._mockState.tags }),
+    // Mirrors Obsidian's runtime `MetadataCache.isUserIgnored` (not in
+    // the bundled `obsidian.d.ts`). Backed by `setMockIgnored()`.
+    isUserIgnored: (path: string): boolean => _mockState.ignored.has(path),
     // Live references — `resetMockVault()` mutates these in place so
     // the bindings stay valid across tests without re-creating the App.
     get resolvedLinks(): Record<string, Record<string, number>> {


### PR DESCRIPTION
## Summary

Adds `get_recent_files`, a read-only MCP tool returning the most recently modified markdown files in the vault, ordered by `mtime` descending. Each entry exposes `path`, `mtime`, `ctime` (Unix epoch ms), and `size` (bytes). Useful agent-recency context without screen-scraping a file picker.

Proposed by @istefox in the [#69 upstream inventory comment](https://github.com/jacksteamdev/obsidian-mcp-tools/pull/69#issuecomment-4371427847) as a "smallest-wins-first" candidate, and confirmed as NEXT after the PR #93 merge in the [#93 close-out comment](https://github.com/istefox/obsidian-mcp-connector/pull/93#issuecomment-4418358887).

## Design

- **Schema (arktype)**: `{ limit?: number }`. `limit` is an integer in `[1, 100]`, default 20. Out-of-range, zero, negatives, and floats are rejected at schema-validation time — fail-loud, no silent clamping, matching the validation bias of the rest of the tool surface.
- **Response**:
  ```json
  {
    "totalFiles": 250,
    "files": [
      { "path": "Notes/today.md", "mtime": 1715432100000, "ctime": 1715000000000, "size": 1234 }
    ]
  }
  ```
  `totalFiles` counts the full visible (post-exclusion) markdown set before the recency slice — matches the contract of `get_files_by_tag` so callers can detect `limit` truncation.
- **Timestamps** are raw epoch milliseconds (`TFile.stat.mtime` / `TFile.stat.ctime`); `size` is the file's byte length.
- **Excluded files**: honours Obsidian's `Files & Links → Excluded files` configuration via the runtime `MetadataCache.isUserIgnored(path)` accessor. The cast through `unknown` mirrors the pattern `list_tags` uses for `metadataCache.getTags` (both methods exist at runtime but are not surfaced by the bundled `obsidian.d.ts`).
- **Markdown-only** via `vault.getMarkdownFiles()`; non-markdown files are not surfaced.
- **Authorization**: matches `list_tags` / `get_files_by_tag` — no per-tool allowlist, no plugin dependency, read-only.

## Out of scope

Deferred for a follow-up if user demand surfaces:

- Folder-scoped filtering (`path` parameter).
- Sort key parameter (`ctime` vs `mtime`).
- Non-markdown surface.

## Counters / regression-guard

- Tools **27 → 28**.
- `mcpServer.test.ts` `tools/list exposes the full registry` updated: `get_recent_files` inserted in the alphabetical slot between `get_outgoing_links` and `get_server_info`, `toHaveLength(27)` → `(28)`.
- README counter reconciliation across 4 locations (lines 26, 43, 138, 401: 26→27 / 27→28). The `17 typed tools` figure on line 32 is unchanged because this tool is metadata, not vault-write.

## Mock-infra extension

`test-setup.ts` extended additively with `setMockIgnored(path)` + `metadataCache.isUserIgnored` — same pattern that landed `setMockFileStat()` in #93, reusable for any follow-up tool that filters against the user-ignored set.

## Test plan

10 cases in `getRecentFiles.test.ts`:

- [x] Schema declares the tool name.
- [x] Empty vault → `{ totalFiles: 0, files: [] }`.
- [x] Orders files by `mtime` descending.
- [x] Default limit is 20 (`totalFiles` still reports full set).
- [x] Respects explicit `limit`.
- [x] `limit > totalFiles` returns all files without error.
- [x] Returns `path`, `mtime`, `ctime`, `size` per file.
- [x] Ignores non-markdown files.
- [x] Respects Obsidian's excluded-files configuration (filtered both from `files` and `totalFiles`).
- [x] Schema rejects invalid limit values (0, -5, 5.5, 101) and accepts boundaries (1, 100) + omitted (`limit?`).

Local validation: `bun test` (sans `port.test.ts` / `httpServer.test.ts`, blocked by an open Obsidian instance) → 760/760 pass. `bun run check` (typecheck across the monorepo) → clean. `bun run build` → success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)