### PR TITLE
chore(comments): strip stale phase/task-ID narration from source

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/autoWrite.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/autoWrite.ts
@@ -4,7 +4,7 @@ import { updateClaudeDesktopConfig } from "./claudeDesktop";
 /**
  * Auto-write Claude Desktop config glue.
  *
- * The Settings UI exposes an opt-in toggle (default OFF, per design D6)
+ * The Settings UI exposes an opt-in toggle (default OFF)
  * that, when ON, automatically rewrites `claude_desktop_config.json`
  * whenever the bearer token rotates or the HTTP server's port changes.
  * This module owns the read/write of that flag and the one-shot sync

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/generators.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/generators.ts
@@ -3,7 +3,7 @@ import { FORK_PLUGIN_ID } from "./claudeDesktop";
 
 /**
  * Pure JSON generators for the three MCP client families the plugin
- * targets (per design D6). Each function returns the inner
+ * targets. Each function returns the inner
  * `mcpServers` entry only — the UI calls `wrapInMcpServers()` if it
  * wants the full ready-to-paste block.
  *

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.ts
@@ -4,7 +4,7 @@ import { existsSync } from "fs";
 import os from "os";
 
 /**
- * Node.js presence + version detection (Phase 4 T9).
+ * Node.js presence + version detection.
  *
  * Background: Claude Desktop's bridge to the in-process HTTP MCP
  * server goes through `npx mcp-remote`. `npx` requires Node.js on

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
@@ -8,7 +8,7 @@ import {
 } from "./nodeDetect";
 
 /**
- * `mcp-remote` pre-warm (Phase 4 T10).
+ * `mcp-remote` pre-warm.
  *
  * The Claude Desktop bridge runs `npx -y mcp-remote ...` at every
  * launch; if the package is not in the npm cache, the first invocation

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
@@ -51,7 +51,7 @@ function errorResult(text: string): ToolResult {
  * Handler for the `search_vault_smart` MCP tool.
  *
  * Dispatches through `plugin.semanticSearchState.provider`, which is
- * picked by the Phase 3 provider factory based on the user's tri-state
+ * picked by the provider factory based on the user's tri-state
  * setting (native / smart-connections / auto). The tool no longer
  * knows or cares which backend services the search — it only forwards
  * the query and filters to the active provider, then JSON-serializes

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -55,7 +55,7 @@ export async function createMcpService(
     pluginVersion: config.pluginVersion,
   });
 
-  // Apply the user's `toolToggle.disabled` filter (Phase 4 T12.c).
+  // Apply the user's `toolToggle.disabled` filter.
   // Disabled tools stay registered but are flipped off the registry's
   // enabled set, so they no longer appear in `tools/list` and any
   // `tools/call` against them returns MethodNotFound. Idempotent.

--- a/packages/obsidian-plugin/src/features/migration/services/setup.ts
+++ b/packages/obsidian-plugin/src/features/migration/services/setup.ts
@@ -10,7 +10,7 @@ import { executeSteps, planMigration, type MigrationContext } from "./plan";
 import { MigrationModalHost } from "./migrationModalHost";
 
 /**
- * First-load wiring for the migration modal (Phase 4 T8).
+ * First-load wiring for the migration modal.
  *
  * Called from `main.ts:onload` after the HTTP transport has been set
  * up so the live `port` + `bearerToken` are available. Does the

--- a/packages/obsidian-plugin/src/features/semantic-search/index.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/index.ts
@@ -59,7 +59,7 @@ export type SemanticSearchState = {
   /**
    * Closure mapping `SemanticSearchSettings` to the matching
    * provider. Present iff `setup()` was called with `factoryDeps`.
-   * The settings UI (T12) calls this on a tri-state change to swap
+   * The settings UI calls this on a tri-state change to swap
    * `state.provider` without rebuilding the embedder/store.
    * Optional in the type so test fixtures can construct partial
    * state shapes; populated to either ProviderChooser or null at
@@ -67,20 +67,20 @@ export type SemanticSearchState = {
    */
   chooser?: ProviderChooser | null;
   /**
-   * Reference to the model downloader so the settings UI (T13) can
+   * Reference to the model downloader so the settings UI can
    * subscribe to the first-run download progress without importing
-   * internal feature plumbing. Wired by T15 production setup;
+   * internal feature plumbing. Wired by production setup;
    * absent in tests and in the early lifecycle.
    */
   downloader?: ModelDownloader | null;
   /**
-   * The constructed indexer (live or low-power per setting) when
-   * Phase 3 is wired. Not auto-started — the search tool calls
-   * `startIndexerIfNeeded()` on first use (Q4 = lazy).
+   * The constructed indexer (live or low-power per setting), when
+   * present. Not auto-started — the search tool calls
+   * `startIndexerIfNeeded()` on first use (lazy).
    */
   indexer?: SemanticIndexer | null;
   /**
-   * The embedding store, wired by T15 production setup. Used by the
+   * The embedding store, wired by production setup. Used by the
    * settings UI to surface the indexed-chunks count.
    */
   store?: EmbeddingStore | null;
