### PR TITLE
fix(0.4): #100 — Windows crash on load (baked build-machine import.meta.url)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
   logged verbatim for diagnostics. Reported by @folotp on a 0.4.6 soak.
   (#98)
 
+- **Windows: plugin no longer crashes on load (`fileURLToPath` of a
+  baked build-machine path).** `@xenova/transformers/src/env.js` calls
+  `fileURLToPath(import.meta.url)` eagerly at module-init. `bun.config.ts`
+  neutralised `import.meta.filename` but not `import.meta.url`, so Bun
+  baked the **build machine's** absolute path into `main.js` — on the
+  GitHub Actions Linux runner, `file:///home/runner/...`. At load on
+  Windows, `getPathFromURLWin32` rejects that drive-less POSIX path with
+  `TypeError: File URL path must be absolute`, taking down the whole
+  plugin before any of our code runs. macOS/Linux were unaffected (a
+  POSIX path is still a valid file-URL path there). Fixed by adding
+  `import.meta.url` to the `define` block, mirroring the existing
+  `import.meta.filename` neutralisation. The placeholder carries a drive
+  letter (`file:///C:/…`) on purpose: a drive-less `file:///…` URL
+  throws on Windows for the *same* reason as the bug, whereas
+  `fileURLToPath` accepts `file:///C:/…` on every platform. The value is
+  dead in our build (`env.allowLocalModels = false`, ONNX wasm pinned to
+  a CDN) — only the eager call needed to stop throwing. Reported by
+  @nathancrum. (#100)
+
 ### Changed
 
 - **Migration walkthrough adds an explicit

--- a/packages/obsidian-plugin/bun.config.ts
+++ b/packages/obsidian-plugin/bun.config.ts
@@ -126,6 +126,20 @@ const config: BuildConfig = {
       isProd ? "production" : "development",
     ),
     "import.meta.filename": JSON.stringify("mcp-tools-for-obsidian.ts"),
+    // Bundled deps (notably `@xenova/transformers/src/env.js`) call
+    // `fileURLToPath(import.meta.url)` eagerly at module init. Without
+    // this define, Bun bakes the BUILD MACHINE's absolute path (the
+    // GitHub Actions Linux runner: `file:///home/runner/...`). On
+    // Windows `getPathFromURLWin32` rejects a drive-less POSIX path with
+    // `TypeError: File URL path must be absolute`, crashing the plugin
+    // on load before any of our code runs (#100). The placeholder MUST
+    // carry a drive letter — a drive-less `file:///x` URL throws on
+    // Windows for the exact same reason (that IS the bug's mechanism);
+    // `file:///C:/…` is accepted by `fileURLToPath` on every platform.
+    // The resolved value is dead in our build (`env.allowLocalModels =
+    // false`, ONNX wasm pinned to a CDN) — only the eager call must not
+    // throw.
+    "import.meta.url": JSON.stringify("file:///C:/mcp-tools-for-obsidian.ts"),
     // These environment variables are critical for the MCP server download functionality.
     // In CI the release workflow injects the correct values (see .github/workflows/release.yml);
     // the fallback targets the active fork repo so local builds keep working.


### PR DESCRIPTION
## Summary

The 0.4.x beta crashes on load on **Windows** (red toast, plugin unusable). @nathancrum's hypothesis was exactly right and I confirmed it at the artifact level.

**Root cause:** `@xenova/transformers/src/env.js` runs `path.dirname(path.dirname(url.fileURLToPath(import.meta.url)))` **eagerly at module init**. `bun.config.ts` neutralised `import.meta.filename` but **not** `import.meta.url`, so Bun substitutes `import.meta.url` with the **build machine's** absolute path. On the GitHub Actions Linux runner that bakes `file:///home/runner/work/...` into `main.js`. At plugin load on Windows, `getPathFromURLWin32` rejects that drive-less POSIX path → `TypeError: File URL path must be absolute`, before any of our code runs. macOS/Linux are unaffected (a POSIX path is a valid file-URL path there). `main` (0.3.x) is unaffected — no Transformers.js.

## Fix

Add `import.meta.url` to the `define` block, mirroring the existing `import.meta.filename` line.

**Important correction vs the issue triage:** the placeholder must carry a **drive letter** (`file:///C:/mcp-tools-for-obsidian.ts`). A drive-less `file:///mcp-tools-for-obsidian.ts` throws on Windows for the *exact same reason* as the bug (`getPathFromURLWin32` requires a drive letter when there's no hostname — verified against the `#100` stack trace and Node's `url` behaviour). `fileURLToPath` accepts `file:///C:/…` on every platform. The resolved value is **dead** in our build (`env.allowLocalModels = false`, ONNX wasm pinned to a CDN) — only the eager call had to stop throwing.

## Verification (artifact-level — this is a bundler `define`, no unit seam)

- **RED:** pre-fix `main.js` contained `fileURLToPath("file:///Users/<dev>/.../node_modules/@xenova/transformers/src/env.js")` — a baked absolute build-machine path (on CI: `/home/runner/...`).
- **GREEN:** post-fix the only `fileURLToPath(...)` is `fileURLToPath("file:///C:/mcp-tools-for-obsidian.ts")`; no `file:///Users/...` or `file:///home/runner/...` baked from that site.
- `bun run check`: all packages 0 errors.
- `bun test`: unaffected (the `define` touches only the bundled `main.js`, not `bun:test` which imports `src` directly). The only failures locally are the **pre-existing `bindWithFallback` port-27200 env flake** (documented), unrelated.
- [ ] **Windows load smoke required** before close — not reproducible on macOS/Linux. Load the built `main.js` in Obsidian on Windows, confirm no crash + semantic search still reaches the remote model.

## Out of scope (noted, not fixed here)

`onnxruntime-web` separately embeds `/…/node_modules/onnxruntime-web/dist` build-machine path **strings** in `main.js`. These do **not** crash (not `fileURLToPath`'d at load, and dead because wasmPaths is CDN-pinned) — a build-reproducibility/path-leak nit, separate from #100's crash. Can be a follow-up if we want byte-reproducible builds.

Reported by @nathancrum ([#100](https://github.com/istefox/obsidian-mcp-connector/issues/100)).