### PR TITLE
fix(0.4): #96 — delete tools honour vault "Deleted files" setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
   pre-cut tests. Reported by @folotp during the 0.4.5 round-6 verify
   on #86. (#88, #92)
 
+- **`delete_vault_file` / `delete_active_file` now honour the vault's
+  "Deleted files" setting instead of permanently unlinking.** Both
+  handlers called `app.vault.delete(file)`, a hard unlink that bypasses
+  Obsidian's configured deletion strategy (system trash / `.trash/` /
+  permanent). Files deleted via MCP were unrecoverable even when the
+  vault was set to move deletions to `.trash` — a data-loss risk in
+  agentic bulk-delete workflows where many files are removed without
+  individual confirmation. Both now route through
+  `app.fileManager.trashFile(file)`, which applies the vault preference
+  automatically (no manual `trashOption` inspection). `delete_vault_directory`
+  is intentionally out of scope — it documents its trash-bypass
+  explicitly. Reported by @folotp on a 0.4.6 soak. (#96)
+
 ### Changed
 
 - **Migration walkthrough adds an explicit

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteActiveFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteActiveFile.test.ts
@@ -3,7 +3,14 @@ import {
   deleteActiveFileHandler,
   deleteActiveFileSchema,
 } from "./deleteActiveFile";
-import { mockApp, resetMockVault, setMockActiveFile, setMockFile } from "$/test-setup";
+import {
+  mockApp,
+  resetMockVault,
+  setMockActiveFile,
+  setMockFile,
+  getMockTrashedPaths,
+  getMockDeletedPaths,
+} from "$/test-setup";
 
 beforeEach(() => resetMockVault());
 
@@ -14,7 +21,7 @@ describe("delete_active_file tool", () => {
     );
   });
 
-  test("deletes the active file via app.vault.delete", async () => {
+  test("trashes the active file via fileManager.trashFile, honouring the vault 'Deleted files' setting (not a permanent unlink)", async () => {
     setMockFile("Inbox/temp.md", "to be deleted");
     setMockActiveFile("Inbox/temp.md");
     const app = mockApp();
@@ -25,6 +32,8 @@ describe("delete_active_file tool", () => {
     expect(result.content[0].text).toMatch(/ok|deleted/i);
     // After deletion, no active file
     expect(app.workspace.getActiveFile()).toBeNull();
+    expect(getMockTrashedPaths()).toContain("Inbox/temp.md");
+    expect(getMockDeletedPaths()).not.toContain("Inbox/temp.md");
   });
 
   test("returns error when no active file", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteActiveFile.ts
@@ -26,6 +26,6 @@ export async function deleteActiveFileHandler(
       isError: true,
     };
   }
-  await ctx.app.vault.delete(file);
+  await ctx.app.fileManager.trashFile(file);
   return { content: [{ type: "text", text: "OK" }] };
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultFile.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import { deleteVaultFileHandler, deleteVaultFileSchema } from "./deleteVaultFile";
-import { mockApp, resetMockVault, setMockFile } from "$/test-setup";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  getMockTrashedPaths,
+  getMockDeletedPaths,
+} from "$/test-setup";
 
 beforeEach(() => resetMockVault());
 
@@ -18,6 +24,19 @@ describe("delete_vault_file tool", () => {
     });
     expect(result.isError).toBeUndefined();
     expect(app.vault.getAbstractFileByPath("trash.md")).toBeNull();
+  });
+
+  test("routes deletion through fileManager.trashFile, honouring the vault 'Deleted files' setting (not a permanent unlink)", async () => {
+    setMockFile("notes/keepme.md", "valuable");
+    const app = mockApp();
+
+    await deleteVaultFileHandler({
+      arguments: { path: "notes/keepme.md" },
+      app,
+    });
+
+    expect(getMockTrashedPaths()).toContain("notes/keepme.md");
+    expect(getMockDeletedPaths()).not.toContain("notes/keepme.md");
   });
 
   test("returns error when path not found", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultFile.ts
@@ -23,6 +23,6 @@ export async function deleteVaultFileHandler(
       isError: true,
     };
   }
-  await ctx.app.vault.delete(file);
+  await ctx.app.fileManager.trashFile(file);
   return { content: [{ type: "text", text: "OK" }] };
 }

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -284,6 +284,12 @@ type MockVaultState = {
   // depending on the glob/regex compilation path. Empty by default so
   // tests that don't exercise exclusion keep observing the full vault.
   ignored: Set<string>;
+  // Records which destructive path a delete took. `trashFile` honours the
+  // vault "Deleted files" setting (recoverable); raw `vault.delete` is a
+  // permanent unlink. Tests assert delete handlers route through the
+  // former (regression guard for fork issue #96).
+  trashedPaths: string[];
+  deletedPaths: string[];
 };
 
 // Synthetic absolute filesystem prefix used by the mock `adapter.rmdir`
