### PR TITLE
docs: sync all docs to standalone 0.4.8 / store-accepted reality

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -4,9 +4,9 @@
 
 ```
 packages/
-├── mcp-server/        # Server implementation
-├── obsidian-plugin/   # Obsidian plugin
-└── shared/           # Shared utilities and types
+├── obsidian-plugin/   # The plugin: in-process MCP server, tools, settings UI
+├── shared/            # Shared ArkType schemas and types
+└── test-site/         # SvelteKit harness (dev-only, not shipped)
 ```
 
 ## Features

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ For questions or general help, use Discord: https://discord.gg/q59pTrN9AA
 - **OS**: (e.g., macOS 14.2, Windows 11, Ubuntu 22.04)
 - **Obsidian version**: (e.g., 1.7.7)  
 - **Claude Desktop version**: (e.g., 1.0.2)
-- **Plugin version**: (e.g., 0.2.23)
+- **Plugin version**: (e.g., 0.4.8)
 - **Required plugins status**:
   - [ ] Local REST API installed and configured
   - [ ] Smart Connections installed (if using semantic search)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -30,7 +30,7 @@ For discussions about ideas, use Discord: https://discord.gg/q59pTrN9AA
 ## Implementation Notes
 <!-- 
 Optional: Technical details if you have ideas about implementation
-- Which package would this affect? (mcp-server, obsidian-plugin, shared)
+- Which package would this affect? (obsidian-plugin, shared)
 - Any specific Obsidian plugins this would integrate with?
 - MCP protocol considerations?
 -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code (and similar AI agents) working in this repository.
 
 ## Project
 
-**MCP Tools for Obsidian** — a Model Context Protocol (MCP) bridge that lets AI clients such as Claude Desktop access an Obsidian vault for reading, writing, searching (text + semantic), and executing templates, without bypassing Obsidian itself.
+**MCP Connector** — a Model Context Protocol (MCP) bridge that lets AI clients such as Claude Desktop access an Obsidian vault for reading, writing, searching (text + semantic), and executing templates, without bypassing Obsidian itself.
 
 One shipped component on the 0.4.x line:
 
@@ -12,13 +12,13 @@ One shipped component on the 0.4.x line:
 
 Why operations go through Obsidian APIs rather than reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the plugin invoke other Obsidian plugins (Templater, Dataview) through their APIs.
 
-Current line: **`main` = 0.4.7** — the standalone in-process HTTP MCP server (promoted 2026-05-16); no separate binary, native semantic search via Transformers.js. The `packages/mcp-server` binary and `features/mcp-server-install` installer are retired. The 0.3.x stdio/binary line is archived at `archive/main-0.3.12` (abandoned; tags retained). The `[Unreleased]` block in `CHANGELOG.md` accumulates the next cut; consult `CHANGELOG.md` for its current contents (do not enumerate here — it drifts). License: MIT.
+Current line: **`main` = 0.4.8** — the standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16); no separate binary, native semantic search via Transformers.js. **Accepted & listed in the Obsidian community plugin store** (id `mcp-tools-istefox`, 2026-05-16; Obsidian shows a standard "not manually reviewed by Obsidian staff" disclaimer — automated review path). The `packages/mcp-server` binary and `features/mcp-server-install` installer are retired. The 0.3.x stdio/binary line is archived at `archive/main-0.3.12` (abandoned; tags retained). The `[Unreleased]` block in `CHANGELOG.md` accumulates the next cut; consult `CHANGELOG.md` for its current contents (do not enumerate here — it drifts). License: MIT.
 
 ### Branch protection policy
 
-**`main` is the production line** — standalone in-process HTTP MCP server, currently **0.4.7** (promoted 2026-05-16). The historical rule "don't merge `feat/http-embedded` → `main` until Stefano decides the 0.4.0 bump" is **discharged**: the promotion has happened; `main` IS the 0.4.x line. Normal branch + PR discipline now applies.
+**`main` is the production line** — standalone in-process HTTP MCP server, currently **0.4.8** (0.4.x promoted to `main` 2026-05-16; accepted & listed in the Obsidian community store). The historical rule "don't merge `feat/http-embedded` → `main` until Stefano decides the 0.4.0 bump" is **discharged**: the promotion has happened; `main` IS the 0.4.x line. Normal branch + PR discipline now applies.
 