@@ -181,11 +181,10 @@ export async function setup(
     const settingsMutex = createMutex();
     const settings = await loadAndPersistSettings(plugin, settingsMutex);
 
-    // Phase 3 T8: if factoryDeps is supplied, construct the chooser
-    // and pick the provider matching the user's tri-state setting.
-    // Without deps, the state holds a NoopProvider; T11 will supply
-    // the real deps from main.ts after the embedder + store are
-    // wired up against the live vault.
+    // If factoryDeps is supplied, construct the chooser and pick the
+    // provider matching the user's tri-state setting. Without deps,
+    // the state holds a NoopProvider until the real deps are supplied
+    // from main.ts after the embedder + store are wired to the vault.
     let provider: SemanticSearchProvider;
     let chooser: ProviderChooser | null = null;
     if (opts.factoryDeps) {
@@ -203,9 +202,9 @@ export async function setup(
       downloader: null,
       indexer: null,
       store: opts.factoryDeps?.store ?? null,
-      startIndexerIfNeeded: undefined, // T15 wiring overrides this
+      startIndexerIfNeeded: undefined, // production wiring overrides this
       teardown: async () => {
-        // T15 production wiring overrides this to flush+close the
+        // production wiring overrides this to flush+close the
         // store, stop the indexer, and unload the embedder model.
       },
     };

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
@@ -8,8 +8,8 @@
  *    share the same `Promise<Pipeline>` so the model is constructed
  *    exactly once.
  * 2. **LRU query cache** — identical query strings reuse the same
- *    `Float32Array` reference. Default size 32 (per design § Query
- *    pipeline). Exact-match cache; semantic dedupe is out of scope.
+ *    `Float32Array` reference. Default size 32. Exact-match cache;
+ *    semantic dedupe is out of scope.
  * 3. **Unload-when-idle** — if `unloadWhenIdle` is true, the pipeline
  *    is dropped 60s after the last call (RAM saver for memory-
  *    constrained users). The next call cold-reloads.

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -1,5 +1,5 @@
 /**
- * Live semantic indexer (design § Indexing pipeline, design D9).
+ * Live semantic indexer.
  *
  * Algorithm:
  *   - On `start`, run a full build over every markdown file currently
@@ -175,7 +175,7 @@ export function createLiveIndexer(opts: LiveIndexerOpts): SemanticIndexer {
 }
 
 // ---------------------------------------------------------------------------
-// Low-power indexer (design D9, opt-in)
+// Low-power indexer (opt-in)
 // ---------------------------------------------------------------------------
 
 export type LowPowerIndexerOpts = {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/nativeProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/nativeProvider.ts
@@ -1,7 +1,7 @@
 /**
  * NativeProvider — semantic search backed by Transformers.js + the
- * local embedding store. Implements `SemanticSearchProvider` and
- * dispatches via the design D7 tri-state setting (T8 factory).
+ * local embedding store. Implements `SemanticSearchProvider`; the
+ * provider factory selects it from the user's tri-state setting.
  *
  * Algorithm:
  *   1. Embed the query (LRU-cached at the embedder layer).

--- a/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.ts
@@ -1,6 +1,6 @@
 /**
  * Provider factory — selects the active SemanticSearchProvider based
- * on the user's tri-state setting (design D7).
+ * on the user's tri-state setting.
  *
  * Behavior matrix:
  *   provider="native"            → always NativeProvider

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
@@ -11,7 +11,7 @@
  *   contentHash, byteOffset, byteLength)`. Bumping `version` triggers
  *   a clean re-index on next `init()` (logged warning, no error).
  *
- * Why flat-file instead of SQLite or HNSW (design D5):
+ * Why flat-file instead of SQLite or HNSW:
  * - Vault sizes targeted at 0.4.0 are well under 100k chunks. Cosine
  *   flat scan over 100k × 384-dim Float32 (~150MB) takes ~20ms on
  *   modern CPU with vectorized typed-array math. HNSW indexing is

--- a/packages/obsidian-plugin/src/features/semantic-search/types.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/types.ts
@@ -3,12 +3,12 @@ import { type } from "arktype";
 /**
  * Runtime schema for the semantic-search settings block.
  *
- * `provider` is the user-facing tri-state from design D7:
- *   - "native"            → always Transformers.js (T6 NativeProvider)
- *   - "smart-connections" → always Smart Connections (T7 wrapper); errors actionably if not installed
+ * `provider` is the user-facing tri-state:
+ *   - "native"            → always Transformers.js (NativeProvider)
+ *   - "smart-connections" → always Smart Connections; errors actionably if not installed
  *   - "auto"              → Smart Connections if loaded and ready, otherwise native
  *
- * `indexingMode` is design D9: live re-embedding on file change vs.
+ * `indexingMode`: live re-embedding on file change vs.
  * 5-minute batched scan. Only meaningful when the active provider
  * is `NativeProvider` — Smart Connections owns its own indexing.
  *

--- a/packages/obsidian-plugin/src/features/tool-toggle/services/applyFilter.ts
+++ b/packages/obsidian-plugin/src/features/tool-toggle/services/applyFilter.ts
@@ -2,7 +2,7 @@ import { logger } from "$/shared/logger";
 
 /**
  * Apply the user-controlled `toolToggle.disabled` list to a freshly-
- * registered ToolRegistry (Phase 4 T12.c).
+ * registered ToolRegistry.
  *
  * The `ToolRegistry` already separates registration from enablement
  * via its internal `enabled` set + `disableByName(name)` API. This


### PR DESCRIPTION
## Summary

Follow-up to #125. Removes internal process narration from source comments — the same "reads as unreviewed AI output" smell, in code this time.

Across **15 files**, drops dead process pointers from docblocks/inline comments: `Phase N`, `Tn` task IDs, `design Dn`, `design §`, `wired by Tn`, `Q4 = lazy`. These describe a *finished* migration's task graph, not behavior.

**Conservative by design:**
- Only the dead process reference is removed; the substantive WHY in every comment is preserved verbatim (e.g. the flat-file vs SQLite/HNSW rationale, the non-atomic loadData/saveData mutex note, the onnxruntime-web redirect — all kept).
- The valid pointer `command-permissions/types.ts → docs/design/issue-29-command-execution.md` is **left intact** — that design doc is authoritative and was NOT removed in #125.
- No behavior change. Comments only (verified: the only non-comment diff in the tree was the unrelated `manifest.json` bump, which is excluded from this PR).

## Stacking

Based on `chore/docs-cleanup` (#125), not `main`, because both touch `semantic-search/index.ts` — stacking avoids a merge conflict. Merge #125 first; this PR's base then retargets to `main` (or rebase).

## Test plan

- [x] `bun run check` — 0 errors across all packages
- [x] Residual-narration grep returns empty over `packages/*/src` (excl. tests)
- [x] `git diff` confirms comment-only changes
- [ ] Merge after #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)