### PR TITLE
docs(CLAUDE.md): sync CI section with ci.yml (tests now run on PR)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ If you ever encounter a "GH013: Repository rule violations" error, the operation
 | Test | `bun:test` (native) |
 | Format | Prettier 3 (`.prettierrc.yaml`) — 2-space indent, 80 col |
 | Build | `packages/obsidian-plugin/bun.config.ts` (Bun bundler) → plugin `main.js`. No binary. `__dirname`/`__filename`/`import.meta.*` are neutralized in the `define` block for a reproducible cross-machine bundle (Obsidian store build-verification) |
-| CI | GitHub Actions (`.github/workflows/release.yml`, tag-triggered) — plugin-only release assets (`main.js` + `manifest.json`) + GitHub build-provenance attestation |
+| CI | GitHub Actions — `ci.yml` (typecheck + workspace tests on push/PR to `main` & `feat/http-embedded`); `release.yml` (tag-triggered) builds plugin assets (`main.js` + `manifest.json`) + GitHub build-provenance attestation |
 
 Path alias inside every package: **`$/*` → `src/*`**. Use it instead of relative imports across feature boundaries.
 
@@ -291,7 +291,7 @@ Active traps in the current tree. Historical bugs already fixed are in `git log`
   - **Stubbing `os.homedir()`**: use `spyOn(os, "homedir").mockReturnValue(tmpRoot)` — Bun/Node cache HOME early, so runtime `process.env.HOME = …` is not reliable. See `config.test.ts` and `uninstall.test.ts`.
   - **Installer integration tests** use real shell scripts as fake binaries (tmpdir, `mode: 0o755`) instead of mocking `child_process.exec`. See `status.integration.test.ts`. macOS-guarded (shebang approach is Unix-only).
 - **Still uncovered**: `installMcpServer` orchestration wrapper, `downloadFile` (HTTP + stream), Svelte component rendering (covered only by `svelte-check` and manual `bun run link` smoke tests).
-- CI: `.github/workflows/release.yml` triggers on tag push, runs `bun run release`, cross-compiles all platforms, generates SLSA provenance, uploads release artifacts. **No test step in CI yet** — keep tests green locally before merging to `main`.
+- CI: `.github/workflows/ci.yml` runs on every push/PR to `main` or `feat/http-embedded` — `bun install --frozen-lockfile`, `bun run check` (workspace typecheck), then `bun test` in `packages/shared` and `packages/obsidian-plugin`. `.github/workflows/release.yml` is separate (tag push): builds the plugin assets + GitHub build-provenance attestation (no binary, no cross-compile). Keep tests green locally — CI gates the PR.
 
 ## Pre-commit checklist
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` was stale on CI in two places. Surfaced while merging #125/#126 — a `CI` workflow gated both PRs, but the doc said there was none.

**Corrected against `.github/workflows/ci.yml` (read, not assumed):**
- Stack table CI row: now names `ci.yml` (typecheck + workspace tests on push/PR to `main` & `feat/http-embedded`) alongside the tag-triggered `release.yml`.
- Testing & CI bullet: replaced "**No test step in CI yet**" + the old "cross-compiles all platforms / SLSA" description (0.3.x-binary-era cruft) with the actual pipeline: `bun install --frozen-lockfile` → `bun run check` → `bun test` (shared + obsidian-plugin); `release.yml` separate, tag-only, plugin assets + provenance (no binary, no cross-compile).

Docs-only, two lines. CI will validate.

## Test plan

- [ ] `ci.yml` green on this PR (self-validating: the doc now describes the very workflow gating it)
- [ ] Merge via `main-strict` when ready