### PR TITLE
fix(build): compile Svelte with dev:false in production

### DIFF
--- a/packages/obsidian-plugin/bun.config.ts
+++ b/packages/obsidian-plugin/bun.config.ts
@@ -74,7 +74,7 @@ const sveltePlugin: BunPlugin = {
           filename: parsed.base,
 					generate: "client",
 					css: "injected",
-					dev: isProd,
+					dev: !isProd,
 				});
 
 				return {


### PR DESCRIPTION
One-line fix: bun.config.ts passed `dev: isProd` to Svelte compile(), shipping prod builds in Svelte DEV mode (runtime checks + bundle bloat) — inverted vs every sibling isProd option. Now `dev: !isProd`. Verified: prod build OK; main.js bytes BEFORE→AFTER (decrease, see report); bun run check 3/3; tests flake-only. Pre-existing defect surfaced during the score-to-100 review.