### PR TITLE
fix(0.4): #98 — pre-warm no longer logs a fatal-looking trace on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
   pre-cut tests. Reported by @folotp during the 0.4.5 round-6 verify
   on #86. (#88, #92)
 
+- **"Pre-warm now" no longer dumps a fatal-looking stack trace to the
+  console when it actually succeeded.** `mcp-remote` has no `--help`
+  flag — probing it throws `ERR_INVALID_URL` on Node 20+/24. The
+  pre-warm already recovers correctly (the package is cached by the
+  time the probe fails, so it is treated as success), but it echoed the
+  raw child-process `Fatal error: TypeError: Invalid URL … at new URL …
+  ERR_INVALID_URL` slice into `logger.debug` — and in the shipped build
+  `logger` *is* `console`, so a successful pre-warm looked like a crash
+  in the user's dev console. Both the catch/recovery branch and the
+  success-path stderr log now detect the expected benign probe shape
+  and emit a clean one-line confirmation instead of the raw trace.
+  Genuinely unexpected stderr (e.g. npm deprecation warnings) is still
+  logged verbatim for diagnostics. Reported by @folotp on a 0.4.6 soak.
+  (#98)
+
 ### Changed
 
 - **Migration walkthrough adds an explicit

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.test.ts
@@ -1,9 +1,35 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, spyOn } from "bun:test";
 import {
   getPreWarmCache,
   preWarm,
   type ExecRunner,
 } from "./preWarm";
