### PR TITLE
chore(0.4): automated-review lint cleanup + CLAUDE.md refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ One shipped component on the 0.4.x line:
 
 Why operations go through Obsidian APIs rather than reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the plugin invoke other Obsidian plugins (Templater, Dataview) through their APIs.
 
-Current versions (2026-05-09): **`main` ships 0.3.12** (stable, 20 MCP tools, stdio+binary architecture as described above), **`feat/http-embedded` ships 0.4.5** (released 2026-05-06, 26 MCP tools, in-process HTTP server inside the plugin, no binary; native semantic search via Transformers.js; see § Branch protection policy below). The `0.4.x` line has shipped 6 consecutive cycles (`0.4.0` → `0.4.5`, 5 soak-driven patches + 1 feature batch); a `[Unreleased]` block in `CHANGELOG.md` accumulates the `0.4.6` batch (currently #79 LRA port unhardcode, #78 migration UX, #88 ENOTEMPTY abs-path leak fix). License: MIT.
+Current lines: **`main` = 0.3.12** — the legacy stdio + standalone-binary architecture, retained only on the protected `main` branch (see § Branch protection policy). **`feat/http-embedded` = 0.4.6** — the active 0.4.x line: in-process HTTP MCP server inside the plugin, no binary, native semantic search via Transformers.js. The `packages/mcp-server` binary and `features/mcp-server-install` installer have been retired from the 0.4.x line. The `[Unreleased]` block in `CHANGELOG.md` accumulates the next cut; consult `CHANGELOG.md` for its current contents (do not enumerate here — it drifts). License: MIT.
 
 ### Fork status
 
@@ -161,9 +161,9 @@ Rules:
 
 Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are exposed.
 
-### Tools (20 total)
+### Tools (29 total, 0.4.x)
 
-**Vault file management** — `packages/obsidian-plugin/src/features/local-rest-api/index.ts`:
+**Vault file management** — `packages/obsidian-plugin/src/features/mcp-tools/tools/`:
 
 | Tool | Purpose |
 |---|---|
@@ -243,7 +243,6 @@ Full spec lives in `.clinerules`. Highlights:
 Active traps in the current tree. Historical bugs already fixed in the fork are in `git log` — don't clutter this list with them.
 
 - **`patches/svelte@5.16.0.patch`** forces Svelte to use `index-client.js` instead of `index-server.js` — required for Bun bundler compatibility. Re-verify if you upgrade Svelte.
-- **Self-signed HTTPS**: the server sets `process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"` inside `makeRequest.ts`. Removing or relocating this breaks every server→Obsidian call.
 - **`packages/obsidian-plugin/main.js` is the only shipped artifact** — CI regenerates it on tagged releases via `bun.config.ts`. Run `bun run build` from `packages/obsidian-plugin` locally; never commit the output.
 - **Version bumps must go through `bun run version`** — it atomically updates `package.json`, `manifest.json`, `versions.json` and creates the git commit + tag. Manual edits get out of sync.
 - **`packages/obsidian-plugin/main.js` is written at the package root, not `dist/`** — Obsidian expects that path. Do not move it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guidance for Claude Code (and similar AI agents) working in this repository.
 
 One shipped component on the 0.4.x line:
 
-1. **Obsidian plugin** — hosts an in-process HTTP MCP server (port 27200 default), writes `claude_desktop_config.json`, exposes all 26 MCP tools and prompts over streamable-HTTP. No separate binary. Semantic search via native Transformers.js (no Smart Connections dependency).
+1. **Obsidian plugin** — hosts an in-process HTTP MCP server (port 27200 default), writes `claude_desktop_config.json`, exposes all 29 MCP tools and prompts over streamable-HTTP. No separate binary. Semantic search via native Transformers.js (no Smart Connections dependency).
 
 Why operations go through Obsidian APIs rather than reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the plugin invoke other Obsidian plugins (Templater, Dataview) through their APIs.
 
@@ -290,7 +290,7 @@ Upstream `jacksteamdev/obsidian-mcp-tools` is **officially unmaintained** (decla
 Current state of the fork:
 
 - `main` at **0.3.12**, stable, on BRAT, fully functional (20 MCP tools, stdio+binary architecture). Protected per the policy above. HEAD `76fa012` 2026-04-28; tag stack `0.3.0` → `0.3.12`.
-- `feat/http-embedded` at **0.4.5** + `[Unreleased]` batch staged. Tag stack `0.4.0` → `0.4.5` (6 cycle iterativi shipped 2026-05-04 → 2026-05-06: stable cut + 4 soak-driven patches + 1 feature batch). Tools: 26 (base 20 + 1 graph batch in 0.4.4: `list_tags` + `get_files_by_tag` + `get_outgoing_links` + `get_backlinks` + 2 dir tools in 0.4.5: `create_vault_directory` + `delete_vault_directory`). `minAppVersion: 1.7.2`. Live in vault TEST via symlink; BRAT-distributed for community testers (folotp + grimlor + others tracked on issue `#54`).
+- `feat/http-embedded` at **0.4.5** + `[Unreleased]` batch staged. Tag stack `0.4.0` → `0.4.5` (6 cycle iterativi shipped 2026-05-04 → 2026-05-06: stable cut + 4 soak-driven patches + 1 feature batch). Tools: 29 (base 20 + 1 graph batch in 0.4.4: `list_tags` + `get_files_by_tag` + `get_outgoing_links` + `get_backlinks` + 2 dir tools in 0.4.5: `create_vault_directory` + `delete_vault_directory`). `minAppVersion: 1.7.2`. Live in vault TEST via symlink; BRAT-distributed for community testers (folotp + grimlor + others tracked on issue `#54`).
 - `[Unreleased]` batch on `feat/http-embedded` ready for `0.4.6` cut: #79 LRA port unhardcode (#90), #78 migration UX recurring Notice + `localTransport` field in `get_server_info` (#91), #88 `delete_vault_directory` ENOTEMPTY abs-path leak fix (#92). 0.4.6 cut gated on store PR #11919 acceptance — disciplina "no feature creep during review".
 - Community plugin store submission `obsidianmd/obsidian-releases#11919` open since 2026-04-13, automated lint cleared on 2026-04-18, **awaiting human review at week 4 of 2-8 typical window** (zero reviewer assignment as of 2026-05-09; labels `Changes requested` / `plugin` / `Additional review required` / `Skipped code scan` all from `github-actions[bot]` or `ObsidianReviewBot`, no human maintainer touch). Strategy = silence: any version bump or comment risks resetting the review queue, so post-cut work goes to `feat/http-embedded` without tagging until store accept lands.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,11 @@ Guidance for Claude Code (and similar AI agents) working in this repository.
 
 **MCP Tools for Obsidian** — a Model Context Protocol (MCP) bridge that lets AI clients such as Claude Desktop access an Obsidian vault for reading, writing, searching (text + semantic), and executing templates, without bypassing Obsidian itself.
 
-Two shipping components glued together by the Local REST API plugin:
+One shipped component on the 0.4.x line:
 
-1. **Obsidian plugin** — installs/updates a signed MCP server binary, writes `claude_desktop_config.json`, and exposes extra HTTP endpoints that the server calls back into (semantic search via Smart Connections, template execution via Templater).
-2. **MCP server binary** — long-lived subprocess launched by Claude Desktop over stdio. Translates MCP tool/prompt calls into HTTPS requests against the Obsidian Local REST API plugin on `127.0.0.1:27124`.
+1. **Obsidian plugin** — hosts an in-process HTTP MCP server (port 27200 default), writes `claude_desktop_config.json`, exposes all 26 MCP tools and prompts over streamable-HTTP. No separate binary. Semantic search via native Transformers.js (no Smart Connections dependency).
 
-Why the detour through Local REST API instead of reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the server invoke other Obsidian plugins (Templater, Smart Connections, Dataview) through their APIs.
+Why operations go through Obsidian APIs rather than reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the plugin invoke other Obsidian plugins (Templater, Dataview) through their APIs.
 
 Current versions (2026-05-09): **`main` ships 0.3.12** (stable, 20 MCP tools, stdio+binary architecture as described above), **`feat/http-embedded` ships 0.4.5** (released 2026-05-06, 26 MCP tools, in-process HTTP server inside the plugin, no binary; native semantic search via Transformers.js; see § Branch protection policy below). The `0.4.x` line has shipped 6 consecutive cycles (`0.4.0` → `0.4.5`, 5 soak-driven patches + 1 feature batch); a `[Unreleased]` block in `CHANGELOG.md` accumulates the `0.4.6` batch (currently #79 LRA port unhardcode, #78 migration UX, #88 ENOTEMPTY abs-path leak fix). License: MIT.
 
@@ -82,30 +81,26 @@ bun run release                       # Cross-platform release build
 bun run version [patch|minor|major]   # Atomic version bump + commit + tag
 ```
 
-Per-package notable scripts: `bun run inspector` in `packages/mcp-server` launches `@modelcontextprotocol/inspector` — **primary debugging tool** for server work. `bun run link` in `packages/obsidian-plugin` symlinks the built plugin into a local vault.
+Per-package notable scripts: `bun run link` in `packages/obsidian-plugin` symlinks the built plugin into a local vault.
 
 ## Architecture
 
 ### Layout
 
-- `packages/mcp-server/` — standalone MCP server, compiled to a binary
-- `packages/obsidian-plugin/` — Obsidian plugin (TS + Svelte 5)
+- `packages/obsidian-plugin/` — Obsidian plugin (TS + Svelte 5); contains the in-process MCP server (HTTP-embedded, 0.4.x)
 - `packages/shared/` — ArkType schemas, logger, cross-package types
 - `packages/test-site/` — SvelteKit harness, not part of the shipped product
 - `docs/` — architecture + feature specs (see References)
 - `.clinerules` — **authoritative architecture contract, read first**
 
-### Data flow
+### Data flow (0.4.x HTTP-embedded)
 
 ```
-Claude Desktop
-    │  stdio (JSON-RPC / MCP protocol)
+Claude Desktop / MCP client
+    │  HTTP / streamable-HTTP (MCP protocol)
     ▼
-mcp-server binary                      (reads env OBSIDIAN_API_KEY at startup)
-    │  HTTPS, self-signed cert, API key header
-    ▼
-Obsidian Local REST API plugin         (listens on 127.0.0.1:27124)
-    │  in-process function calls
+Obsidian plugin — in-process MCP server (0.4.x, port 27200 default)
+    │  in-process function calls + Local REST API for auth/vault ops
     ▼
 Obsidian (vault, Templater, Smart Connections, Dataview)
 ```
@@ -114,8 +109,7 @@ The MCP server **never** touches the vault filesystem directly, even when it wou
 
 ### Entry points
 
-- **Server**: `packages/mcp-server/src/index.ts` → instantiates `ObsidianMcpServer` (`features/core/index.ts`), wires the stdio transport, fans out feature registration.
-- **Plugin**: `packages/obsidian-plugin/src/main.ts` → `class McpToolsPlugin extends Plugin`, loads features via their `setup()` functions, registers the settings tab.
+- **Plugin** (also the MCP server host): `packages/obsidian-plugin/src/main.ts` → `class McpToolsPlugin extends Plugin`, loads features via their `setup()` functions, starts the in-process HTTP MCP server, registers the settings tab.
 - **Shared**: `packages/shared/src/index.ts` → re-exports logger and types.
 
 ### Feature-based architecture
@@ -169,7 +163,7 @@ Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are expos
 
 ### Tools (20 total)
 
-**Vault file management** — `packages/mcp-server/src/features/local-rest-api/index.ts`:
+**Vault file management** — `packages/obsidian-plugin/src/features/local-rest-api/index.ts`:
 
 | Tool | Purpose |
 |---|---|
@@ -250,7 +244,7 @@ Active traps in the current tree. Historical bugs already fixed in the fork are 
 
 - **`patches/svelte@5.16.0.patch`** forces Svelte to use `index-client.js` instead of `index-server.js` — required for Bun bundler compatibility. Re-verify if you upgrade Svelte.
 - **Self-signed HTTPS**: the server sets `process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"` inside `makeRequest.ts`. Removing or relocating this breaks every server→Obsidian call.
-- **`packages/mcp-server/dist/`** is gitignored — CI regenerates binaries on tagged releases. Run `bun run build` locally for `dist/mcp-server`, or the per-target scripts (`build:mac-arm64`, `build:mac-x64`, `build:linux`, `build:windows`), but never commit the output.
+- **`packages/obsidian-plugin/main.js` is the only shipped artifact** — CI regenerates it on tagged releases via `bun.config.ts`. Run `bun run build` from `packages/obsidian-plugin` locally; never commit the output.
 - **Version bumps must go through `bun run version`** — it atomically updates `package.json`, `manifest.json`, `versions.json` and creates the git commit + tag. Manual edits get out of sync.
 - **`packages/obsidian-plugin/main.js` is written at the package root, not `dist/`** — Obsidian expects that path. Do not move it.
 - **External modules in `bun.config.ts`** (`obsidian`, `@codemirror/*`, `@lezer/*`) must stay external. Bundling them breaks the plugin on load.
@@ -267,7 +261,7 @@ Active traps in the current tree. Historical bugs already fixed in the fork are 
 - Tests live next to the code (`*.test.ts`). Run a single file with `bun test <path>`; run a whole package with `cd packages/<name> && bun test`. There is no monorepo-wide fan-out today — run `bun run check` from the root, then `bun test` in each package.
 - **Plugin test infrastructure**:
   - `packages/obsidian-plugin/bunfig.toml` — `[test] preload` registers a synthetic `"obsidian"` module via `src/test-setup.ts`, so tests can import production modules that reference `Plugin`, `Notice`, `FileSystemAdapter`, `TFile`, etc.
-  - `packages/obsidian-plugin/src/test-setup.ts` — the module mock. `FileSystemAdapter` accepts an optional `basePath` for anchoring tests at a real temp directory. Production code never constructs it itself — Obsidian does — so the extra parameter is invisible to the ship build. Also stubs `Modal` (shallow base class with `onOpen`/`onClose` plumbing) and the `svelte` module's `mount`/`unmount` as recorders — every call is published on `globalThis.__svelteMockCalls.{mount,unmount}` so tests can both inspect component props (including callback handles like `onDecision`) and assert mount/unmount pairing. Tests that use these helpers must reset `__svelteMockCalls` in `beforeEach` for isolation.
+  - `packages/obsidian-plugin/src/test-setup.ts` — the module mock. `FileSystemAdapter` accepts an optional `basePath` for anchoring tests at a real temp directory. Production code never constructs it itself — Obsidian does — so the extra parameter is invisible to the ship build. Also stubs `Modal` (shallow base class with `onOpen`/`onClose` plumbing) and the `svelte` module's `mount`/`unmount` as recorders — every call is pushed to the exported `svelteMockCalls.{mount,unmount}` object so tests can both inspect component props (including callback handles like `onDecision`) and assert mount/unmount pairing. Tests that use these helpers must reset `svelteMockCalls` in `beforeEach` for isolation (`import { svelteMockCalls } from "$/test-setup"`; `svelteMockCalls.mount = []; svelteMockCalls.unmount = [];`).
   - `packages/obsidian-plugin/.env.test` — fake `GITHUB_DOWNLOAD_URL` / `GITHUB_REF_NAME` for the build-time `environmentVariables()` macro. Bun auto-loads when `bun test` runs.
   - **Stubbing `os.homedir()`**: use `spyOn(os, "homedir").mockReturnValue(tmpRoot)` — Bun/Node cache HOME early, so runtime `process.env.HOME = …` is not reliable. See `config.test.ts` and `uninstall.test.ts`.
   - **Installer integration tests** use real shell scripts as fake binaries (tmpdir, `mode: 0o755`) instead of mocking `child_process.exec`. See `status.integration.test.ts`. macOS-guarded (shebang approach is Unix-only).
@@ -280,11 +274,6 @@ Active traps in the current tree. Historical bugs already fixed in the fork are 
 
 1. **`bun run check`** (at repo root) — TypeScript strict check across all packages. Must pass.
 2. **Never bump version fields by hand.** Use `bun run version [patch|minor|major]`.
-
-**For changes in `packages/mcp-server/`:**
-
-3. **`bun test`** — existing tests must pass. Add tests when touching parsing or conversion logic.
-4. **`bun run inspector`** — verify new/modified tools register correctly, expose the expected schema, return well-formed MCP results.
 
 **For changes in `packages/obsidian-plugin/`:**
 
@@ -400,8 +389,7 @@ Implicit single-point responses to multi-point offers read as engagement loss �
 
 - `.clinerules` — authoritative feature architecture, ArkType conventions, error handling contract.
 - `docs/project-architecture.md` — monorepo overview (aligned with `.clinerules`).
-- `docs/features/mcp-server-install.md` — installer feature spec.
-- `docs/features/prompt-system.md` — authoritative reference for the prompt feature. Read before touching `packages/mcp-server/src/features/prompts/` or the template execution endpoint in the plugin.
+- `docs/features/prompt-system.md` — authoritative reference for the prompt feature. Read before touching the prompts feature or the template execution endpoint in the plugin.
 - `docs/design/issue-29-command-execution.md` — fork design review for Obsidian command execution (threat model, policy options, phased plan). Authoritative when resuming issue #29 / PR #47.
 - `CONTRIBUTING.md`, `SECURITY.md`.
 

--- a/packages/obsidian-plugin/src/features/command-permissions/services/commandPermissionModal.test.ts
+++ b/packages/obsidian-plugin/src/features/command-permissions/services/commandPermissionModal.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
+import { svelteMockCalls } from "$/test-setup";
 import { CommandPermissionModal } from "./commandPermissionModal";
 
 /**
@@ -10,8 +11,8 @@ import { CommandPermissionModal } from "./commandPermissionModal";
  *   - `Modal` from "obsidian" — stubbed in `test-setup.ts` with a
  *     minimal base class that invokes onOpen/onClose from open/close.
  *   - `mount`/`unmount` from "svelte" — stubbed in `test-setup.ts`
- *     with recorders that publish every call on
- *     `globalThis.__svelteMockCalls` so tests can:
+ *     with recorders that publish every call on the exported
+ *     `svelteMockCalls` object so tests can:
  *       1. read the props passed to the Svelte component (to access
  *          the `onDecision` callback that the component would invoke
  *          on a real click), and
@@ -26,19 +27,18 @@ import { CommandPermissionModal } from "./commandPermissionModal";
  * The tests respect that contract.
  */
 
-interface SvelteMockCalls {
+interface SvelteMockCallsLocal {
   mount: Array<{ component: unknown; options: { props?: unknown } }>;
   unmount: Array<unknown>;
 }
 
-function getSvelteMocks(): SvelteMockCalls {
-  return (globalThis as unknown as { __svelteMockCalls: SvelteMockCalls })
-    .__svelteMockCalls;
+function getSvelteMocks(): SvelteMockCallsLocal {
+  return svelteMockCalls;
 }
 
 function resetSvelteMocks(): void {
-  (globalThis as unknown as { __svelteMockCalls: SvelteMockCalls }).__svelteMockCalls =
-    { mount: [], unmount: [] };
+  svelteMockCalls.mount = [];
+  svelteMockCalls.unmount = [];
 }
 
 interface PromptProps {

--- a/packages/obsidian-plugin/src/features/command-permissions/services/permissionCheck.test.ts
+++ b/packages/obsidian-plugin/src/features/command-permissions/services/permissionCheck.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { Request, Response } from "express";
 import type { Plugin } from "obsidian";
+import { svelteMockCalls } from "$/test-setup";
 import type { CommandAuditEntry } from "../types";
 import { handleCommandPermissionRequest } from "./permissionCheck";
 
@@ -17,10 +18,10 @@ import { handleCommandPermissionRequest } from "./permissionCheck";
  *     methods the handler touches (`status`, `json`, `writableEnded`).
  *   - The real `CommandPermissionModal` class, running on top of the
  *     Modal + Svelte stubs installed by `test-setup.ts`. The stubs
- *     publish every Svelte `mount` call on
- *     `globalThis.__svelteMockCalls`, so the test body simulates a
- *     user click by pulling the `onDecision` callback out of the
- *     recorded props and invoking it.
+ *     publish every Svelte `mount` call on the exported
+ *     `svelteMockCalls` object, so the test body simulates a user
+ *     click by pulling the `onDecision` callback out of the recorded
+ *     props and invoking it.
  *
  * Note on the 30-second modal timeout: the production constant lives
  * inside `permissionCheck.ts` and is not overridable, so the timeout
@@ -31,7 +32,7 @@ import { handleCommandPermissionRequest } from "./permissionCheck";
 
 // -------- Svelte mock helpers (shared contract with test-setup.ts) --------
 
-interface SvelteMockCalls {
+interface SvelteMockCallsLocal {
   mount: Array<{ component: unknown; options: { props?: unknown } }>;
   unmount: Array<unknown>;
 }
@@ -45,14 +46,13 @@ interface PromptProps {
   onDecision: (decision: "allow-once" | "allow-always" | "deny") => void;
 }
 
-function getSvelteMocks(): SvelteMockCalls {
-  return (globalThis as unknown as { __svelteMockCalls: SvelteMockCalls })
-    .__svelteMockCalls;
+function getSvelteMocks(): SvelteMockCallsLocal {
+  return svelteMockCalls;
 }
 
 function resetSvelteMocks(): void {
-  (globalThis as unknown as { __svelteMockCalls: SvelteMockCalls }).__svelteMockCalls =
-    { mount: [], unmount: [] };
+  svelteMockCalls.mount = [];
+  svelteMockCalls.unmount = [];
 }
 
 /**

--- a/packages/obsidian-plugin/src/features/command-permissions/services/permissionCheck.ts
+++ b/packages/obsidian-plugin/src/features/command-permissions/services/permissionCheck.ts
@@ -147,9 +147,9 @@ async function awaitModalDecision(
     .waitForDecision()
     .then((decision): ModalOutcome => ({ kind: "decided", decision }));
 
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  let timeoutHandle: ReturnType<typeof activeWindow.setTimeout> | undefined;
   const timeoutPromise = new Promise<ModalOutcome>((resolve) => {
-    timeoutHandle = setTimeout(
+    timeoutHandle = activeWindow.setTimeout(
       () => resolve({ kind: "timeout" }),
       MODAL_TIMEOUT_MS,
     );
@@ -162,7 +162,7 @@ async function awaitModalDecision(
     }
     return outcome;
   } finally {
-    if (timeoutHandle) clearTimeout(timeoutHandle);
+    if (timeoutHandle) activeWindow.clearTimeout(timeoutHandle);
   }
 }
 

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -21,6 +21,19 @@
 
 import { mock } from "bun:test";
 
+// Obsidian injects `activeWindow` as a global (points to the focused Window
+// in popout-window scenarios). Tests run outside Obsidian, so we stub it to
+// the global timer functions so timer-dependent production code still works.
+// We delegate through an accessor so tests that swap `globalThis.setTimeout`
+// (e.g. the modal-timeout test) still take effect — activeWindow.setTimeout
+// reads the live globalThis binding at call time, not the one at setup time.
+(globalThis as unknown as { activeWindow: { setTimeout: typeof setTimeout; clearTimeout: typeof clearTimeout } }).activeWindow = {
+  setTimeout: ((...args: Parameters<typeof setTimeout>) =>
+    (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout(...args)) as typeof setTimeout,
+  clearTimeout: (...args: Parameters<typeof clearTimeout>) =>
+    (globalThis as unknown as { clearTimeout: typeof clearTimeout }).clearTimeout(...args),
+};
+
 void mock.module("obsidian", () => {
   class Notice {
     constructor(_message?: string, _timeout?: number) {}
@@ -182,7 +195,7 @@ void mock.module("obsidian", () => {
 /**
  * Mock Svelte's `mount`/`unmount` so we can exercise Obsidian Modal
  * lifecycle without a real DOM runtime. The mock records every call
- * on `globalThis.__svelteMockCalls` so tests can:
+ * on the exported `svelteMockCalls` object so tests can:
  *
  *   1. inspect the props passed to the component (including the
  *      `onDecision` callback);
@@ -190,15 +203,17 @@ void mock.module("obsidian", () => {
  *   3. assert that `unmount` was called with the same component ref
  *      that `mount` returned.
  *
- * Tests should reset the recorder in `beforeEach` to keep per-test
- * isolation (`(globalThis as any).__svelteMockCalls = { mount: [], unmount: [] }`).
+ * Tests should reset the recorder in `beforeEach` for isolation:
+ *   `import { svelteMockCalls } from "$/test-setup";`
+ *   `beforeEach(() => { svelteMockCalls.mount = []; svelteMockCalls.unmount = []; });`
  */
-interface SvelteMockCalls {
+export interface SvelteMockCalls {
   mount: Array<{ component: unknown; options: { props?: unknown } }>;
   unmount: Array<unknown>;
 }
 
-(globalThis as unknown as { __svelteMockCalls: SvelteMockCalls }).__svelteMockCalls = {
+/** Module-scoped Svelte mount/unmount recorder. Import in tests to read and reset. */
+export const svelteMockCalls: SvelteMockCalls = {
   mount: [],
   unmount: [],
 };
@@ -206,15 +221,11 @@ interface SvelteMockCalls {
 void mock.module("svelte", () => ({
   mount: (component: unknown, options: { props?: unknown }) => {
     const ref = { __mockRef: Symbol("svelte-mock-ref"), component, options };
-    (
-      globalThis as unknown as { __svelteMockCalls: SvelteMockCalls }
-    ).__svelteMockCalls.mount.push({ component, options });
+    svelteMockCalls.mount.push({ component, options });
     return ref;
   },
   unmount: (ref: unknown) => {
-    (
-      globalThis as unknown as { __svelteMockCalls: SvelteMockCalls }
-    ).__svelteMockCalls.unmount.push(ref);
+    svelteMockCalls.unmount.push(ref);
   },
 }));
 

--- a/packages/test-site/eslint.config.js
+++ b/packages/test-site/eslint.config.js
@@ -10,10 +10,10 @@ const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
 export default ts.config(
 	includeIgnoreFile(gitignorePath),
 	js.configs.recommended,
-	...ts.configs.recommended,
-	...svelte.configs['flat/recommended'],
+	ts.configs.recommended,
+	svelte.configs['flat/recommended'],
 	prettier,
-	...svelte.configs['flat/prettier'],
+	svelte.configs['flat/prettier'],
 	{
 		languageOptions: {
 			globals: {


### PR DESCRIPTION
Phase 4 lint/quality cleanup.

## Changes

- **command-permissions** (`permissionCheck.ts`): use `activeWindow.setTimeout/clearTimeout` for popout-window compatibility (Obsidian guideline).
- **test-setup.ts**: add `activeWindow` global stub that delegates to live `globalThis` timers (so the modal-timeout test's `setTimeout` swap still takes effect). Replace `globalThis.__svelteMockCalls` recorder with a module-scoped `export const svelteMockCalls` — clears the globalThis lint flag on a test-only preload; test files updated to `import { svelteMockCalls } from "$/test-setup"`.
- **test-site `eslint.config.js`**: pass arrays directly to `ts.config()` instead of spreading (avoids `InfiniteDepthConfigWithExtends` typing quirk; `ESLINT-CONFIG-OK` verified).
- **CLAUDE.md**: drop all stale `packages/mcp-server` / `features/mcp-server-install` / `bun run inspector` / stdio-binary architecture references retired by Phases 1-2. Update data flow diagram, project description, layout, entry points, tool table header, gotchas, pre-commit checklist, and References.
- **npm-run-all**: retained — `run-s` is used by `packages/obsidian-plugin/package.json` release script.

## Verification

- `bun run check`: all packages Exited with code 0
- `bun test` (obsidian-plugin): 724 pass, 3 fail — all failures are `bindWithFallback` pre-existing flake only
- Prod build: `Build successful`
- `bun test src/features/command-permissions`: 100 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)