### PR TITLE
chore(0.4): root build script + main.js release provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,12 @@ jobs:
         with:
           subject-path: "packages/mcp-server/dist/*"
 
+      - name: Generate artifact attestation for the plugin bundle (0.4.x line)
+        if: steps.release_line.outputs.ships_binary != 'true'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: "main.js"
+
       - name: Get existing release body
         id: get_release_body
         uses: actions/github-script@v9
@@ -95,7 +101,8 @@ jobs:
             });
             return release.data.body || '';
 
-      - name: Upload plugin artifacts (always)
+      - name: Upload plugin artifacts (0.3.x line — includes convenience zip)
+        if: steps.release_line.outputs.ships_binary == 'true'
         env:
           GH_WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         uses: ncipollo/release-action@v1
@@ -114,6 +121,29 @@ jobs:
             ---
             ${{ steps.release_line.outputs.ships_binary == 'true' && '✨ This release includes attested build artifacts.' || '' }}
             ${{ steps.release_line.outputs.ships_binary == 'true' && format('📝 View attestation details in the [workflow run]({0})', env.GH_WORKFLOW_URL) || '' }}
+
+      - name: Upload plugin artifacts (0.4.x line — main.js and manifest.json only)
+        if: steps.release_line.outputs.ships_binary != 'true'
+        env:
+          GH_WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          omitName: true
+          tag: ${{ github.ref_name }}
+          # styles.css intentionally omitted — Svelte 5 inlines
+          # component CSS into main.js, no separate stylesheet is
+          # emitted by this build. ncipollo/release-action errors out
+          # if a literal (non-glob) artifact is missing.
+          # Convenience zip omitted — automated reviewer flagged
+          # additional files beyond main.js/manifest.json/styles.css.
+          artifacts: "main.js,manifest.json"
+          body: |
+            ${{ steps.get_release_body.outputs.result }}
+
+            ---
+            ${{ steps.release_line.outputs.ships_binary != 'true' && '✨ This release includes an attested build artifact (main.js).' || '' }}
+            ${{ steps.release_line.outputs.ships_binary != 'true' && format('📝 View attestation details in the [workflow run]({0})', env.GH_WORKFLOW_URL) || '' }}
 
       - name: Upload mcp-server binaries (0.3.x line only)
         if: steps.release_line.outputs.ships_binary == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,10 @@ name: Release
 
 # Release-line-aware workflow:
 #
-# - Plugin artifacts (manifest.json, main.js, obsidian-plugin-*.zip)
-#   are built and uploaded for EVERY tag, on both the 0.3.x and 0.4.x
-#   release lines.
+# - Plugin artifacts: the 0.3.x line uploads main.js + manifest.json +
+#   the obsidian-plugin-*.zip convenience archive + the cross-platform
+#   mcp-server binaries. The 0.4.x line uploads only main.js +
+#   manifest.json (no zip, no binary).
 #
 # - mcp-server cross-platform binaries are built and uploaded ONLY for
 #   tags on the 0.3.x line. The 0.4.x line ships an in-process MCP
@@ -119,8 +120,8 @@ jobs:
             ${{ steps.get_release_body.outputs.result }}
 
             ---
-            ${{ steps.release_line.outputs.ships_binary == 'true' && '✨ This release includes attested build artifacts.' || '' }}
-            ${{ steps.release_line.outputs.ships_binary == 'true' && format('📝 View attestation details in the [workflow run]({0})', env.GH_WORKFLOW_URL) || '' }}
+            ✨ This release includes attested build artifacts.
+            📝 View attestation details in the [workflow run](${{ env.GH_WORKFLOW_URL }})
 
       - name: Upload plugin artifacts (0.4.x line — main.js and manifest.json only)
         if: steps.release_line.outputs.ships_binary != 'true'
@@ -142,8 +143,8 @@ jobs:
             ${{ steps.get_release_body.outputs.result }}
 
             ---
-            ${{ steps.release_line.outputs.ships_binary != 'true' && '✨ This release includes an attested build artifact (main.js).' || '' }}
-            ${{ steps.release_line.outputs.ships_binary != 'true' && format('📝 View attestation details in the [workflow run]({0})', env.GH_WORKFLOW_URL) || '' }}
+            ✨ This release includes an attested build artifact (main.js).
+            📝 View attestation details in the [workflow run](${{ env.GH_WORKFLOW_URL }})
 
       - name: Upload mcp-server binaries (0.3.x line only)
         if: steps.release_line.outputs.ships_binary == 'true'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "packages/*"
   ],
   "scripts": {
+    "build": "bun --filter '@obsidian-mcp-tools/obsidian-plugin' build",
     "check": "bun --filter '*' check",
     "dev": "bun --filter '*' dev",
     "version": "bun scripts/version.ts",


### PR DESCRIPTION
Resolves the two automated-review recommendations: adds a root `build` script (fixes 'Build verification skipped'); adds main.js artifact attestation on the 0.4.x release line (mirrors the 0.3.x binary attestation, inverted gate); trims 0.4.x release assets to main.js,manifest.json. 0.3.x release path untouched. Verified: `bun run build` works (check + prod build green).