### PR TITLE
feat(0.4): add get_vault_file_partial MCP tool (in-process)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ### Added
 
+- **`get_vault_file_partial` tool** — partial-read access to a vault
+  file via four modes operating on Obsidian's already-cached metadata
+  (`MetadataCache`) and `vault.cachedRead`. No Local REST API
+  required. Useful for context-window economics on large notes
+  (e.g. spot-check a frontmatter field on a 30 KB file without
+  loading the body).
+
+  Originated as RFC [#77](https://github.com/istefox/obsidian-mcp-connector/issues/77)
+  from @folotp (2026-05-04 upstream), originally triaged as a LRA
+  passthrough wrapper. Re-anchored in-process per bilateral lockin
+  between @istefox and @folotp on 2026-05-13 (issue #77
+  [comment 4440557399](https://github.com/istefox/obsidian-mcp-connector/issues/77#issuecomment-4440557399) /
+  [4440927656](https://github.com/istefox/obsidian-mcp-connector/issues/77#issuecomment-4440927656) /
+  [4440988763](https://github.com/istefox/obsidian-mcp-connector/issues/77#issuecomment-4440988763)),
+  aligning the tool with the 0.4.x "LRA-optional" stance — bumping
+  the "works without LRA" count from 27 to **28** of 29 tools.
+
+  Schema: `{ filename, mode, target?, targetDelimiter? }` (Option A
+  verbatim from the RFC).
+
+  - **`mode: "frontmatter"`** — returns a single frontmatter field
+    value (scalar / array / nested object), serialised as JSON.
+    Zero file I/O (cache-only). Requires `target`.
+  - **`mode: "document-map"`** — returns the file outline:
+    `{ path, frontmatter: [keys], headings: [{heading, level, line}],
+    blocks: [ids] }`. Zero file I/O (cache-only). `target` ignored.
+  - **`mode: "heading"`** — returns the markdown section under the
+    target heading, from the heading line (inclusive) to before the
+    next same-or-higher-level heading (exclusive) or EOF. Nested
+    paths via `targetDelimiter` (default `"::"`, e.g.
+    `"Parent::Child::Grandchild"`). Ambiguous targets
+    (multiple matches at the same depth) fail loud with `isError:
+    true`. Requires `target`.
+  - **`mode: "block"`** — returns the markdown range of the block
+    reference identified by `target` (with or without the leading
+    `^`). Requires `target`.
+
+  All four modes fail loud with `isError: true` and a descriptive
+  message on missing target, missing field/heading/block, ambiguous
+  heading, frontmatter-less file (frontmatter mode), or
+  filename-not-resolved. Schema validates the `mode` to the four-value
+  union at arktype layer; out-of-range modes never reach the handler.
+
+  Authorisation gate matches `list_tags` / `get_files_by_tag` /
+  `get_recent_files` — no per-tool allowlist, no plugin dependency,
+  read-only. Out of scope (deferred if surfaced): folder-scoped
+  filtering, regex-match on heading text, case-insensitive heading
+  match, multi-target batch.
+
+  Pinned by 24 cases in `getVaultFilePartial.test.ts` following the
+  priority order adopted in the #77 close-out (PRIMARY depth for
+  `frontmatter` + `document-map` since they are the zero-I/O
+  cache-only paths consumers reach for most heavily; SECONDARY
+  positive + missing + ambiguous coverage for `heading` + `block`).
+  Mock surface untouched — the existing `setMockMetadata()` helper
+  covers headings, blocks, and frontmatter shapes shipped from PR #87.
+
 - **`get_recent_files` tool** — returns the most recently modified
   markdown files in the vault, ordered by `mtime` descending with a
   `path` ascending tiebreaker on equal `mtime` (so repeat calls return

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Starting with **0.4.0**, the plugin hosts the MCP server **in-process inside Obs
 - **HTTP-native MCP clients** (Claude Code, Cursor, Cline, Continue, Windsurf, VS Code) connect directly to the local HTTP endpoint.
 - **Claude Desktop** (which speaks only stdio MCP) connects through the official `npx mcp-remote` bridge — a two-line config the plugin generates for you.
 - **Native semantic search** runs entirely on-device via Transformers.js + `Xenova/all-MiniLM-L6-v2` (~25 MB, downloaded once and cached). No cloud, no Smart Connections requirement.
-- **Local REST API is now optional**: only the `search_vault` tool (Dataview DQL / JsonLogic queries) needs it, and that tool returns an actionable error if it isn't installed. The other 27 tools work without it. [^4]
+- **Local REST API is now optional**: only the `search_vault` tool (Dataview DQL / JsonLogic queries) needs it, and that tool returns an actionable error if it isn't installed. The other 28 tools work without it. [^4]
 
 ## Features
 
@@ -39,9 +39,10 @@ When connected to an MCP-compatible client, this plugin enables:
 - **Tag listing** — `list_tags` returns every tag in the vault with its usage count, sourced from `app.metadataCache.getTags()`. Inline `#tags` and frontmatter tags both included; no plugin dependency.
 - **Tag-filtered file lookup** — `get_files_by_tag` returns every file tagged with a given tag, with per-file occurrence count for relevance ranking. Optional `includeNested` to match `#project` against `#project/active`, `#project/archived`, etc. (mirrors Obsidian's tag pane).
 - **Recent-file context** — `get_recent_files` returns the most recently modified markdown files in the vault (ordered by `mtime` desc, with `ctime` and `size` per entry), honouring Obsidian's `Files & Links → Excluded files` configuration. Optional `limit` (1–100, default 20, fail-loud on out-of-range). Useful for agent-recency context without screen-scraping a file picker.
+- **Partial-read access** — `get_vault_file_partial` returns one of four slices of a file without loading the whole body: a single `frontmatter` field, the markdown section under a `heading` (nested paths via `targetDelimiter`, default `"::"`), the markdown range of a `block` reference, or a structured `document-map` outline (heading list + block-id list + frontmatter-field list, zero file I/O). Useful for context-window economics on large notes — spot-check a frontmatter field or grab a single section without paying for the full read.
 - **Graph navigation** — `get_outgoing_links` returns the body, embed, and frontmatter links emanating from a file (with resolved `targetPath` and `resolved` flag); `get_backlinks` returns every file that links to a given target, with per-source count. Both read-only, both backed by `app.metadataCache.resolvedLinks` / `getFirstLinkpathDest`.
 
-28 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
+29 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
 
 ## Prerequisites
 
@@ -135,7 +136,7 @@ Click **Copy config for streamable-http clients**. The snippet uses the generic 
 
 ### Verifying the setup
 
-Once configured, your client should expose **28 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
+Once configured, your client should expose **29 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
 
 To verify the connection works end-to-end, ask the agent to call `get_server_info`. A successful response confirms the client can reach the in-process server and the bearer token is correct. For deeper inspection (request/response logs, tool schema inspection without an LLM in the loop), use [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector):
 
@@ -398,4 +399,4 @@ See [GitHub Releases on this fork](https://github.com/istefox/obsidian-mcp-conne
 [^1]: For information about Claude data privacy and security, see [Claude AI's data usage policy](https://support.anthropic.com/en/articles/8325621-i-would-like-to-input-sensitive-data-into-free-claude-ai-or-claude-pro-who-can-view-my-conversations).
 [^2]: For more information about the Model Context Protocol, see [MCP Introduction](https://modelcontextprotocol.io/introduction).
 [^3]: For a list of available MCP Clients, see [MCP Example Clients](https://modelcontextprotocol.io/clients).
-[^4]: Local REST API was a hard requirement on the 0.3.x line. Starting with 0.4.0 it is optional and only enables the `search_vault` tool (DQL / JsonLogic queries). The other 27 tools work without it; `search_vault` returns an actionable error if it isn't installed. As of `0.4.5`, `search_vault` reads the LRA host and port from the plugin's live settings instead of a hardcoded `127.0.0.1:27124`, so reconfiguring LRA's listen port no longer requires a plugin restart.
+[^4]: Local REST API was a hard requirement on the 0.3.x line. Starting with 0.4.0 it is optional and only enables the `search_vault` tool (DQL / JsonLogic queries). The other 28 tools work without it; `search_vault` returns an actionable error if it isn't installed. As of `0.4.5`, `search_vault` reads the LRA host and port from the plugin's live settings instead of a hardcoded `127.0.0.1:27124`, so reconfiguring LRA's listen port no longer requires a plugin restart.

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -89,6 +89,10 @@ import {
   getRecentFilesSchema,
 } from "./tools/getRecentFiles";
 import {
+  getVaultFilePartialHandler,
+  getVaultFilePartialSchema,
+} from "./tools/getVaultFilePartial";
+import {
   getOutgoingLinksHandler,
   getOutgoingLinksSchema,
 } from "./tools/getOutgoingLinks";
@@ -186,6 +190,9 @@ export async function registerTools(
   );
   registry.register(getRecentFilesSchema, async ({ arguments: args }) =>
     getRecentFilesHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(getVaultFilePartialSchema, async ({ arguments: args }) =>
+    getVaultFilePartialHandler({ arguments: args, app: ctx.app }),
   );
 
   // Links

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  getVaultFilePartialHandler,
+  getVaultFilePartialSchema,
+} from "./getVaultFilePartial";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockMetadata,
+} from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+describe("get_vault_file_partial tool", () => {
+  // ── Common ────────────────────────────────────────────────────────────────
+
+  test("schema declares the tool name", () => {
+    expect(getVaultFilePartialSchema.get("name")?.toString()).toContain(
+      "get_vault_file_partial",
+    );
+  });
+
+  test("returns isError when filename does not resolve", async () => {
+    const r = await getVaultFilePartialHandler({
+      arguments: { filename: "missing.md", mode: "frontmatter", target: "x" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain("File not found");
+  });
+
+  test("rejects missing target for non-document-map modes", async () => {
+    setMockFile("note.md", "");
+    // Empty target on `frontmatter` → handler returns isError before touching
+    // the cache. Same applies to `heading` / `block`. document-map ignores
+    // `target` (tested separately below).
+    for (const mode of ["frontmatter", "heading", "block"] as const) {
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "note.md", mode },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain("Missing required `target`");
+    }
+  });
+
+  test("targetDelimiter override is respected on heading mode", async () => {
+    setMockFile(
+      "doc.md",
+      "# Parent\nfoo\n## Child\nbar\n## Other\nbaz",
+    );
+    setMockMetadata("doc.md", {
+      headings: [
+        { heading: "Parent", level: 1, line: 0 },
+        { heading: "Child", level: 2, line: 2 },
+        { heading: "Other", level: 2, line: 4 },
+      ],
+    });
+    const r = await getVaultFilePartialHandler({
+      arguments: {
+        filename: "doc.md",
+        mode: "heading",
+        target: "Parent>>Child",
+        targetDelimiter: ">>",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    expect(r.content[0].text).toBe("## Child\nbar");
+  });
+
+  // ── Primary: frontmatter (6 cases) ────────────────────────────────────────
+
+  describe("mode: frontmatter (PRIMARY depth)", () => {
+    test("returns a scalar frontmatter value", async () => {
+      setMockFile("note.md", "");
+      setMockMetadata("note.md", { frontmatter: { status: "open" } });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "note.md", mode: "frontmatter", target: "status" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBeUndefined();
+      expect(JSON.parse(r.content[0].text)).toBe("open");
+    });
+
+    test("returns isError when target field is missing", async () => {
+      setMockFile("note.md", "");
+      setMockMetadata("note.md", { frontmatter: { other: "x" } });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "note.md", mode: "frontmatter", target: "status" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain("Frontmatter field not found");
+      expect(r.content[0].text).toContain('"status"');
+    });
+
+    test("returns isError when file has no frontmatter at all", async () => {
+      setMockFile("note.md", "body only");
+      // No setMockMetadata call → frontmatter is undefined / empty.
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "note.md", mode: "frontmatter", target: "any" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain("File has no frontmatter");
+    });
+
+    test("supports special-character keys", async () => {
+      setMockFile("note.md", "");
+      setMockMetadata("note.md", {
+        frontmatter: {
+          "field with spaces": "v1",
+          "field-with-dashes": "v2",
+          field_with_underscore: "v3",
+          "numeric-2026": "v4",
+        },
+      });
+      for (const [key, val] of [
+        ["field with spaces", "v1"],
+        ["field-with-dashes", "v2"],
+        ["field_with_underscore", "v3"],
+        ["numeric-2026", "v4"],
+      ]) {
+        const r = await getVaultFilePartialHandler({
+          arguments: { filename: "note.md", mode: "frontmatter", target: key },
+          app: mockApp(),
+        });
+        expect(r.isError).toBeUndefined();
+        expect(JSON.parse(r.content[0].text)).toBe(val);
+      }
+    });
+
+    test("returns nested object values serialized as JSON", async () => {
+      setMockFile("note.md", "");
+      setMockMetadata("note.md", {
+        frontmatter: { author: { name: "Marco", role: "PM" } },
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "note.md", mode: "frontmatter", target: "author" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBeUndefined();
+      const parsed = JSON.parse(r.content[0].text);
+      expect(parsed).toEqual({ name: "Marco", role: "PM" });
+    });
+
+    test("returns array-valued fields as JSON arrays", async () => {
+      setMockFile("note.md", "");
+      setMockMetadata("note.md", {
+        frontmatter: { tags: ["project", "active", "2026"] },
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "note.md", mode: "frontmatter", target: "tags" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBeUndefined();
+      expect(JSON.parse(r.content[0].text)).toEqual([
+        "project",
+        "active",
+        "2026",
+      ]);
+    });
+  });
+
+  // ── Primary: document-map (5 cases) ──────────────────────────────────────
+
+  describe("mode: document-map (PRIMARY depth)", () => {
+    test("returns the outline of a file with headings, blocks, and frontmatter", async () => {
+      setMockFile("doc.md", "");
+      setMockMetadata("doc.md", {
+        headings: [
+          { heading: "Intro", level: 1, line: 0 },
+          { heading: "Details", level: 2, line: 5 },
+        ],
+        blocks: { "abc": { startLine: 10, endLine: 12 } },
+        frontmatter: { status: "draft", tags: ["x"] },
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "document-map" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBeUndefined();
+      const data = JSON.parse(r.content[0].text);
+      expect(data.path).toBe("doc.md");
+      expect(data.frontmatter.sort()).toEqual(["status", "tags"]);
+      expect(data.headings).toEqual([
+        { heading: "Intro", level: 1, line: 0 },
+        { heading: "Details", level: 2, line: 5 },
+      ]);
+      expect(data.blocks).toEqual(["abc"]);
+    });
+
+    test("returns outline for a file with only headings (no frontmatter)", async () => {
+      setMockFile("doc.md", "");
+      setMockMetadata("doc.md", {
+        headings: [{ heading: "Only", level: 1, line: 0 }],
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "document-map" },
+        app: mockApp(),
+      });
+      const data = JSON.parse(r.content[0].text);
+      expect(data.frontmatter).toEqual([]);
+      expect(data.headings).toHaveLength(1);
+      expect(data.blocks).toEqual([]);
+    });
+
+    test("returns an empty outline for an empty file", async () => {
+      setMockFile("empty.md", "");
+      // No metadata at all.
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "empty.md", mode: "document-map" },
+        app: mockApp(),
+      });
+      const data = JSON.parse(r.content[0].text);
+      expect(data).toEqual({
+        path: "empty.md",
+        frontmatter: [],
+        headings: [],
+        blocks: [],
+      });
+    });
+
+    test("preserves nested-heading levels in the outline", async () => {
+      setMockFile("doc.md", "");
+      setMockMetadata("doc.md", {
+        headings: [
+          { heading: "H1A", level: 1, line: 0 },
+          { heading: "H2A", level: 2, line: 1 },
+          { heading: "H3A", level: 3, line: 2 },
+          { heading: "H2B", level: 2, line: 3 },
+          { heading: "H1B", level: 1, line: 4 },
+        ],
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "document-map" },
+        app: mockApp(),
+      });
+      const data = JSON.parse(r.content[0].text);
+      expect(data.headings.map((h: { level: number }) => h.level)).toEqual([
+        1, 2, 3, 2, 1,
+      ]);
+    });
+
+    test("ignores `target` if passed", async () => {
+      setMockFile("doc.md", "");
+      setMockMetadata("doc.md", {
+        frontmatter: { status: "open" },
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: {
+          filename: "doc.md",
+          mode: "document-map",
+          target: "should-be-ignored",
+        },
+        app: mockApp(),
+      });
+      // No error, no special treatment — target is silently dropped.
+      expect(r.isError).toBeUndefined();
+      const data = JSON.parse(r.content[0].text);
+      expect(data.frontmatter).toEqual(["status"]);
+    });
+  });
+
+  // ── Secondary: heading (5 cases) ──────────────────────────────────────────
+
+  describe("mode: heading (SECONDARY)", () => {
+    test("returns the section under a unique heading", async () => {
+      setMockFile(
+        "doc.md",
+        "# Intro\nthis is intro\nstill intro\n# Other\nother body",
+      );
+      setMockMetadata("doc.md", {
+        headings: [
+          { heading: "Intro", level: 1, line: 0 },
+          { heading: "Other", level: 1, line: 3 },
+        ],
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "heading", target: "Intro" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBeUndefined();
+      // Section is from the heading line (inclusive) to before the next
+      // same-or-higher-level heading (exclusive).
+      expect(r.content[0].text).toBe("# Intro\nthis is intro\nstill intro");
+    });
+
+    test("returns isError when the target heading is missing", async () => {
+      setMockFile("doc.md", "# A\ntext");
+      setMockMetadata("doc.md", {
+        headings: [{ heading: "A", level: 1, line: 0 }],
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "heading", target: "Nope" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain("Heading not found");
+    });
+
+    test("returns isError when the target heading is ambiguous", async () => {
+      setMockFile(
+        "doc.md",
+        "# Section\nfirst\n# Section\nsecond",
+      );
+      setMockMetadata("doc.md", {
+        headings: [
+          { heading: "Section", level: 1, line: 0 },
+          { heading: "Section", level: 1, line: 2 },
+        ],
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "heading", target: "Section" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain("Ambiguous heading target");
+    });
+
+    test("resolves nested heading paths via the default `::` delimiter", async () => {
+      setMockFile(
+        "doc.md",
+        "# Parent\nintro\n## Section\nfirst\n# Other\n## Section\nsecond",
+      );
+      setMockMetadata("doc.md", {
+        headings: [
+          { heading: "Parent", level: 1, line: 0 },
+          { heading: "Section", level: 2, line: 2 },
+          { heading: "Other", level: 1, line: 4 },
+          { heading: "Section", level: 2, line: 5 },
+        ],
+      });
+      // Both "Section" headings would be ambiguous at top-level, but the
+      // nested path disambiguates to the one under "Parent".
+      const r = await getVaultFilePartialHandler({
+        arguments: {
+          filename: "doc.md",
+          mode: "heading",
+          target: "Parent::Section",
+        },
+        app: mockApp(),
+      });
+      expect(r.isError).toBeUndefined();
+      expect(r.content[0].text).toBe("## Section\nfirst");
+    });
+
+    test("section extends to end-of-file when no closer heading exists", async () => {
+      setMockFile("doc.md", "# A\nline1\nline2");
+      setMockMetadata("doc.md", {
+        headings: [{ heading: "A", level: 1, line: 0 }],
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "heading", target: "A" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBeUndefined();
+      expect(r.content[0].text).toBe("# A\nline1\nline2");
+    });
+  });
+
+  // ── Secondary: block (4 cases) ────────────────────────────────────────────
+
+  describe("mode: block (SECONDARY)", () => {
+    test("returns the markdown range of a block reference", async () => {
+      setMockFile(
+        "doc.md",
+        "intro\nthis is the target ^abc\nfollowup",
+      );
+      setMockMetadata("doc.md", {
+        blocks: { abc: { startLine: 1, endLine: 1 } },
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "block", target: "abc" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBeUndefined();
+      expect(r.content[0].text).toBe("this is the target ^abc");
+    });
+
+    test("accepts the target with or without the leading `^`", async () => {
+      setMockFile("doc.md", "line0\nline1 ^xyz");
+      setMockMetadata("doc.md", {
+        blocks: { xyz: { startLine: 1, endLine: 1 } },
+      });
+      const withCaret = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "block", target: "^xyz" },
+        app: mockApp(),
+      });
+      const withoutCaret = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "block", target: "xyz" },
+        app: mockApp(),
+      });
+      expect(withCaret.content[0].text).toBe(withoutCaret.content[0].text);
+    });
+
+    test("returns isError when the target block is missing", async () => {
+      setMockFile("doc.md", "line0\nline1");
+      setMockMetadata("doc.md", {
+        blocks: { present: { startLine: 0, endLine: 0 } },
+      });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "block", target: "missing" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain("Block not found");
+      expect(r.content[0].text).toContain('"^missing"');
+    });
+
+    test("returns isError when target collapses to empty after stripping `^`", async () => {
+      setMockFile("doc.md", "x");
+      setMockMetadata("doc.md", { blocks: {} });
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "doc.md", mode: "block", target: "^^^" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain("Invalid block target");
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
@@ -1,0 +1,288 @@
+import { type } from "arktype";
+import type { App, TFile } from "obsidian";
+
+export const getVaultFilePartialSchema = type({
+  name: '"get_vault_file_partial"',
+  arguments: {
+    filename: type("string>0").describe(
+      "Vault-relative path to the file.",
+    ),
+    mode: type(
+      '"frontmatter" | "heading" | "block" | "document-map"',
+    ).describe(
+      'One of: `"frontmatter"` (returns a single frontmatter field value), `"heading"` (returns the markdown section under the target heading), `"block"` (returns the markdown range of the target block reference), or `"document-map"` (returns the file outline — heading list, block-id list, frontmatter-field list — with no body content).',
+    ),
+    "target?": type("string>0").describe(
+      'Field name for `frontmatter`, heading text (optionally nested via `targetDelimiter`) for `heading`, or block id (with or without the leading `^`) for `block`. Required for all modes EXCEPT `document-map` (where it is ignored).',
+    ),
+    "targetDelimiter?": type("string>0").describe(
+      'Delimiter used to address a nested heading path, e.g. `"Parent::Child::Grandchild"`. Defaults to `"::"` (matching the Local REST API convention). Only meaningful for `mode: "heading"`.',
+    ),
+  },
+}).describe(
+  "Returns a partial read of a vault file: a single frontmatter field, a heading section, a block range, or the file outline. All four modes operate on Obsidian's already-cached metadata (`MetadataCache`) and `vault.cachedRead`; no Local REST API required. The `frontmatter` and `document-map` modes are zero-I/O on cached data; `heading` and `block` perform one cached read each. Useful for context-window economics on large notes (e.g. spot-check a frontmatter field on a 30 KB file without loading the body). Always read-only.",
+);
+
+export type GetVaultFilePartialContext = {
+  arguments: {
+    filename: string;
+    mode: "frontmatter" | "heading" | "block" | "document-map";
+    target?: string;
+    targetDelimiter?: string;
+  };
+  app: App;
+};
+
+type MockHeading = {
+  heading: string;
+  level: number;
+  position: { start: { line: number }; end?: { line: number } };
+};
+
+type MockBlock = {
+  position: { start: { line: number }; end: { line: number } };
+};
+
+type MockCache = {
+  headings?: MockHeading[];
+  blocks?: Record<string, MockBlock>;
+  frontmatter?: Record<string, unknown>;
+};
+
+function errorResponse(
+  message: string,
+): { content: Array<{ type: "text"; text: string }>; isError: true } {
+  return {
+    content: [{ type: "text", text: message }],
+    isError: true,
+  };
+}
+
+function jsonResponse(
+  value: unknown,
+): { content: Array<{ type: "text"; text: string }> } {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+function textResponse(
+  text: string,
+): { content: Array<{ type: "text"; text: string }> } {
+  return {
+    content: [{ type: "text", text }],
+  };
+}
+
+/**
+ * Find the heading entry that matches a target path. `target` may be a single
+ * heading text or a path of headings separated by `delimiter` (e.g.
+ * `"Parent::Child::Grandchild"` with delimiter `"::"`).
+ *
+ * Returns either the matched heading + the lower bound of its section
+ * (exclusive end line: the line BEFORE the next same-or-higher-level heading,
+ * or `totalLines` for end-of-file), or an error string.
+ *
+ * Disambiguation: if the path is unique, the match is returned. If multiple
+ * matches exist at the same depth (truly ambiguous), an error is returned. The
+ * caller surfaces it as `isError: true`.
+ */
+function findHeadingSection(
+  headings: MockHeading[],
+  target: string,
+  delimiter: string,
+  totalLines: number,
+):
+  | { startLine: number; endLine: number; level: number }
+  | { error: string } {
+  const segments = target.split(delimiter).map((s) => s.trim()).filter(Boolean);
+  if (segments.length === 0) {
+    return { error: "Invalid heading target: empty after delimiter split." };
+  }
+
+  // Walk the segments. For each segment, we need to find a heading whose text
+  // matches AND that lives inside the section of the previous segment (i.e.
+  // appears after the previous match and before the previous section closes).
+  //
+  // - prevEndLine starts at `totalLines` so the first segment can match
+  //   anywhere in the file.
+  // - prevLevel starts at 0 so the first segment matches any level.
+  let prevStartLine = -1; // exclusive lower bound for the next segment
+  let prevEndLine = totalLines;
+  let prevLevel = 0;
+  let lastMatch: MockHeading | null = null;
+
+  for (let segIdx = 0; segIdx < segments.length; segIdx++) {
+    const seg = segments[segIdx];
+    const candidates = headings.filter(
+      (h) =>
+        h.heading === seg &&
+        h.position.start.line > prevStartLine &&
+        h.position.start.line < prevEndLine &&
+        (segIdx === 0 || h.level > prevLevel),
+    );
+
+    if (candidates.length === 0) {
+      const where =
+        segIdx === 0
+          ? "in the file"
+          : `under "${segments.slice(0, segIdx).join(delimiter)}"`;
+      return {
+        error: `Heading not found: "${seg}" ${where}.`,
+      };
+    }
+    if (candidates.length > 1) {
+      const lines = candidates
+        .map((c) => `level ${c.level} at line ${c.position.start.line}`)
+        .join(", ");
+      return {
+        error: `Ambiguous heading target: "${seg}" matches multiple headings (${lines}). Use a nested path with \`targetDelimiter\` to disambiguate.`,
+      };
+    }
+
+    const match = candidates[0];
+    lastMatch = match;
+    prevStartLine = match.position.start.line;
+    prevLevel = match.level;
+
+    // The section under `match` ends at the next heading with level <= match.level
+    // (or EOF if no such heading exists). This is the boundary that the next
+    // segment in the path must respect.
+    const closer = headings.find(
+      (h) =>
+        h.position.start.line > match.position.start.line &&
+        h.level <= match.level,
+    );
+    prevEndLine = closer ? closer.position.start.line : totalLines;
+  }
+
+  if (!lastMatch) {
+    return { error: `Heading not found: "${target}".` };
+  }
+
+  return {
+    startLine: lastMatch.position.start.line,
+    endLine: prevEndLine,
+    level: lastMatch.level,
+  };
+}
+
+export async function getVaultFilePartialHandler(
+  ctx: GetVaultFilePartialContext,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const { filename, mode, target, targetDelimiter } = ctx.arguments;
+
+  const abstract = ctx.app.vault.getAbstractFileByPath(filename);
+  if (!abstract) {
+    return errorResponse(`File not found: ${filename}`);
+  }
+  const file = abstract as TFile;
+
+  // Schema-level guard: `target` is required for every mode except
+  // `document-map`. We enforce this at the handler level (rather than via
+  // arktype) so the error message can name the mode explicitly.
+  if (mode !== "document-map" && (!target || !target.trim())) {
+    return errorResponse(
+      `Missing required \`target\` for mode "${mode}". The \`target\` argument is required for "frontmatter", "heading", and "block" modes.`,
+    );
+  }
+
+  const cache = (ctx.app.metadataCache.getFileCache(file) ??
+    {}) as MockCache;
+
+  // ── frontmatter ───────────────────────────────────────────────────────────
+  if (mode === "frontmatter") {
+    const fm = cache.frontmatter;
+    if (!fm || Object.keys(fm).length === 0) {
+      return errorResponse(
+        `File has no frontmatter: ${filename}.`,
+      );
+    }
+    const key = target!.trim();
+    if (!(key in fm)) {
+      return errorResponse(
+        `Frontmatter field not found: "${key}" in ${filename}.`,
+      );
+    }
+    return jsonResponse(fm[key]);
+  }
+
+  // ── document-map ──────────────────────────────────────────────────────────
+  if (mode === "document-map") {
+    // Pinned locale + sensitivity for cross-platform deterministic order on
+    // the frontmatter-key list and the block-id list (matches the contract
+    // used by `list_tags` / `get_files_by_tag` / `get_recent_files`).
+    const compareName = (a: string, b: string): number =>
+      a.localeCompare(b, "en", { sensitivity: "variant" });
+
+    const headings = (cache.headings ?? []).map((h) => ({
+      heading: h.heading,
+      level: h.level,
+      line: h.position.start.line,
+    }));
+    const blocks = Object.keys(cache.blocks ?? {}).slice().sort(compareName);
+    const frontmatterKeys = Object.keys(cache.frontmatter ?? {})
+      .slice()
+      .sort(compareName);
+
+    return jsonResponse({
+      path: file.path,
+      frontmatter: frontmatterKeys,
+      headings,
+      blocks,
+    });
+  }
+
+  // Modes below need the file contents.
+  const text = await ctx.app.vault.cachedRead(file);
+  const lines = text.split("\n");
+
+  // ── heading ───────────────────────────────────────────────────────────────
+  if (mode === "heading") {
+    const headings = cache.headings ?? [];
+    if (headings.length === 0) {
+      return errorResponse(
+        `File has no headings: ${filename}.`,
+      );
+    }
+    const delim = targetDelimiter ?? "::";
+    const result = findHeadingSection(headings, target!, delim, lines.length);
+    if ("error" in result) {
+      return errorResponse(result.error);
+    }
+    // `endLine` is the start line of the next same-or-higher-level heading
+    // (exclusive) or `lines.length` for EOF. Slice [startLine, endLine).
+    const section = lines.slice(result.startLine, result.endLine).join("\n");
+    return textResponse(section);
+  }
+
+  // ── block ─────────────────────────────────────────────────────────────────
+  if (mode === "block") {
+    const blocks = cache.blocks ?? {};
+    // Strip leading `^` characters and trim. Obsidian addresses blocks
+    // without the caret in the metadata cache; users may pass either form.
+    const key = target!.trim().replace(/^\^+/, "");
+    if (!key) {
+      return errorResponse(
+        `Invalid block target: input is empty or contains only "^" characters.`,
+      );
+    }
+    const entry = blocks[key];
+    if (!entry) {
+      return errorResponse(
+        `Block not found: "^${key}" in ${filename}.`,
+      );
+    }
+    // Block position uses inclusive end line in the metadata cache.
+    const section = lines
+      .slice(entry.position.start.line, entry.position.end.line + 1)
+      .join("\n");
+    return textResponse(section);
+  }
+
+  // Unreachable: arktype validates `mode` to the four-value union.
+  return errorResponse(`Unknown mode: "${mode}".`);
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -105,6 +105,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "get_recent_files",
         "get_server_info",
         "get_vault_file",
+        "get_vault_file_partial",
         "list_obsidian_commands",
         "list_tags",
         "list_vault_files",
@@ -117,7 +118,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "show_file_in_obsidian",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(28);
+      expect(names).toHaveLength(29);
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }


### PR DESCRIPTION
## Summary

Adds `get_vault_file_partial`, a partial-read MCP tool surfacing four slices of a vault file without loading the full body. Closes #77 (RFC by @folotp).

**Architectural note**: implemented **in-process** (via `MetadataCache` + `vault.cachedRead`) rather than as an LRA passthrough wrapper, per the bilateral lockin between @istefox and @folotp on 2026-05-13:

- [#77 comment 4440321478](https://github.com/istefox/obsidian-mcp-connector/issues/77#issuecomment-4440321478) — consultation
- [#77 comment 4440557399](https://github.com/istefox/obsidian-mcp-connector/issues/77#issuecomment-4440557399) — @istefox calls in-process
- [#77 comment 4440927656](https://github.com/istefox/obsidian-mcp-connector/issues/77#issuecomment-4440927656) — @folotp confirms + priority heuristic
- [#77 comment 4440988763](https://github.com/istefox/obsidian-mcp-connector/issues/77#issuecomment-4440988763) — @istefox locks

Aligns with the 0.4.x "LRA-optional" stance — bumps "works without LRA" count from 27 to **28** of 29 total tools.

## Design

**Schema** (arktype, Option A verbatim from the RFC):

```ts
{
  filename: string,
  mode: "frontmatter" | "heading" | "block" | "document-map",
  target?: string,        // required for all modes except document-map
  targetDelimiter?: string // default "::"
}
```

`target` enforcement lives in the handler (not arktype) so the error message can name the offending mode explicitly.

### Mode contracts

| Mode | I/O | Returns | Errors |
|------|-----|---------|--------|
| `frontmatter` | Cache only | JSON-serialised field value (scalar / array / nested object) | Missing field; frontmatter-less file |
| `document-map` | Cache only | `{ path, frontmatter: [keys], headings: [{heading, level, line}], blocks: [ids] }`. Sorted lists use `Intl.Collator` for cross-platform determinism. `target` silently ignored. | n/a (positive-only) |
| `heading` | One `cachedRead` | Markdown slice from heading line (inclusive) to next same-or-higher-level heading (exclusive) or EOF. Nested paths via `targetDelimiter` resolved by a walking algorithm scoping each segment to its parent's section. | Missing target; ambiguous target (lists candidates, no first-wins) |
| `block` | One `cachedRead` | Markdown slice from `cache.blocks[id].position` (inclusive end). Target accepts `^abc` or `abc`. | Missing target; empty-after-`^`-strip |

**Authorisation** matches sibling metadata tools — no per-tool allowlist, read-only.

## Counts & regression-guard

- Tools **28 → 29**.
- `mcpServer.test.ts` regression-guard: `"get_vault_file_partial"` inserted between `"get_vault_file"` and `"list_obsidian_commands"`; `toHaveLength(28)` → `(29)`.
- README counters: 4 lines reconciled (26, 44, 139, 402). "17 typed tools" on line 32 unchanged — this tool is metadata-read, not vault-write.

### Aritmetic note on the "without-LRA" count

Your `#77` close-out anticipated `27 → 29` ("off-by-two correction"). Re-checking the README at HEAD `8c2b727`: PR #94 already moved the without-LRA count from 26 to 27 in both the architecture bullet and footnote `[^4]`. So this PR is a clean +1, landing at **27 → 28** (28 of 29 tools work without LRA). Happy to revisit if I've misread the baseline.

## Test plan

24 cases in `getVaultFilePartial.test.ts`, following the priority order adopted in the lockin:

### PRIMARY depth (zero-I/O cache-only modes — folotp's "30 KB note" cost-shape)

- [x] **frontmatter** × 6: scalar, missing-field, no-frontmatter, special-character keys, nested object, array-valued
- [x] **document-map** × 5: full outline, headings-only, empty file, nested-level preservation, target-silently-ignored

### SECONDARY (positive + missing + ambiguous per folotp's heuristic)

- [x] **heading** × 5: unique-match section, missing-target, ambiguous rejected, nested path via `::`, EOF-bound section
- [x] **block** × 4: positive markdown range, `^` strip equivalence, missing-target, empty-after-strip rejection

### Common

- [x] schema name
- [x] filename-not-found
- [x] missing-target enforcement across modes
- [x] `targetDelimiter` override honoured (`Parent>>Child`)

Mock surface untouched — `setMockMetadata()` (shipped in PR #87) already covers headings, blocks, and frontmatter shapes. Validates the cluster-infra-reuse loop you flagged in the #94 review.

### Validation

- [x] `bun test getVaultFilePartial.test.ts` → 24/24 pass.
- [x] `bun test` sans `port.test.ts` / `httpServer.test.ts` (blocked by an open Obsidian instance locally) → 786/786 pass (+24 vs the 762 baseline from #95).
- [x] `bun run check` (typecheck across the monorepo) → clean.
- [x] `bun run build` → success.
- [x] `bun.lock` untouched — preventive of the missed-commit MED1 from #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)