+import { logger } from "$/shared/logger";
+
+/** Regex for the scary child-process stack trace we must NOT echo. */
+const SCARY_NOISE =
+  /ERR_INVALID_URL|Fatal error|TypeError: Invalid URL|at new URL/;
+
+/**
+ * Capture every `logger.debug` argument (message + meta) during `fn`
+ * as a single flattened JSON string, so a test can assert the recovery
+ * path does not leak the raw mcp-remote stack trace to the (prod =
+ * console) logger.
+ */
+async function captureDebugDuring(fn: () => Promise<void>): Promise<string> {
+  const calls: unknown[][] = [];
+  const spy = spyOn(logger, "debug").mockImplementation(
+    (...args: unknown[]) => {
+      calls.push(args);
+    },
+  );
+  try {
+    await fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return JSON.stringify(calls);
+}
 
 /**
  * Tests for the mcp-remote pre-warm runner + cache persistence.
@@ -190,6 +216,70 @@ describe("preWarm — error classification", () => {
     const cached = await getPreWarmCache(p);
     expect(cached?.lastWarmedAt).toBe("2026-01-01T00:00:00.000Z");
     expect(cached?.version).toBe("1.0.0");
+  });
+});
+
+describe("preWarm — #98 benign mcp-remote probe error is not surfaced as noise", () => {
+  const benignThrow = () => {
+    throw new Error(
+      'Command failed: "/opt/homebrew/bin/npx" -y mcp-remote@latest --help\n' +
+        "[46042] Fatal error: TypeError: Invalid URL\n" +
+        "    at new URL (node:internal/url:819:25)\n" +
+        "    at parseCommandLineArgs (file:///.../mcp-remote/dist/chunk-…) {\n" +
+        "  code: 'ERR_INVALID_URL',\n" +
+        "  input: '--help'\n" +
+        "}",
+    );
+  };
+
+  test("recovery branch does not echo the raw stack trace into the logger", async () => {
+    const p = fakePlugin({});
+    const runner: ExecRunner = async () => benignThrow();
+
+    let result: Awaited<ReturnType<typeof preWarm>> | undefined;
+    const logged = await captureDebugDuring(async () => {
+      result = await preWarm(p, { runner, npxPath: "npx" });
+    });
+
+    // Recovery semantics unchanged: still treated as success.
+    expect(result?.ok).toBe(true);
+    // But the scary child-process trace must not reach the logger
+    // (which is `console` in the shipped/prod build — #98).
+    expect(logged).not.toMatch(SCARY_NOISE);
+  });
+
+  test("success path with benign stderr does not echo the scary trace", async () => {
+    const p = fakePlugin({});
+    const runner: ExecRunner = async () => ({
+      stdout: "mcp-remote 1.2.3 - Remote MCP server proxy\n",
+      stderr:
+        "[46042] Fatal error: TypeError: Invalid URL\n" +
+        "    at new URL (node:internal/url:819:25)\n" +
+        "  code: 'ERR_INVALID_URL', input: '--help'",
+    });
+
+    let result: Awaited<ReturnType<typeof preWarm>> | undefined;
+    const logged = await captureDebugDuring(async () => {
+      result = await preWarm(p, { runner, npxPath: "npx" });
+    });
+
+    expect(result?.ok).toBe(true);
+    expect(logged).not.toMatch(SCARY_NOISE);
+  });
+
+  test("a genuinely unexpected stderr is still logged for diagnostics", async () => {
+    const p = fakePlugin({});
+    const runner: ExecRunner = async () => ({
+      stdout: "mcp-remote 1.2.3\n",
+      stderr: "npm warn deprecated something@1.0.0: please upgrade",
+    });
+
+    const logged = await captureDebugDuring(async () => {
+      await preWarm(p, { runner, npxPath: "npx" });
+    });
+
+    // Non-benign stderr is preserved (not over-suppressed).
+    expect(logged).toMatch(/deprecated something/);
   });
 });
 

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
@@ -161,9 +161,21 @@ export async function preWarm(
     // parse — the success of the install is what matters, not the
     // version string.
     if (stderr) {
-      logger.debug("preWarm: stderr from mcp-remote", {
-        stderr: stderr.slice(0, 200),
-      });
+      if (isBenignMcpRemoteProbeError(stderr)) {
+        // mcp-remote has no `--help`; probing it emits an
+        // ERR_INVALID_URL / "Invalid URL" stack to stderr. That is the
+        // expected behaviour of the probe, not a problem — log a clean
+        // one-liner instead of echoing the raw trace, which in the
+        // shipped build goes to `console` and reads as a fatal error
+        // even though the pre-warm succeeded (#98).
+        logger.debug(
+          "preWarm: mcp-remote emitted its expected no-arguments probe error on stderr (benign — the package is cached)",
+        );
+      } else {
+        logger.debug("preWarm: stderr from mcp-remote", {
+          stderr: stderr.slice(0, 200),
+        });
+      }
     }
     const version = parseVersionFromHelp(stdout) ?? parseVersionFromHelp(stderr);
     const entry: PreWarmCacheEntry = {
@@ -183,14 +195,15 @@ export async function preWarm(
     // pre-warm. Distinguish that case from real failures (network
     // errors, missing Node, package not found in registry) by looking
     // at the error text.
-    if (
-      /mcp-remote/i.test(message) ||
-      /ERR_INVALID_URL/i.test(message) ||
-      /Invalid URL/i.test(message)
-    ) {
+    if (isBenignMcpRemoteProbeError(message)) {
+      // Deliberately do NOT echo `message` here: it carries the child
+      // process's raw `Fatal error: TypeError: Invalid URL … at new URL
+      // … ERR_INVALID_URL` stack. In the shipped build `logger` IS
+      // `console`, so dumping that slice makes a *successful* pre-warm
+      // look like a crash in the user's dev console (#98). The recovery
+      // is expected and benign — a clean one-liner is enough.
       logger.debug(
-        "preWarm: npx exited non-zero but mcp-remote was loaded — treating as success",
-        { message: message.slice(0, 300) },
+        "preWarm: npx exited non-zero but mcp-remote was loaded — treating as success (mcp-remote has no --help flag; its probe rejection is expected and the package is now cached)",
       );
       const entry: PreWarmCacheEntry = {
         lastWarmedAt: new Date().toISOString(),
@@ -217,6 +230,22 @@ function parseVersionFromHelp(stdout: string): string | undefined {
     stdout,
   );
   return m?.[1];
+}
+
+/**
+ * True when the text is the *expected* failure of probing `mcp-remote`
+ * (it has no `--help`/`--version`; it requires a URL positional and
+ * emits ERR_INVALID_URL / "Invalid URL" otherwise). By the time this
+ * surfaces, npx has already cached the package — the pre-warm goal is
+ * met. Used both to recover the catch path and to silence the
+ * equivalent stderr noise on the success path (#98).
+ */
+function isBenignMcpRemoteProbeError(text: string): boolean {
+  return (
+    /mcp-remote/i.test(text) ||
+    /ERR_INVALID_URL/i.test(text) ||
+    /Invalid URL/i.test(text)
+  );
 }
 
 function classifyError(message: string): string {


### PR DESCRIPTION
## Summary

Clicking **Pre-warm now** logged a `TypeError: Invalid URL` / `ERR_INVALID_URL` stack trace to the dev console even though the pre-warm **succeeded**.

Root cause confirmed in code: `mcp-remote` has no `--help` flag — probing it (`npx -y mcp-remote@latest --help`) throws `ERR_INVALID_URL` on Node 20+/24 → non-zero exit → `promisify(exec)` rejects with the child stderr embedded in `.message`. The catch branch already recovers correctly (the package is cached by the time the probe fails, so it returns `ok: true`), **but** it logged `{ message: message.slice(0, 300) }` — the raw `Fatal error: TypeError: Invalid URL … at new URL … ERR_INVALID_URL` slice. And `shared/logger.ts` is `export const logger = isProd ? console : createLogger(...)` — in the shipped build `logger` **is** `console`, so a successful pre-warm rendered as a crash.

## Fix

- Extracted `isBenignMcpRemoteProbeError()` (DRY — reuses the regexes already gating the recovery branch).
- Catch/recovery branch: emits a clean one-line confirmation, no raw trace.
- Success-path stderr log: same benign-shape detection — clean note instead of echoing the raw stderr.
- Genuinely unexpected stderr (e.g. `npm warn deprecated …`) is still logged verbatim — guarded by a regression test so the suppression can't over-reach.
- Recovery semantics unchanged: still `ok: true`, cache still persisted.

## Test plan

- [x] `bun test` (plugin): **799 pass / 0 fail** (+3 new: recovery-branch clean, success-path clean, unexpected-stderr still logged; the existing "treated as success" recovery test unchanged & green)
- [x] `bun run check` (repo root): all packages 0 errors
- [ ] Manual smoke: click "Pre-warm now" on Node 24 → console shows the clean one-liner, no `Fatal error` / `ERR_INVALID_URL` stack; pre-warm still reports success

Reported by @folotp on a 0.4.6 soak ([#98](https://github.com/istefox/obsidian-mcp-connector/issues/98)).