-`feat/http-embedded` is a residual dev branch that became equal to `main` at promotion time. `main` is authoritative going forward; `feat/http-embedded` may be used for in-flight work or left as a historical marker — it no longer has "pre-release" status.
+`feat/http-embedded` was **retired (deleted from origin) 2026-05-16** — it was 0-ahead/29-behind `main` at the time, so nothing was lost (it was removed from the `General` ruleset first, keeping `main` protection intact). `main` is the sole, authoritative line.
 
 The 0.3.x stdio/binary line is **archived at `archive/main-0.3.12`** (do not delete it or its tags; users on old installs may reference them). Active development against 0.3.x is abandoned.
 
@@ -34,7 +34,7 @@ If a request seems likely to compromise `main`'s functionality, stop and ask bef
 
 **GitHub Rulesets active on `istefox/obsidian-mcp-connector`** (since 2026-05-05):
 
-- **`General`** (branch): targets `main` + `feat/http-embedded`, rules: Restrict deletions + Block force pushes.
+- **`General`** (branch): targets `main` (`~DEFAULT_BRANCH`) only — `feat/http-embedded` was removed from it when that branch was retired 2026-05-16. Rules: Restrict deletions + Block force pushes.
 - **`main-strict`** (branch): targets `main` only, rule: Require pull request before merging (0 approvals). Direct push to `main` will be REJECTED.
 - **`tags-protection`** (tag): targets pattern `0.*` (covers 0.1.x through 0.9.x), rules: Restrict updates + Restrict deletions + Block force pushes.
 
@@ -47,7 +47,7 @@ If you ever encounter a "GH013: Repository rule violations" error, the operation
 | Layer | Tech |
 |---|---|
 | Monorepo | Bun workspaces (`bun.lock`) — **do not use npm/yarn/pnpm** |
-| Toolchain pinning | `mise.toml` (bun latest) |
+| Toolchain pinning | `mise.toml` + `release.yml` (bun pinned `1.3.12` — reproducible builds; do not revert to `latest`) |
 | Language | TypeScript 5, strict mode, `verbatimModuleSyntax: true` |
 | Runtime validation | **ArkType** (`arktype` 2.0.0-rc.30) at every external boundary |
 | MCP | `@modelcontextprotocol/sdk` 1.29.0 |
@@ -56,8 +56,8 @@ If you ever encounter a "GH013: Repository rule violations" error, the operation
 | HTML→Markdown | Turndown 7.2 |
 | Test | `bun:test` (native) |
 | Format | Prettier 3 (`.prettierrc.yaml`) — 2-space indent, 80 col |
-| Build | `bun build --compile` for the server binary, custom `bun.config.ts` for the plugin |
-| CI | GitHub Actions (`.github/workflows/release.yml`) — cross-platform binaries + SLSA provenance |
+| Build | `packages/obsidian-plugin/bun.config.ts` (Bun bundler) → plugin `main.js`. No binary. `__dirname`/`__filename`/`import.meta.*` are neutralized in the `define` block for a reproducible cross-machine bundle (Obsidian store build-verification) |
+| CI | GitHub Actions (`.github/workflows/release.yml`, tag-triggered) — plugin-only release assets (`main.js` + `manifest.json`) + GitHub build-provenance attestation |
 
 Path alias inside every package: **`$/*` → `src/*`**. Use it instead of relative imports across feature boundaries.
 
@@ -175,11 +175,11 @@ Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are expos
 | `search_vault` | Search via Dataview DQL or JsonLogic query. |
 | `search_vault_simple` | Plain text search with context window. |
 
-**Semantic search** — `features/smart-connections/index.ts`:
+**Semantic search** — `features/semantic-search/` (native Transformers.js MiniLM embedder, WASM CDN-pinned, in-process — no Smart Connections required):
 
 | Tool | Purpose |
 |---|---|
