### PR TITLE
fix(0.4): #99 — search_vault_smart honours the smart-connections provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
   pre-cut tests. Reported by @folotp during the 0.4.5 round-6 verify
   on #86. (#88, #92)
 
+- **`search_vault_smart` now honours the `smart-connections` provider
+  setting instead of always invoking the native pipeline.** Two root
+  causes: (1) the production wiring never bound the resolved Smart
+  Connections API onto the plugin instance, so
+  `SmartConnectionsProvider.isReady()` (which reads `plugin.smartSearch`)
+  always returned `false` — the tool reported "Semantic search is not
+  ready" even with Smart Connections fully loaded and explicitly
+  selected; (2) the handler kicked the native Transformers.js indexer
+  unconditionally on every call, triggering a HuggingFace embedding
+  model download (`ensurePipeline` → `from_pretrained`) even when Smart
+  Connections was the selected backend. Fixes: `main.ts` binds
+  `this.smartSearch` from the existing `loadSmartSearchAPI` reactive
+  loader (same best-effort pattern as the Local REST API binding); the
+  `search_vault_smart` handler skips the native indexer kick when Smart
+  Connections is the active backend (`smart-connections`, or `auto`
+  with Smart Connections available). The "not ready" error is now
+  provider-aware — under Smart Connections it names the Smart
+  Connections plugin rather than the irrelevant native embedding model.
+  Reported by @folotp on a 0.4.6 soak. (#99)
+
 ### Changed
 
 - **Migration walkthrough adds an explicit

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.test.ts
@@ -164,3 +164,110 @@ describe("search_vault_smart tool — dispatch contract (T11)", () => {
     expect(result.content[0]?.text).toMatch(/transient backend hiccup/);
   });
 });