@@ -307,6 +313,8 @@ const _mockState: MockVaultState = {
   requestUrlResponses: new Map(),
   fileStats: new Map(),
   ignored: new Set(),
+  trashedPaths: [],
+  deletedPaths: [],
 };
 
 export function resetMockVault(): void {
@@ -328,6 +336,18 @@ export function resetMockVault(): void {
   _mockState.requestUrlResponses.clear();
   _mockState.fileStats.clear();
   _mockState.ignored.clear();
+  _mockState.trashedPaths = [];
+  _mockState.deletedPaths = [];
+}
+
+/** Paths routed through `fileManager.trashFile` (recoverable delete). */
+export function getMockTrashedPaths(): string[] {
+  return [..._mockState.trashedPaths];
+}
+
+/** Paths routed through `vault.delete` (permanent unlink). */
+export function getMockDeletedPaths(): string[] {
+  return [..._mockState.deletedPaths];
 }
 
 export function setMockFile(path: string, content: string): void {
@@ -650,6 +670,7 @@ export function mockApp(): App {
     },
     delete: async (file: TAbstractFile): Promise<void> => {
       const path = (file as unknown as MockTFile).path;
+      _mockState.deletedPaths.push(path);
       _mockState.files.delete(path);
       if (_mockState.activeFilePath === path) {
         _mockState.activeFilePath = null;
@@ -819,6 +840,22 @@ export function mockApp(): App {
       }
       if (_mockState.activeFilePath === path) {
         _mockState.activeFilePath = newPath;
+      }
+    },
+    /**
+     * Mock of `app.fileManager.trashFile`. The real implementation
+     * honours the vault's "Deleted files" setting (system trash /
+     * `.trash/` / permanent). Here the destination is irrelevant —
+     * tests only need to observe that the recoverable path was taken
+     * (vs. the permanent `vault.delete`), so the call is recorded and
+     * the file removed from the live vault.
+     */
+    trashFile: async (file: TAbstractFile): Promise<void> => {
+      const path = (file as unknown as MockTFile).path;
+      _mockState.trashedPaths.push(path);
+      _mockState.files.delete(path);
+      if (_mockState.activeFilePath === path) {
+        _mockState.activeFilePath = null;
       }
     },
   };


### PR DESCRIPTION
## Summary

- `delete_vault_file` and `delete_active_file` called `app.vault.delete(file)` — a permanent unlink that bypasses Obsidian's configured deletion strategy (system trash / `.trash/` / permanent). MCP-driven deletions were unrecoverable even when the vault was set to move deletions to `.trash`.
- Both handlers now route through `app.fileManager.trashFile(file)`, which honours the vault preference automatically (no manual `trashOption` inspection). `trashFile` is properly typed in the bundled `obsidian.d.ts` — no cast needed.
- `delete_vault_directory` is intentionally **out of scope**: it documents its trash-bypass explicitly in its schema.

## Why this matters

Data-loss risk in agentic bulk-delete workflows where many files are removed without individual confirmation. Reported by @folotp on a 0.4.6 soak ([#96](https://github.com/istefox/obsidian-mcp-connector/issues/96)).

## TDD

- `test-setup.ts` mock records trashed vs. permanently-deleted paths (`getMockTrashedPaths()` / `getMockDeletedPaths()`), so the routing decision is regression-locked, not just "file is gone".
- Two RED tests added (one per handler) asserting the recoverable path is taken and the permanent path is not — watched fail (production still called `vault.delete`), then GREEN after the swap.

## Test plan

- [x] `bun test` (plugin package): 797 pass / 0 fail
- [x] `bun run check` (repo root): all packages 0 errors
- [ ] Manual: delete a file via MCP with vault set to "Move to Obsidian trash" → file appears in `.trash/`