-| `search_vault_smart` | Semantic search delegated to the Smart Connections plugin (`/search/smart` endpoint registered by this repo's plugin). Supports folder include/exclude filters and result limits. |
+| `search_vault_smart` | Semantic search via the bundled native Transformers.js MiniLM provider. Smart Connections is an optional alternative backend selectable via the provider setting (`providerFactory`), not a dependency. Supports folder include/exclude filters and result limits. |
 
 **Templater integration** — `features/templates/index.ts`:
 
@@ -244,7 +244,7 @@ Active traps in the current tree. Historical bugs already fixed are in `git log`
 - **`execute_template.createFile`** is typed as the string `"true"|"false"` (not boolean) because older MCP clients serialize booleans as strings — explicit workaround in `features/templates/index.ts`, kept as belt-and-suspenders for SDK 1.29.0.
 - **`plugin.loadData()` / `plugin.saveData()` are NOT atomic** — default Obsidian persistence is two independent async calls. Any feature doing `load → modify → save` in response to concurrent events MUST serialize with a mutex. See `features/command-permissions/services/settingsLock.ts` for the canonical implementation + 35-way regression test.
 - **Command-permission policy invariants** — `features/command-permissions/` is the security boundary for `execute_obsidian_command`. Whenever you touch `permissionCheck.ts`, preserve these load-bearing properties: (1) **deny by default** — `enabled !== true` short-circuits to deny BEFORE any allowlist check; (2) **two-phase mutex** — Phase A (load + decide-or-detect-modal-needed + save-on-fast-path) holds the lock; modal wait runs OUTSIDE the lock; Phase B (re-load + persist final outcome) re-acquires it, so concurrent requests serialize their I/O without serializing user interaction; (3) **the destructive heuristic is a nudge, not a gate** — matching commands disable "Allow always" but "Allow once" still works; presets in `presets.ts` MUST exclude every word the regex catches; (4) **allowlist entries are exact ids** — no wildcard support, deliberate. The full threat model and option matrix lives in `docs/design/issue-29-command-execution.md` — read it before changing the policy shape.
-- **Every `from "obsidian"` import in `packages/shared/` must be `import type`.** The npm `obsidian` package ships only `.d.ts`; Obsidian injects the runtime module at plugin load. A value import survives `verbatimModuleSyntax` and fails `bun build --compile` with `Could not resolve "obsidian"`. The `packages/obsidian-plugin/` package is fine — value imports there are legitimate.
+- **Every `from "obsidian"` import in `packages/shared/` must be `import type`.** The npm `obsidian` package ships only `.d.ts`; Obsidian injects the runtime module at plugin load. A value import survives `verbatimModuleSyntax` and fails the plugin bundle build (`bun.config.ts`) with `Could not resolve "obsidian"`. The `packages/obsidian-plugin/` package is fine — value imports there are legitimate.
 
 ## Testing & CI
 
@@ -277,18 +277,18 @@ Active traps in the current tree. Historical bugs already fixed are in `git log`
 
 ## Project status (2026-05-16)
 
-- `main` at **0.4.7** — standalone in-process HTTP MCP server (promoted 2026-05-16). Tools: 29. `minAppVersion: 1.7.2`. BRAT-distributed for community testers. Tag stack `0.4.0` → `0.4.7`.
+- `main` at **0.4.8** — standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16). Tools: 29. `minAppVersion: 1.7.2`. Distributed via the **Obsidian community store** (accepted & listed, id `mcp-tools-istefox`) **and** BRAT. Tag stack `0.4.0` → `0.4.8`.
 - `archive/main-0.3.12` — the retired 0.3.x stdio/binary line (20 MCP tools). Preserved for historical reference; HEAD `76fa012` 2026-04-28; tag stack `0.3.0` → `0.3.12`. No active development.