+
+describe("search_vault_smart — native indexer gating by provider (#99)", () => {
+  function stateWith(opts: {
+    providerSetting: "native" | "smart-connections" | "auto";
+    ready?: boolean;
+    smartSearchPresent?: boolean;
+  }): {
+    plugin: ReturnType<typeof mockPlugin>;
+    indexerKicks: () => number;
+  } {
+    let kicks = 0;
+    const spy = fakeProvider({ ready: opts.ready ?? true, results: [] });
+    const plugin = mockPlugin({
+      // `isSmartConnectionsAvailable` reads plugin.smartSearch?.search
+      smartSearch: opts.smartSearchPresent
+        ? { search: async () => [] }
+        : undefined,
+      semanticSearchState: {
+        provider: spy.provider,
+        settings: { provider: opts.providerSetting, indexingMode: "live" },
+        startIndexerIfNeeded: () => {
+          kicks += 1;
+        },
+      },
+    } as never);
+    return { plugin, indexerKicks: () => kicks };
+  }
+
+  test("does NOT kick the native indexer when provider = smart-connections", async () => {
+    const { plugin, indexerKicks } = stateWith({
+      providerSetting: "smart-connections",
+    });
+    await searchVaultSmartHandler({
+      arguments: { query: "x" },
+      app: mockApp(),
+      plugin,
+    });
+    expect(indexerKicks()).toBe(0);
+  });
+
+  test("kicks the native indexer when provider = native", async () => {
+    const { plugin, indexerKicks } = stateWith({ providerSetting: "native" });
+    await searchVaultSmartHandler({
+      arguments: { query: "x" },
+      app: mockApp(),
+      plugin,
+    });
+    expect(indexerKicks()).toBe(1);
+  });
+
+  test("provider = auto: kicks native indexer only when Smart Connections is unavailable", async () => {
+    const withSC = stateWith({
+      providerSetting: "auto",
+      smartSearchPresent: true,
+    });
+    await searchVaultSmartHandler({
+      arguments: { query: "x" },
+      app: mockApp(),
+      plugin: withSC.plugin,
+    });
+    expect(withSC.indexerKicks()).toBe(0);
+
+    const withoutSC = stateWith({
+      providerSetting: "auto",
+      smartSearchPresent: false,
+    });
+    await searchVaultSmartHandler({
+      arguments: { query: "x" },
+      app: mockApp(),
+      plugin: withoutSC.plugin,
+    });
+    expect(withoutSC.indexerKicks()).toBe(1);
+  });
+});
+
+describe("search_vault_smart — provider-aware not-ready message (#99)", () => {
+  function notReadyPlugin(providerSetting: "native" | "smart-connections") {
+    const spy = fakeProvider({ ready: false });
+    return mockPlugin({
+      semanticSearchState: {
+        provider: spy.provider,
+        settings: { provider: providerSetting, indexingMode: "live" },
+      },
+    } as never);
+  }
+
+  test("smart-connections: message names Smart Connections, not the embedding model", async () => {
+    const result = await searchVaultSmartHandler({
+      arguments: { query: "x" },
+      app: mockApp(),
+      plugin: notReadyPlugin("smart-connections"),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/smart connections/i);
+    expect(result.content[0]?.text).not.toMatch(/embedding model/i);
+  });
+
+  test("native: message refers to the embedding model loading", async () => {
+    const result = await searchVaultSmartHandler({
+      arguments: { query: "x" },
+      app: mockApp(),
+      plugin: notReadyPlugin("native"),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/embedding model|still be loading/i);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 import type { App } from "obsidian";
 import type McpToolsPlugin from "$/main";
+import { isSmartConnectionsAvailable } from "$/features/semantic-search/services/providerFactory";
 
 export const searchVaultSmartSchema = type({
   name: '"search_vault_smart"',
@@ -78,16 +79,34 @@ export async function searchVaultSmartHandler(
     );
   }
 
+  // Which backend will actually serve this query? The native
+  // Transformers.js index is only meaningful when the native provider
+  // is the one answering — Smart Connections maintains its own index.
+  // `settings` is absent only in partial test fixtures; treat that as
+  // native (the historical unconditional behaviour) to avoid
+  // regressing the native default.
+  const settings = state.settings;
+  const usingSmartConnections =
+    settings?.provider === "smart-connections" ||
+    (settings?.provider === "auto" &&
+      isSmartConnectionsAvailable(ctx.plugin));
+
   // Lazy indexer kick (Q4 = lazy on first query). Fire-and-forget:
   // the indexer's start() runs the first full vault build in the
   // background and subscribes to vault events for incremental
-  // updates. Subsequent calls are no-ops.
-  state.startIndexerIfNeeded?.();
+  // updates. Subsequent calls are no-ops. Skipped entirely under
+  // Smart Connections — kicking the native indexer there triggers a
+  // pointless embedding-model download (#99).
+  if (!usingSmartConnections) {
+    state.startIndexerIfNeeded?.();
+  }
 
   const provider = state.provider;
   if (!provider.isReady()) {
     return errorResult(
-      "Semantic search is not ready. The provider may still be loading the embedding model, or the configured backend is unavailable. Open Settings → MCP Connector → Semantic Search to choose or reconfigure a provider.",
+      usingSmartConnections
+        ? "Semantic search is not ready: the Smart Connections plugin is not loaded or has not finished indexing this vault. Wait for Smart Connections to finish loading, or open Settings → MCP Connector → Semantic Search to switch providers."
+        : "Semantic search is not ready. The provider may still be loading the embedding model, or the configured backend is unavailable. Open Settings → MCP Connector → Semantic Search to choose or reconfigure a provider.",
     );
   }
 

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -10,6 +10,7 @@ import {
   Templater,
   type PromptArgAccessor,
   type SearchResponse,
+  type SmartConnections,
 } from "shared";
 import {
   CommandPermissionModal,
@@ -84,6 +85,17 @@ export default class McpToolsPlugin extends Plugin {
   mcpTransportState?: McpTransportState;
 
   semanticSearchState?: SemanticSearchState;
+
+  /**
+   * Resolved Smart Connections search API, populated best-effort at
+   * onload from the reactive `loadSmartSearchAPI` loader. The
+   * SmartConnectionsProvider + provider factory read this field to
+   * decide readiness and to dispatch `search_vault_smart` queries when
+   * the user picks the "smart-connections" (or "auto") provider.
+   * Undefined until the loader resolves, or permanently if Smart
+   * Connections is not installed (#99).
+   */
+  smartSearch?: SmartConnections.SmartSearch;
 
   getLocalRestApiKey(): string | undefined {
     return this.localRestApi.plugin?.settings?.apiKey;
@@ -499,6 +511,33 @@ export default class McpToolsPlugin extends Plugin {
       })
       .catch((error: unknown) => {
         logger.debug("Local REST API load skipped", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+    // Smart Connections: resolve the search API best-effort and bind
+    // it onto the plugin instance. The SmartConnectionsProvider and
+    // the provider factory read `this.smartSearch` to decide readiness
+    // and dispatch `search_vault_smart` under the "smart-connections" /
+    // "auto" provider settings. Without this binding the field stays
+    // undefined and the provider can never become ready even with
+    // Smart Connections fully loaded (#99). Best-effort, same shape as
+    // the Local REST API binding above.
+    lastValueFrom(loadSmartSearchAPI(this))
+      .then((dep) => {
+        this.smartSearch = dep.api;
+        if (this.smartSearch) {
+          logger.info(
+            "Smart Connections detected — `search_vault_smart` can use it",
+          );
+        } else {
+          logger.debug(
+            "Smart Connections not installed — `search_vault_smart` falls back to the native provider unless reconfigured",
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        logger.debug("Smart Connections load skipped", {
           error: error instanceof Error ? error.message : String(error),
         });
       });


### PR DESCRIPTION
## Summary

`search_vault_smart` ignored `provider: "smart-connections"` and always invoked the native Transformers.js pipeline. Investigation found **two independent root causes** (the triage's "handler bypasses the factory" was incorrect — the handler already dispatches through `semanticSearchState.provider`):

1. **`plugin.smartSearch` was never bound in production.** `SmartConnectionsProvider.isReady()`/`.search()` and `providerFactory.isSmartConnectionsAvailable()` all read `plugin.smartSearch`. `loadSmartSearchAPI` is only consumed locally inside the LRA `handleSearchRequest` endpoint — it never assigns the field. Result: `isReady()` always `false` → "Semantic search is not ready" even with Smart Connections fully loaded (897/897) and explicitly selected. The provider's own doc-comment claimed the field was "set by the existing `loadSmartSearchAPI` reactive loader" — that contract was never wired.
   **Fix:** `main.ts` binds `this.smartSearch` from `loadSmartSearchAPI`, mirroring the proven best-effort `loadLocalRestAPI` binding right above it.

2. **The native indexer was kicked unconditionally.** `searchVaultSmartHandler` called `state.startIndexerIfNeeded?.()` before the provider check; the production hook starts the native indexer (`embed → ensurePipeline → from_pretrained → HuggingFace download`) regardless of provider. This is exactly folotp's stack trace.
   **Fix:** skip the native indexer kick when Smart Connections is the active backend (`smart-connections`, or `auto` with SC available).

Plus: the not-ready error is now **provider-aware** — under Smart Connections it names the SC plugin, not the irrelevant native embedding model (the misleading message #99 explicitly flagged).

## Test plan

- [x] `bun test` (plugin): **801 pass / 0 fail** (+4 new: indexer gating ×3 + provider-aware message ×2; existing field-contract tests in `smartConnectionsProvider.test.ts` / `providerFactory.test.ts` unchanged & green)
- [x] `bun run check` (repo root): all packages 0 errors
- [ ] **Manual smoke required**: the `main.ts` onload binding has no unit harness (onload orchestration is documented-uncovered in CLAUDE.md). Verified by type-check + parity with the existing `loadLocalRestAPI` binding. Smoke: vault with Smart Connections loaded + provider=`smart-connections` → `search_vault_smart` returns SC results, no HuggingFace download, no "not ready".

## Note / out of scope

`loadSmartSearchAPI` resolves once at onload (same one-shot characteristic as the existing `loadLocalRestAPI` binding). If Smart Connections is enabled >5s *after* plugin load, the field won't repopulate until reload — a pre-existing pattern limitation, not part of the reported scenario (SC was fully loaded). Flagged for awareness; not expanded here to keep the fix minimal and consistent with the established pattern.

Reported by @folotp on a 0.4.6 soak ([#99](https://github.com/istefox/obsidian-mcp-connector/issues/99)).