### PR TITLE
feat(0.4): get_recent_files review follow-ups (LOW1/LOW2/LOW3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 ### Added
 
 - **`get_recent_files` tool** — returns the most recently modified
-  markdown files in the vault, ordered by `mtime` descending. Useful
+  markdown files in the vault, ordered by `mtime` descending with a
+  `path` ascending tiebreaker on equal `mtime` (so repeat calls return
+  deterministic order on bulk-import / sync-event ties). Useful
   agent-recency context (proposed by @istefox in
   [#69 upstream comment](https://github.com/jacksteamdev/obsidian-mcp-tools/pull/69#issuecomment-4371427847)
   as a "smallest-wins-first" candidate; confirmed as NEXT after the
   PR #93 merge in
-  [#93 close-out](https://github.com/istefox/obsidian-mcp-connector/pull/93#issuecomment-4418358887)).
+  [#93 close-out](https://github.com/istefox/obsidian-mcp-connector/pull/93#issuecomment-4418358887);
+  shipped in PR #94; review follow-ups (LOW1/LOW2/LOW3 from
+  [#94 close-out](https://github.com/istefox/obsidian-mcp-connector/pull/94))
+  landed in the same `[Unreleased]` block).
 
   Schema: `{ limit?: number }`. `limit` is an arktype-validated integer
   in `[1, 100]` (default 20). Out-of-range values, zero, negatives, and
@@ -40,23 +45,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
   the runtime `MetadataCache.isUserIgnored(path)` accessor. The cast
   through `unknown` mirrors the pattern used by `list_tags` for
   `metadataCache.getTags` (both methods exist at runtime but are not
-  surfaced by the bundled `obsidian.d.ts`). Markdown-only via
-  `vault.getMarkdownFiles()`; non-markdown files are not surfaced.
+  surfaced by the bundled `obsidian.d.ts`). If the accessor is
+  unavailable (future Obsidian rename / removal), the handler degrades
+  gracefully to "no exclusion applied" and emits a one-shot
+  `logger.warn` so the regression is observable in the plugin log
+  instead of silently surfacing user-ignored entries. Markdown-only
+  via `vault.getMarkdownFiles()`; non-markdown files are not surfaced.
 
   Authorization gate matches `list_tags` / `get_files_by_tag` — no
   per-tool allowlist, no plugin dependency, read-only. Out of scope
   (deferred for a follow-up if user demand surfaces): folder-scoped
   filtering, sort key parameter, non-markdown surface.
 
-  Pinned by 10 cases in `getRecentFiles.test.ts` (schema name,
-  empty-vault response, mtime ordering, default limit of 20, explicit
-  limit, limit > totalFiles graceful path, full per-entry shape
-  including `size`, non-markdown filter, `isUserIgnored` exclusion, and
-  arktype boundary validation covering 0/-5/5.5/101 rejects and 1/100
-  boundary accepts). Mock surface in `test-setup.ts` extended additively
-  with `setMockIgnored(path)` + `metadataCache.isUserIgnored` (same
-  pattern that landed `setMockFileStat()` in #93 — reusable for any
-  follow-up tool that filters against the user-ignored set).
+  Pinned by 12 cases in `getRecentFiles.test.ts` (schema name,
+  empty-vault response, mtime ordering, equal-mtime path-ascending
+  tiebreaker, default limit of 20, explicit limit, limit > totalFiles
+  graceful path, full per-entry shape including `size`, non-markdown
+  filter, graceful degradation when `isUserIgnored` is absent,
+  `isUserIgnored` exclusion when present, and arktype boundary
+  validation covering 0 / -5 / 5.5 / 101 rejects and 1 / 100 boundary
+  accepts). Mock surface in `test-setup.ts` extended additively with
+  `setMockIgnored(path)` + `metadataCache.isUserIgnored` (same pattern
+  that landed `setMockFileStat()` in #93 — reusable for any follow-up
+  tool that filters against the user-ignored set).
 
 ## [0.4.6] — 2026-05-11
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -300,7 +299,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.5", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/codemirror": ["@types/codemirror@5.60.8", "", { "dependencies": { "@types/tern": "*" } }, "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw=="],
 
@@ -450,7 +449,7 @@
 
     "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import { type } from "arktype";
 import {
+  _resetMissingIsUserIgnoredWarning,
   getRecentFilesHandler,
   getRecentFilesSchema,
 } from "./getRecentFiles";
@@ -12,7 +13,12 @@ import {
   setMockIgnored,
 } from "$/test-setup";
 
-beforeEach(() => resetMockVault());
+beforeEach(() => {
+  resetMockVault();
+  // The one-shot warning flag in `getRecentFiles.ts` persists at module
+  // scope across tests; reset it so each test exercises a clean state.
+  _resetMissingIsUserIgnoredWarning();
+});
 
 describe("get_recent_files tool", () => {
   test("schema declares the tool name", () => {
@@ -42,6 +48,31 @@ describe("get_recent_files tool", () => {
       "newest.md",
       "middle.md",
       "old.md",
+    ]);
+  });
+
+  test("applies a path-ascending tiebreaker on equal mtimes", async () => {
+    // Three files share the same `mtime` (common on bulk imports /
+    // sync events). The response contract pins `path` ascending as
+    // the secondary key so repeat calls return deterministic order
+    // regardless of the underlying `vault.getMarkdownFiles()`
+    // iteration order, which is undocumented.
+    setMockFile("zebra.md", "");
+    setMockFile("apple.md", "");
+    setMockFile("mango.md", "");
+    setMockFile("recent.md", "");
+    setMockFileStat("zebra.md", { mtime: 1000 });
+    setMockFileStat("apple.md", { mtime: 1000 });
+    setMockFileStat("mango.md", { mtime: 1000 });
+    setMockFileStat("recent.md", { mtime: 9999 });
+
+    const r = await getRecentFilesHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.files.map((f: { path: string }) => f.path)).toEqual([
+      "recent.md",
+      "apple.md",
+      "mango.md",
+      "zebra.md",
     ]);
   });
 
@@ -126,6 +157,32 @@ describe("get_recent_files tool", () => {
     expect(data.totalFiles).toBe(1);
     expect(data.files).toHaveLength(1);
     expect(data.files[0].path).toBe("note.md");
+  });
+
+  test("gracefully degrades when isUserIgnored is unavailable", async () => {
+    // If a future Obsidian release renames or drops the runtime
+    // `MetadataCache.isUserIgnored` accessor, the handler must NOT
+    // throw — it falls back to "no exclusion applied" and emits a
+    // one-shot warning to the plugin log. Verified here by stripping
+    // the accessor from a fresh mockApp().
+    setMockFile("a.md", "");
+    setMockFile("b.md", "");
+    setMockFileStat("a.md", { mtime: 1 });
+    setMockFileStat("b.md", { mtime: 2 });
+
+    const app = mockApp();
+    delete (
+      app.metadataCache as unknown as { isUserIgnored?: unknown }
+    ).isUserIgnored;
+
+    const r = await getRecentFilesHandler({ arguments: {}, app });
+    const data = JSON.parse(r.content[0].text as string);
+    // Without the exclusion accessor, all visible markdown files flow
+    // through unfiltered.
+    expect(data.totalFiles).toBe(2);
+    expect(data.files).toHaveLength(2);
+    expect(data.files[0].path).toBe("b.md");
+    expect(data.files[1].path).toBe("a.md");
   });
 
   test("respects Obsidian's excluded files setting", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype";
 import type { App, TFile } from "obsidian";
+import { logger } from "$/shared/logger";
 
 export const getRecentFilesSchema = type({
   name: '"get_recent_files"',
@@ -9,13 +10,27 @@ export const getRecentFilesSchema = type({
     ),
   },
 }).describe(
-  "Returns the most recently modified markdown files in the vault, ordered by `mtime` descending. Each entry includes `path`, `mtime`, `ctime` (Unix epoch milliseconds), and `size` (bytes). Honours Obsidian's `Files & Links → Excluded files` configuration via `MetadataCache.isUserIgnored`; markdown-only via `vault.getMarkdownFiles()`. Useful for agent-recency context. Always read-only.",
+  "Returns the most recently modified markdown files in the vault, ordered by `mtime` descending with a `path` ascending tiebreaker on equal `mtime`. Each entry includes `path`, `mtime`, `ctime` (Unix epoch milliseconds), and `size` (bytes). Honours Obsidian's `Files & Links → Excluded files` configuration via `MetadataCache.isUserIgnored`; markdown-only via `vault.getMarkdownFiles()`. Useful for agent-recency context. Always read-only.",
 );
 
 export type GetRecentFilesContext = {
   arguments: { limit?: number };
   app: App;
 };
+
+// Module-scope flag for the one-shot warning when Obsidian's runtime
+// `isUserIgnored` accessor cannot be found. If the API ever gets
+// renamed or removed in a future Obsidian release, this surfaces the
+// regression in the plugin log on first call (rather than silently
+// returning user-ignored entries in `files` and `totalFiles`). Reset
+// helper is exported for tests; production callers should not touch
+// it.
+let _warnedMissingIsUserIgnored = false;
+
+/** @internal — test-only reset of the one-shot warning flag. */
+export function _resetMissingIsUserIgnoredWarning(): void {
+  _warnedMissingIsUserIgnored = false;
+}
 
 export async function getRecentFilesHandler(
   ctx: GetRecentFilesContext,
@@ -33,6 +48,17 @@ export async function getRecentFilesHandler(
     }
   ).isUserIgnored?.bind(ctx.app.metadataCache);
 
+  if (!isUserIgnored && !_warnedMissingIsUserIgnored) {
+    _warnedMissingIsUserIgnored = true;
+    // One-shot per process. If Obsidian renames or drops the runtime
+    // accessor, the filter degrades to "no exclusion applied" — this
+    // warn makes the regression observable in the log instead of
+    // silently surfacing user-ignored entries to the agent.
+    logger.warn(
+      "get_recent_files: app.metadataCache.isUserIgnored is unavailable — `Files & Links → Excluded files` filtering disabled for this session. If you see this in production, the Obsidian runtime API may have changed.",
+    );
+  }
+
   const allMarkdown = ctx.app.vault.getMarkdownFiles();
   const visible = isUserIgnored
     ? allMarkdown.filter((f: TFile) => !isUserIgnored(f.path))
@@ -43,9 +69,26 @@ export async function getRecentFilesHandler(
   // where `totalFiles` is the total match count, not the page size.
   const totalFiles = visible.length;
 
+  // Pinned locale + sensitivity for cross-platform deterministic order
+  // on the tiebreaker (matches the contract used by `list_tags` /
+  // `get_files_by_tag`). Without this, the default `Intl.Collator`
+  // reads the OS locale, which can shift Unicode ordering between
+  // macOS / Linux / Windows test runs.
+  const comparePath = (a: string, b: string): number =>
+    a.localeCompare(b, "en", { sensitivity: "variant" });
+
   const files = visible
     .slice()
-    .sort((a, b) => b.stat.mtime - a.stat.mtime)
+    .sort((a, b) => {
+      // Primary: mtime descending (most-recent first).
+      if (b.stat.mtime !== a.stat.mtime) return b.stat.mtime - a.stat.mtime;
+      // Secondary: path ascending. `Array.prototype.sort` stability is
+      // guaranteed by ES2019 (V8 / Bun honour it) but the response
+      // contract should not rely on that — an explicit tiebreaker keeps
+      // the API deterministic across repeat calls when several files
+      // share an `mtime` (common on bulk imports / sync events).
+      return comparePath(a.path, b.path);
+    })
     .slice(0, limit)
     .map((f) => ({
       path: f.path,


### PR DESCRIPTION
## Summary

Addresses the three non-blocking notes from your PR #94 close-out review ([approved + merged 2026-05-13T08:07:51Z](https://github.com/istefox/obsidian-mcp-connector/pull/94#pullrequestreview-3104970000)). All three were flagged "LOW, fix-forward if/when load-bearing"; bundling them as a single follow-up while the design context is fresh keeps the `[Unreleased]` block coherent ahead of the next cut release.

## Changes

### LOW1 — Tiebreaker on equal `mtime`

Response contract now pins a secondary sort key: `path` ascending, with `Intl.Collator("en", { sensitivity: "variant" })` matching the locale convention used by `list_tags` / `get_files_by_tag`. Repeat calls return deterministic order on bulk-import / sync-event ties.

```ts
.sort((a, b) => {
  if (b.stat.mtime !== a.stat.mtime) return b.stat.mtime - a.stat.mtime;
  return comparePath(a.path, b.path);
})
```

`Array.prototype.sort` stability (ES2019+) was sufficient for V8 / Bun in practice, but the explicit tiebreaker keeps the contract independent of that guarantee — and decouples the API from the undocumented `vault.getMarkdownFiles()` iteration order.

### LOW2 — One-shot `logger.warn` when `isUserIgnored` is unavailable

The handler still degrades gracefully (no exclusion applied) but now emits a one-shot `logger.warn` on the optional-fallthrough path. Surfaces the regression in the plugin log instead of silently returning user-ignored entries if Obsidian ever renames / removes the runtime accessor.

```ts
if (!isUserIgnored && !_warnedMissingIsUserIgnored) {
  _warnedMissingIsUserIgnored = true;
  logger.warn("get_recent_files: app.metadataCache.isUserIgnored is unavailable — …");
}
```

Module-scope flag keeps the warn to once per process. `_resetMissingIsUserIgnoredWarning()` helper exported for test reset only (underscore prefix marking internal-use).

### LOW3 — Test gap: equal-`mtime` tiebreaker

Added two test cases — suite now **12 tests** (up from 10 in #94):

1. `applies a path-ascending tiebreaker on equal mtimes` — four files, three sharing `mtime=1000` and one with `mtime=9999`; asserts recent-first, then ascending `path` order (apple → mango → zebra).
2. `gracefully degrades when isUserIgnored is unavailable` — strips the accessor from a fresh `mockApp()`; asserts the handler does not throw and returns all visible files unfiltered.

Mock surface unchanged. The present-accessor path stays covered by the existing `setMockIgnored` test; the absent-accessor path is exercised by deleting the property directly on the mock instance.

## CHANGELOG handling

`[Unreleased]` entry for `get_recent_files` edited in place (rather than appending a second sub-entry) to reflect the final contract that ships at the next cut. Consistent with the patch-in-`[Unreleased]` precedent from #91 follow-ups in 0.4.6.

## Test plan

- [x] `bun test src/features/mcp-tools/tools/getRecentFiles.test.ts` → **12/12 pass**.
- [x] `bun test` sans `port.test.ts` / `httpServer.test.ts` (blocked by an open Obsidian instance) → **762/762 pass** (up from 760 in #94, +2 new cases).
- [x] `bun run check` (typecheck across the monorepo) → clean.
- [x] `bun run build` → success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)