-- Community plugin store submission `obsidianmd/obsidian-releases#11919` open since 2026-04-13, automated lint cleared on 2026-04-18, **awaiting human review**. Consult `CHANGELOG.md` for the current `[Unreleased]` state.
+- **Community store: ACCEPTED & LISTED** (2026-05-16) — id `mcp-tools-istefox` in `obsidianmd/obsidian-releases/community-plugins.json`; installable in-app + via BRAT. Obsidian shows a standard "not manually reviewed by Obsidian staff" disclaimer (automated review path; high-risk `fs`/`child_process` capability disclosures, which are intrinsic and were deliberately NOT removed). The legacy PR-based submission `obsidianmd/obsidian-releases#11919` was closed (process moved to the community.obsidian.md portal). Consult `CHANGELOG.md` for the current `[Unreleased]` state.
 
 ## Pending work
 
 Items in flight, ordered by priority:
 
-1. **Store PR #11919 monitor** — passive wait. Routine `trig_015yL8D3VNao7nhRKjBu95ZK` (Mondays 07:00 UTC = 09:00 Rome CEST / 08:00 Rome CET) checks weekly and notifies only on real activity. The hourly issue `#79` watcher `trig_01Dx8sZTD78yBj7buuVYP9KE` remains active for orthogonal scope.
-2. **Next version cut**: when ready, run `bun run version patch` + tag push; CI `release.yml` produces release artifacts. Consult `CHANGELOG.md` `[Unreleased]` for current pending entries.
-3. **Marcoaperez next PR** (passive): inventory of 5+ tools agreed (`get_recent_files` / `get_document_map` / `get_periodic_note` family / `execute_dataview_query` / `get_vault_files`). PR #83 `list_tags` shipped 2026-05-05; next contribution stochastic in 1-2 week window. Mock infra `setMockFileStat()` already in `main` to be consumed when PR arrives.
-4. **Community store listing**: gated on store PR #11919 acceptance.
+1. **Next version cut**: when ready, branch + PR a `manifest.json`/`package.json`/`versions.json`/`CHANGELOG` bump + tag push; CI `release.yml` produces plugin-only release artifacts (reproducible bundle + build-provenance attestation). Roll forward only — never reuse or move a published `0.*` tag.
+2. **Owner-only, non-blocking**: (a) GitHub fork-network detach is CLOSED won't-do (only path is destructive — accept the "forked from" badge + the suppressed Contributors UI); (b) Windows #100 load smoke unperformed but field-corroborated by the reporter — non-blocking; roll forward to a patch release if it ever regresses.
+
+The community-store listing is DONE (accepted & listed 2026-05-16). The fork-era external-contribution pipeline tracking no longer applies — the project is standalone; contributions are evaluated per-PR on their merits.
 
 Items resolved and out of "pending":
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to MCP Tools for Obsidian
+# Contributing to MCP Connector
 
 ## Community Standards
 
@@ -59,9 +59,9 @@ Think before you post. Ask yourself:
 ### Monorepo Structure
 ```
 packages/
-├── mcp-server/        # TypeScript MCP server implementation
-├── obsidian-plugin/   # Obsidian plugin (TypeScript/Svelte)
-└── shared/           # Shared utilities and types
+├── obsidian-plugin/   # The plugin: in-process MCP server, tools, settings UI (TypeScript/Svelte)
+├── shared/            # Shared ArkType schemas and types
+└── test-site/         # SvelteKit harness (dev-only, not shipped)
 ```
 
 ### Feature-Based Architecture
@@ -119,11 +119,10 @@ packages/
    - Creates git commit and tag
    - Pushes to GitHub
 
-2. **Automated build**: GitHub Actions handles:
-   - Cross-platform binary compilation
-   - SLSA provenance attestation  
-   - Release artifact upload
-   - Security verification
+2. **Automated build**: GitHub Actions (`release.yml`, tag-triggered) handles:
+   - Plugin bundle build (`bun.config.ts` → `main.js`) — no binary
+   - GitHub build-provenance attestation for `main.js`
+   - Release artifact upload (`main.js` + `manifest.json`)
 
 3. **Release notes**: GitHub automatically generates release notes from PRs
 
