### PR TITLE
fix(transport): drain connections on close, body-size cap, log redaction, auth doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are expos
 
 | Tool | Purpose |
 |---|---|
-| `get_server_info` | Local REST API status + auth check. Only tool that works without auth. |
+| `get_server_info` | Local REST API status + auth check. Like every MCP tool, requires the bearer token — there is no unauthenticated path. |
 | `get_active_file` | Content of the currently active note (markdown or JSON with tags + frontmatter). |
 | `update_active_file` | Replace content of the active note. |
 | `append_to_active_file` | Append to the active note. |

--- a/packages/obsidian-plugin/src/features/mcp-transport/constants.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/constants.ts
@@ -3,6 +3,9 @@ export const BIND_HOST = "127.0.0.1" as const;
 export const MCP_PATH_PREFIX = "/mcp" as const;
 export const TOKEN_BYTE_LENGTH = 32 as const;
 
+// Cap on the request body to bound memory in the Electron renderer (DoS/OOM).
+export const MAX_REQUEST_BODY_BYTES = 1_048_576 as const;
+
 export const ALLOWED_ORIGINS_PATTERN = /^https?:\/\/(127\.0\.0\.1|localhost)(:\d+)?$/;
 
 export const ERROR_CODES = {
@@ -10,4 +13,5 @@ export const ERROR_CODES = {
   NOT_FOUND: 404,
   ORIGIN_FORBIDDEN: 403,
   UNAUTHORIZED: 401,
+  PAYLOAD_TOO_LARGE: 413,
 } as const;

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test, afterEach } from "bun:test";
+import type { Server } from "node:http";
 import {
   startHttpServer,
   stopHttpServer,
   type RunningServer,
 } from "./httpServer";
+import { MAX_REQUEST_BODY_BYTES } from "../constants";
 
 const running: RunningServer[] = [];
 afterEach(async () => {
@@ -112,6 +114,85 @@ describe("startHttpServer", () => {
     } finally {
       console.error = originalConsoleError;
     }
+  });
+});
+
+describe("stopHttpServer — connection draining", () => {
+  test("force-drops keep-alive/SSE sockets before close()", async () => {
+    const order: string[] = [];
+    const fakeServer = {
+      closeAllConnections: () => {
+        order.push("closeAllConnections");
+      },
+      close: (cb: (err?: Error) => void) => {
+        order.push("close");
+        cb();
+      },
+    } as unknown as Server;
+
+    await stopHttpServer({ server: fakeServer, port: 0 });
+
+    // closeAllConnections MUST run first — otherwise an open mcp-remote
+    // stream keeps close() from ever resolving.
+    expect(order).toEqual(["closeAllConnections", "close"]);
+  });
+});
+
+describe("request body size cap", () => {
+  test("rejects an oversize Content-Length with 413 before the handler runs", async () => {
+    let handlerCalled = false;
+    const token = "t".repeat(32);
+    const server = await startHttpServer({
+      bearerToken: token,
+      requestHandler: async (_req, res) => {
+        handlerCalled = true;
+        res.writeHead(200);
+        res.end("ok");
+      },
+    });
+    running.push(server);
+
+    // fetch derives Content-Length from the body, so send a real
+    // oversize payload — the server reads the declared length and
+    // rejects before the handler is ever invoked.
+    const oversize = "x".repeat(MAX_REQUEST_BODY_BYTES + 1);
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: oversize,
+    });
+    expect(res.status).toBe(413);
+    expect(handlerCalled).toBe(false);
+  });
+
+  test("an under-limit request still reaches the handler with its body", async () => {
+    let received = "";
+    const token = "t".repeat(32);
+    const server = await startHttpServer({
+      bearerToken: token,
+      requestHandler: async (req, res) => {
+        for await (const chunk of req) received += chunk;
+        res.writeHead(200);
+        res.end("ok");
+      },
+    });
+    running.push(server);
+
+    const payload = JSON.stringify({ hello: "world" });
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: payload,
+    });
+    expect(res.status).toBe(200);
+    // The body must still flow to the handler untouched on the happy path.
+    expect(received).toBe(payload);
   });
 });
 

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.ts
@@ -6,7 +6,11 @@ import {
 } from "node:http";
 import { runMiddleware } from "./middleware";
 import { bindWithFallback } from "./port";
-import { PORT_RANGE } from "../constants";
+import {
+  ERROR_CODES,
+  MAX_REQUEST_BODY_BYTES,
+  PORT_RANGE,
+} from "../constants";
 
 export type RequestHandler = (
   req: IncomingMessage,
@@ -56,6 +60,25 @@ export async function startHttpServer(
       return;
     }
 
+    // Reject an oversize body up front via the declared Content-Length so
+    // the SDK never buffers a huge payload (DoS/OOM in the renderer). We
+    // do NOT also attach a streamed req.on('data') byte counter: the SDK
+    // consumes this same stream later (hono's Readable.toWeb(req)), and a
+    // 'data' listener here would flip the stream to flowing mode and steal
+    // bytes from it, breaking every valid request. Content-Length is a
+    // partial but safe mitigation; a chunked request with no length still
+    // reaches the SDK's own parser.
+    const declaredLength = Number(req.headers["content-length"]);
+    if (
+      Number.isFinite(declaredLength) &&
+      declaredLength > MAX_REQUEST_BODY_BYTES
+    ) {
+      res.writeHead(ERROR_CODES.PAYLOAD_TOO_LARGE);
+      res.end();
+      req.destroy();
+      return;
+    }
+
     // void prefix: fire-and-forget is intentional. Errors are caught
     // below and logged without rethrowing.
     void config.requestHandler(req, res).catch((err) => {
@@ -89,12 +112,29 @@ export async function startHttpServer(
  * Gracefully close the HTTP server and release its port.
  *
  * Resolves when the server has fully closed (all connections drained).
- * Rejects if the server was not listening or if close() emits an error.
+ * Rejects only on a genuine close() error — an already-stopped listener
+ * counts as success since the port is released either way.
  *
  * @param running - The RunningServer returned by startHttpServer.
  */
 export async function stopHttpServer({ server }: RunningServer): Promise<void> {
+  // Force-drop keep-alive + in-flight + SSE sockets first: without this an
+  // open mcp-remote stream keeps the connection alive and server.close()
+  // never resolves on plugin disable/update, so the port "walks".
+  // Cast: closeAllConnections is Node >=18.2 (Obsidian's Electron + Bun
+  // both have it) but the pinned @types/node@16 predates the typing.
+  (server as { closeAllConnections?: () => void }).closeAllConnections?.();
   await new Promise<void>((resolve, reject) => {
-    server.close((err) => (err ? reject(err) : resolve()));
+    server.close((err) => {
+      // ERR_SERVER_NOT_RUNNING means the listener is already gone, i.e.
+      // the port is released — the goal is met. (Bun's closeAllConnections
+      // also stops the listener; real Node/Electron does not. Tolerating
+      // it here keeps one teardown path correct on both runtimes.)
+      if (err && (err as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING") {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
   });
 }

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/setup.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/setup.ts
@@ -55,7 +55,9 @@ export async function setup(plugin: McpToolsPlugin): Promise<SetupResult> {
       >;
       let token = mcpTransportSettings.bearerToken as string | undefined;
 
-      if (!token || token.length < 32) {
+      // Byte length, not UTF-16 code units: the 32-byte floor is a
+      // security threshold and must hold regardless of encoding.
+      if (!token || Buffer.byteLength(token, "utf8") < 32) {
         // No valid token yet — generate a fresh one and persist it.
         // This only happens on the very first load after plugin install.
         token = generateToken();

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, spyOn } from "bun:test";
 import { type } from "arktype";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { logger } from "$/shared/logger";
 import { normalizeInputSchema, ToolRegistryClass } from "./toolRegistry";
 
 /**
@@ -353,5 +354,43 @@ describe("ToolRegistry — issue #74 (registry-level isError envelope)", () => {
     // Handler-side isError envelope is forwarded byte-for-byte.
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text).toBe("Template not found: foo.md");
+  });
+});
+
+describe("ToolRegistry — tool-error log redaction", () => {
+  test("error log carries the tool name but never params.arguments", async () => {
+    const tools = new ToolRegistryClass();
+    const schema = type({
+      name: '"redact-me"',
+      arguments: { secret: "string" },
+    }).describe("Tool that throws so the error path logs");
+
+    tools.register(schema, () => {
+      throw new McpError(ErrorCode.InternalError, "boom");
+    });
+
+    const calls: Array<[unknown, unknown]> = [];
+    const spy = spyOn(logger, "error").mockImplementation(
+      (msg: unknown, meta?: unknown) => {
+        calls.push([msg, meta]);
+      },
+    );
+
+    try {
+      await tools.dispatch(
+        // The argument value is sensitive user data; it must not be logged.
+        { name: "redact-me", arguments: { secret: "private-note-body" } },
+        fakeContext,
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(calls.length).toBe(1);
+    const meta = calls[0]?.[1] as Record<string, unknown>;
+    expect(meta.tool).toBe("redact-me");
+    expect("params" in meta).toBe(false);
+    // No serialized form of the meta object may leak the argument value.
+    expect(JSON.stringify(meta)).not.toContain("private-note-body");
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
@@ -261,16 +261,18 @@ export class ToolRegistryClass<
       // local fix in PR #69 was the same shape; this lifts the pattern
       // up so it applies uniformly to every tool that throws.
       //
-      // Logging stays on `logger.error` because we still want full
-      // diagnostic context (stack, error, params) for the operator
+      // Logging stays on `logger.error` because we still want
+      // diagnostic context (stack, error, tool name) for the operator
       // even when the client-facing surface is the cleaner envelope.
       const formattedError = formatMcpError(error);
+      // Log the tool name only, never params.arguments — those carry
+      // user data (note content, paths, queries) onto the on-disk log.
       logger.error(`Error handling ${params.name}`, {
         ...formattedError,
         message: formattedError.message,
         stack: formattedError.stack,
         error,
-        params,
+        tool: params.name,
       });
       return {
         content: [


### PR DESCRIPTION
## Summary

Phase 3 of the approved transport-hardening plan. Scope: `packages/obsidian-plugin/src/features/mcp-transport/` plus one `CLAUDE.md` doc-alignment line. No version bump, no `manifest.json` change, no behavior change outside these items.

### Hardening items

1. **HIGH — drain connections on close.** `stopHttpServer` now calls `server.closeAllConnections()` immediately before `server.close()`, so a plugin disable/enable or update with an open `mcp-remote` keep-alive/SSE stream force-drops in-flight sockets and `close()` resolves promptly. Previously the old listener never closed and the port "walked", breaking the client. (`close()` tolerates `ERR_SERVER_NOT_RUNNING` because Bun's `closeAllConnections` also stops the listener while Node/Electron does not — one teardown path, correct on both runtimes.)
2. **MEDIUM — 1 MiB request body cap (DoS/OOM).** Implemented **approach (a) only**: if the declared `Content-Length` exceeds `MAX_REQUEST_BODY_BYTES` (1 048 576), respond `413` and `req.destroy()` **before** the SDK sees the stream. The streamed `req.on('data')` byte-counter (approach b) is **intentionally omitted**: the MCP SDK consumes this same `req` stream later via `@hono/node-server`'s `Readable.toWeb(req)`; attaching a `data` listener here flips the stream to flowing mode and steals bytes, breaking every valid request. This is a partial but safe mitigation (a chunked request with no `Content-Length` still reaches the SDK's own parser); the trade-off is documented in code.
3. **MEDIUM — tool-error log redaction.** `toolRegistry` no longer logs the full `params` object (which included `params.arguments` = user note content, paths, queries) on tool error. It now logs only `{ tool: params.name }` alongside the unchanged formatted error. Error behavior is unchanged; only the logged payload changed.
4. **LOW — bearer-token byte length.** The loaded-token guard in `setup.ts` now uses `Buffer.byteLength(token, "utf8") < 32` instead of `token.length < 32` (UTF-16 code units). The `globalSettingsMutex.run` wrapping introduced by #129 is left intact.

### `get_server_info` doc resolution

`CLAUDE.md` previously claimed `get_server_info` is "the only tool that works without auth", but the code requires the bearer token on **all** `/mcp` tool calls. Decision: **keep auth-on-everything** — in the 0.4.x in-process architecture the plugin always provisions the token into the client config, so there is no discover-before-auth need and an unauthenticated tool is needless attack surface. The doc row is aligned to state that `get_server_info` (like every MCP tool) requires the bearer token. No code change for this item.

### Tests

- `stopHttpServer` force-drops sockets via `closeAllConnections()` **before** `close()` (ordering asserted with a fake server).
- An oversize body yields `413` and the handler is never invoked; an under-limit request still reaches the handler with its body intact.
- The tool-error log payload contains the tool name and **never** `params.arguments`.

`bun run check` (repo root) → 0 errors. `bun test src/features/mcp-transport` → 70 pass, 2 fail; the 2 failures are the pre-existing environmental `port.test.ts` "port 27201 in use" cases (a real Obsidian instance holds the port) — unrelated to this change, zero new failures introduced.

## Stacking

Based on **#129** (`fix/settings-mutex-unification`), **not** `main`, because `mcp-transport/services/setup.ts` is modified by both #129 and this phase (ITEM 4 edits the post-#129 mutex-wrapped form of that block). This PR targets `fix/settings-mutex-unification` and should be **retargeted to `main` after #129 merges**.

## Test plan

- [ ] CI green on the stacked branch
- [ ] After #129 merges: retarget base to `main`, confirm diff is clean
- [ ] Manual: disable/enable plugin with an open `mcp-remote` stream → server closes promptly, port does not walk
- [ ] Manual: POST a >1 MiB body to `/mcp` → 413; normal tool calls unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>