@@ -148,7 +147,7 @@ bun test
 
 # Integration testing with local vault
 # 1. Set up test Obsidian vault
-# 2. Install plugin locally: `bun run build:plugin`
+# 2. Build plugin locally: `bun run build` (outputs main.js + manifest.json at repo root)
 # 3. Test MCP server connection with Claude Desktop
 # 4. Verify all features work end-to-end
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ When connected to an MCP-compatible client, this plugin enables:
 
 ### Required
 
-- [Obsidian](https://obsidian.md/) v1.7.7 or higher.
+- [Obsidian](https://obsidian.md/) v1.7.2 or higher.
 - An MCP-compatible client. Examples: [Claude Desktop](https://claude.ai/download), [Claude Code](https://docs.anthropic.com/claude/docs/claude-code), [Cursor](https://cursor.com), [Cline](https://github.com/cline/cline), [Continue](https://continue.dev), [Windsurf](https://codeium.com/windsurf), [VS Code](https://code.visualstudio.com).
 - For **Claude Desktop only**: [Node.js](https://nodejs.org) (any LTS version) — required to run the `npx mcp-remote` bridge. The plugin auto-detects your Node install (including Homebrew on macOS) and offers a one-click install if missing.
 
@@ -52,18 +52,18 @@ When connected to an MCP-compatible client, this plugin enables:
 
 ## Installation
 
-There are two install paths depending on whether MCP Connector has finished community-store review.
+MCP Connector is available in the Obsidian community plugin store **and** via BRAT — use either.
 
-### Option A — Community plugin store (once approved)
+### Option A — Community plugin store
 
-1. **Settings → Community plugins → Browse**, search **"MCP Connector"** by Stefano Ferri.
-2. Install + Enable.
+1. **Settings → Community plugins → Browse**, search **"MCP Connector"**.
+2. Install + Enable. Obsidian shows a *"This plugin has not been manually reviewed by Obsidian staff"* notice — community plugins pass an automated build/security review, not a hand audit.
 3. The first-load migration modal opens if you have a 0.3.x install — confirm or skip the steps it proposes (see [Migration from 0.3.x](#migration-from-03x) below).
 4. Open the plugin settings and use the **Quick setup for clients** section to wire up your MCP client.
 
-### Option B — BRAT (available immediately)
+### Option B — BRAT
 
-While the community-store entry is in review, install via [BRAT](https://github.com/TfTHacker/obsidian42-brat):
+Prefer the latest build, or the store entry hasn't propagated to your client yet? Install via [BRAT](https://github.com/TfTHacker/obsidian42-brat):
 
 1. Install and enable the **Obsidian42 — BRAT** plugin from the community store.
 2. **Settings → BRAT → Add Beta plugin**, paste `istefox/obsidian-mcp-connector`.
@@ -330,8 +330,7 @@ This project uses a Bun monorepo with a feature-based architecture. For the full
 
 ```
 packages/
-├── mcp-server/        # In-process MCP server (registered tools, ToolRegistry)
-├── obsidian-plugin/   # Obsidian plugin (settings UI, migration modal, transport)
+├── obsidian-plugin/   # The plugin: in-process MCP server, registered tools, settings UI, migration modal, transport
 ├── shared/            # Shared ArkType schemas and types
 └── test-site/         # SvelteKit harness (dev-only, not shipped)
 ```
@@ -357,7 +356,7 @@ The plugin's `main.js` is written at the package root (`packages/obsidian-plugin
 **Before contributing, please read our [Contributing Guidelines](CONTRIBUTING.md) including our community standards and behavioral expectations.**
 
 1. Fork the repository.
-2. Create a feature branch from `main` (bug fix on the 0.3.x line) or `feat/http-embedded` (0.4.x work).
+2. Create a feature branch from `main`.
 3. Make your changes; keep PRs scoped.
 4. Run tests:
    ```bash
@@ -376,7 +375,7 @@ We welcome genuine contributions but maintain strict community standards. Be res
 
 ## Changelog
 
-See [GitHub Releases on this fork](https://github.com/istefox/obsidian-mcp-connector/releases) and [`CHANGELOG.md`](CHANGELOG.md) for the detailed changelog.
+See [GitHub Releases](https://github.com/istefox/obsidian-mcp-connector/releases) and [`CHANGELOG.md`](CHANGELOG.md) for the detailed changelog.
 
 ## Other MCP servers by istefox
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,7 +72,7 @@ The following are **explicitly not** addressed by this plugin's security model. 
 
 ## Legacy 0.3.x Considerations
 
-The 0.3.x line (`main` branch) ships a different architecture: a standalone Go MCP server binary launched by Claude Desktop over stdio, communicating with Obsidian via the [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin over HTTPS with a self-signed certificate.
+The 0.3.x line (abandoned; archived at the `archive/main-0.3.12` branch — no longer `main`) shipped a different architecture: a standalone Go MCP server binary launched by Claude Desktop over stdio, communicating with Obsidian via the [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin over HTTPS with a self-signed certificate.
 
 For 0.3.x users, the binary distribution is secured by:
 
@@ -89,7 +89,7 @@ The 0.4.x release pipeline (per `release.yml` split, PR #62) only emits attestat
 
 | Version | Status | Security policy |
 |---|---|---|
-| **0.4.x** | **Current — full support** | Critical and high vulnerabilities patched; plugin-only release line. Latest: `0.4.7` (2026-05-16). |
+| **0.4.x** | **Current — full support** | Critical and high vulnerabilities patched; plugin-only release line. Latest: `0.4.8` (2026-05-16). |
 | **0.3.x** | Legacy — critical fixes only | Binary release line for users on the standalone-server architecture. Patched only for actively exploited or data-loss-class issues. Latest: `0.3.12` (2026-04-28). |
 | 0.2.x and earlier | End of life | No support. Users should migrate to `0.4.0` (or `0.3.12` if the binary architecture is required). |
 
@@ -101,7 +101,7 @@ Time-to-patch targets, measured from confirmed report:
 - **High** (privilege escalation within the documented threat model, authentication bypass requiring local access, persistent unauthorized state changes): patch within 30 days.
 - **Moderate / Low**: addressed in the next regular release.
 
-Patches for the 0.4.x line ship as new tags on the `feat/http-embedded` → `main` track. Patches for the 0.3.x line ship from the `main` branch as 0.3.x tags.
+Patches for the 0.4.x line ship as new tags on `main` (roll forward only — published `0.*` tags are immutable). Any critical-only 0.3.x patch would ship from the archived `archive/main-0.3.12` branch as a new 0.3.x tag.
 
 ## Best Practices for Users
 

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,5 +1,7 @@
 # Migration Plan
 
+> **⚠️ HISTORICAL / SUPERSEDED (kept for reference).** This was the pre-0.4 reorganization plan; it references the now-removed `mcp-server` / `mcp-server-install` pieces. The 0.4.x in-process migration is **complete** — for the current architecture see [`docs/project-architecture.md`](project-architecture.md). Do not treat this as an active plan.
+
 This document outlines the step-by-step plan to migrate the current codebase to the new project architecture.
 
 ## Phase 1: Project Structure Setup

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mcp-tools-for-obsidian",
   "version": "0.4.8",
   "private": true,
-  "description": "Securely connect Claude Desktop to your Obsidian vault with semantic search, templates, and file management capabilities.",
+  "description": "Connect MCP-compatible clients (Claude Desktop, Claude Code, Cline) to your Obsidian vault with semantic search, templates, file management and gated command execution.",
   "tags": [
     "obsidian",
     "plugin",


### PR DESCRIPTION
Audit-driven documentation drift fix (9 files, docs-only, no code change). Aligns README/CLAUDE/CONTRIBUTING/SECURITY/.clinerules/issue-templates/package.json/migration-plan with the current reality: standalone, 0.4.8, accepted & listed in the Obsidian community store (with the honest 'not manually reviewed' disclaimer), no mcp-server, feat/http-embedded retired, native semantic search, plugin-only build, bun pinned. LICENSE + CHANGELOG history untouched.