### PR TITLE
fix(security): SSRF guard on fetch, no-shell exec, template-exec mutex, vault-tool guards

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.test.ts
@@ -12,7 +12,8 @@ import {
  * tests do not depend on the host having Node on PATH and so we can
  * exercise the parsing / error-classification branches deterministically.
  *
- * The real production runner is `promisify(child_process.exec)`. The
+ * The real production runner is promisified `execFile` — a no-shell
+ * `(file, args)` seam (FIX 3: shell-injection hardening). The
  * `status.integration.test.ts` pattern (real shell scripts in tmpdir)
  * is overkill here — we only ever invoke `node --version`, which has
  * a stable contract we can fake at the runner level.
@@ -67,7 +68,9 @@ describe("detectNode — error classification", () => {
 
   test("Windows `not recognized` error → friendly hint", async () => {
     const runner: ExecRunner = async () => {
-      throw new Error("'node' is not recognized as an internal or external command");
+      throw new Error(
+        "'node' is not recognized as an internal or external command",
+      );
     };
     const r = await detectNode({ runner, forceRefresh: true });
     expect(r.found).toBe(false);
@@ -149,16 +152,16 @@ describe("detectNode — caching", () => {
 
 describe("detectNode — canonical-path fallback (launchctl PATH gotcha)", () => {
   test("falls back to /opt/homebrew/bin/node when PATH-based fails", async () => {
-    const calls: string[] = [];
-    const runner: ExecRunner = async (cmd) => {
-      calls.push(cmd);
-      if (cmd === "node --version") {
+    const calls: Array<{ file: string; args: string[] }> = [];
+    const runner: ExecRunner = async (file, args) => {
+      calls.push({ file, args });
+      if (file === "node") {
         throw new Error("spawn node ENOENT");
       }
-      if (cmd.includes("/opt/homebrew/bin/node")) {
+      if (file === "/opt/homebrew/bin/node") {
         return { stdout: "v22.3.0\n", stderr: "" };
       }
-      throw new Error("unexpected runner call: " + cmd);
+      throw new Error("unexpected runner call: " + file);
     };
 
     const r = await detectNode({
@@ -169,21 +172,22 @@ describe("detectNode — canonical-path fallback (launchctl PATH gotcha)", () =>
     });
 
     expect(r).toEqual({ found: true, version: "22.3.0", raw: "v22.3.0\n" });
-    expect(calls[0]).toBe("node --version"); // tried PATH first
-    expect(calls[1]).toContain("/opt/homebrew/bin/node");
+    expect(calls[0]).toEqual({ file: "node", args: ["--version"] }); // PATH first
+    expect(calls[1]?.file).toBe("/opt/homebrew/bin/node");
+    expect(calls[1]?.args).toEqual(["--version"]);
   });
 
   test("scans candidates in order until one matches", async () => {
-    const runner: ExecRunner = async (cmd) => {
-      if (cmd === "node --version") throw new Error("spawn node ENOENT");
-      if (cmd.includes("/opt/homebrew/bin/node")) {
+    const runner: ExecRunner = async (file) => {
+      if (file === "node") throw new Error("spawn node ENOENT");
+      if (file === "/opt/homebrew/bin/node") {
         // Path exists per probe but binary is broken on this run
         throw new Error("unrecognized");
       }
-      if (cmd.includes("/usr/local/bin/node")) {
+      if (file === "/usr/local/bin/node") {
         return { stdout: "v18.20.4\n", stderr: "" };
       }
-      throw new Error("unexpected: " + cmd);
+      throw new Error("unexpected: " + file);
     };
 
     const r = await detectNode({
@@ -210,6 +214,29 @@ describe("detectNode — canonical-path fallback (launchctl PATH gotcha)", () =>
 
     expect(r.found).toBe(false);
     expect(r.found === false && r.error).toMatch(/Node\.js|node --version/i);
+  });
+
+  test("FIX 3: a candidate path with shell metacharacters is passed as argv[0], not interpolated", async () => {
+    // A maliciously-named path must reach the runner as a literal file
+    // argument (no `/bin/sh -c "..."`), so `; rm -rf ~` cannot execute.
+    const evil = "/opt/homebrew/bin/node; rm -rf ~";
+    let received: { file: string; args: string[] } | null = null;
+    const runner: ExecRunner = async (file, args) => {
+      if (file === "node") throw new Error("spawn node ENOENT");
+      received = { file, args };
+      return { stdout: "v20.0.0\n", stderr: "" };
+    };
+
+    const r = await detectNode({
+      runner,
+      forceRefresh: true,
+      candidatePaths: [evil],
+      pathExists: () => true,
+    });
+
+    expect(r).toEqual({ found: true, version: "20.0.0", raw: "v20.0.0\n" });
+    // The full evil string is the literal argv[0] — never split by a shell.
+    expect(received).toEqual({ file: evil, args: ["--version"] });
   });
 });
 

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import { existsSync } from "fs";
 import os from "os";
@@ -43,12 +43,18 @@ export type NodeDetectResult =
       error: string;
     };
 
-export type ExecRunner = (command: string) => Promise<{
+// (file, args) shape — no shell. A binary path containing shell
+// metacharacters (spaces, `;`, `$()`) cannot inject because `execFile`
+// passes argv directly to the OS rather than through `/bin/sh -c`.
+export type ExecRunner = (
+  file: string,
+  args: string[],
+) => Promise<{
   stdout: string;
   stderr: string;
 }>;
 
-const defaultRunner: ExecRunner = promisify(exec) as unknown as ExecRunner;
+const defaultRunner: ExecRunner = promisify(execFile) as unknown as ExecRunner;
 
 let cached: NodeDetectResult | null = null;
 let cachedNodePath: string | null = null;
@@ -113,7 +119,7 @@ export async function detectNode(opts?: {
   // 1. Try PATH-based lookup first — fastest on systems where it works.
   let lastError: string | null = null;
   try {
-    const { stdout } = await runner("node --version");
+    const { stdout } = await runner("node", ["--version"]);
     const version = parseVersion(stdout);
     if (version) {
       cached = { found: true, version, raw: stdout };
@@ -130,8 +136,9 @@ export async function detectNode(opts?: {
   for (const candidate of candidates) {
     if (!probe(candidate)) continue;
     try {
-      // Quote the path so paths with spaces survive the shell.
-      const { stdout } = await runner(`"${candidate}" --version`);
+      // No-shell invocation: the absolute path is argv[0], not embedded
+      // in a shell string, so spaces/metacharacters cannot break out.
+      const { stdout } = await runner(candidate, ["--version"]);
       const version = parseVersion(stdout);
       if (version) {
         cached = { found: true, version, raw: stdout };
@@ -143,7 +150,10 @@ export async function detectNode(opts?: {
     }
   }
 
-  cached = { found: false, error: classifyError(lastError ?? "node --version failed") };
+  cached = {
+    found: false,
+    error: classifyError(lastError ?? "node --version failed"),
+  };
   cachedNodePath = null;
   return cached;
 }
@@ -242,12 +252,14 @@ export async function detectBrew(opts?: {
 
   const tryParse = (stdout: string): BrewDetectResult => {
     const m = /Homebrew\s+(\d+\.\d+\.\d+)/.exec(stdout);
-    return m ? { found: true, version: m[1]! } : { found: true, version: "unknown" };
+    return m
+      ? { found: true, version: m[1]! }
+      : { found: true, version: "unknown" };
   };
 
   // 1. PATH-based.
   try {
-    const { stdout } = await runner("brew --version");
+    const { stdout } = await runner("brew", ["--version"]);
     cachedBrew = tryParse(stdout);
     cachedBrewPath = "brew"; // PATH-based — let the install runner inherit PATH.
     return cachedBrew;
@@ -259,7 +271,7 @@ export async function detectBrew(opts?: {
   for (const candidate of candidates) {
     if (!probe(candidate)) continue;
     try {
-      const { stdout } = await runner(`"${candidate}" --version`);
+      const { stdout } = await runner(candidate, ["--version"]);
       cachedBrew = tryParse(stdout);
       cachedBrewPath = candidate;
       return cachedBrew;

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, test, spyOn } from "bun:test";
-import {
-  getPreWarmCache,
-  preWarm,
-  type ExecRunner,
-} from "./preWarm";
+import { getPreWarmCache, preWarm, type ExecRunner } from "./preWarm";
 import { logger } from "$/shared/logger";
 
 /** Regex for the scary child-process stack trace we must NOT echo. */
@@ -77,6 +73,25 @@ describe("preWarm — success path", () => {
     expect(cached?.lastWarmedAt).toBe(
       result.ok ? result.entry.lastWarmedAt : "",
     );
+  });
+
+  test("FIX 3: npx path is argv[0] and args are a fixed array (no shell string)", async () => {
+    const p = fakePlugin({});
+    // A path with a shell metacharacter must reach the runner verbatim
+    // as the file argument — never concatenated into a `/bin/sh -c` line.
+    const evilNpx = "/Users/a b/npx; touch /tmp/pwned";
+    let received: { file: string; args: string[] } | null = null;
+    const runner: ExecRunner = async (file, args) => {
+      received = { file, args };
+      return { stdout: "mcp-remote 1.0.0", stderr: "" };
+    };
+
+    const result = await preWarm(p, { runner, npxPath: evilNpx });
+    expect(result.ok).toBe(true);
+    expect(received).toEqual({
+      file: evilNpx,
+      args: ["-y", "mcp-remote@latest", "--help"],
+    });
   });
 
   test("succeeds even when version cannot be parsed", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import { logger } from "$/shared/logger";
 import {
@@ -45,17 +45,22 @@ export type PreWarmResult =
   | { ok: true; entry: PreWarmCacheEntry }
   | { ok: false; error: string };
 
+// (file, args, options) shape — no shell. The npx path is argv[0]; a
+// path with spaces/metacharacters cannot inject because `execFile`
+// passes argv straight to the OS instead of through `/bin/sh -c`.
 export type ExecRunner = (
-  command: string,
+  file: string,
+  args: string[],
   options?: { timeout?: number; env?: NodeJS.ProcessEnv },
 ) => Promise<{ stdout: string; stderr: string }>;
 
-const defaultRunner: ExecRunner = (command, options) => {
-  const exec_ = promisify(exec) as (
-    cmd: string,
+const defaultRunner: ExecRunner = (file, args, options) => {
+  const execFile_ = promisify(execFile) as (
+    f: string,
+    a: string[],
     opts?: { timeout?: number; env?: NodeJS.ProcessEnv },
   ) => Promise<{ stdout: string; stderr: string }>;
-  return exec_(command, options);
+  return execFile_(file, args, options);
 };
 
 type PluginLike = {
@@ -134,8 +139,8 @@ export async function preWarm(
   }
 
   try {
-    // Quote the path so spaces survive the shell.
-    const cmd = `"${npxPath}" -y mcp-remote@latest --help`;
+    // No-shell argv — npxPath is argv[0], not embedded in a shell string.
+    const npxArgs = ["-y", "mcp-remote@latest", "--help"];
 
     // Build the child env. `npx` is a shebang script that re-invokes
     // `node` via `env node`, which does a PATH lookup INSIDE the
@@ -151,7 +156,7 @@ export async function preWarm(
         : {}),
     };
 
-    const { stdout, stderr } = await runner(cmd, {
+    const { stdout, stderr } = await runner(npxPath, npxArgs, {
       timeout: PREWARM_TIMEOUT_MS,
       env,
     });
@@ -177,7 +182,8 @@ export async function preWarm(
         });
       }
     }
-    const version = parseVersionFromHelp(stdout) ?? parseVersionFromHelp(stderr);
+    const version =
+      parseVersionFromHelp(stdout) ?? parseVersionFromHelp(stderr);
     const entry: PreWarmCacheEntry = {
       lastWarmedAt: new Date().toISOString(),
       ...(version ? { version } : {}),

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
@@ -144,6 +144,75 @@ export function hasParentH1(lines: string[], headingLine: number): boolean {
 }
 
 /**
+ * Precompute, in a single O(n) pass, whether each line sits inside an
+ * open fenced code block — i.e. `fenceOpen[i]` is the value the old
+ * `count ``` up to lineIdx` loop would have produced for `lineIdx = i`.
+ * Used so a range scan does not rescan from line 0 per line (was O(n²)).
+ */
+function computeFenceOpenState(lines: string[]): boolean[] {
+  const fenceOpen: boolean[] = new Array(lines.length);
+  let inFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    // The toggle at line `i` affects lines AFTER `i`, exactly matching
+    // the original `for (i = 0; i < lineIdx; i++)` semantics.
+    fenceOpen[i] = inFence;
+    if (lines[i].trim().startsWith("```")) inFence = !inFence;
+  }
+  return fenceOpen;
+}
+
+/**
+ * The per-line table/fence check, consulting a precomputed fence-open
+ * array instead of rescanning from line 0. Behaviour is byte-identical
+ * to the original single-function form.
+ */
+function isInsideTableOrFencedCodeAt(
+  lines: string[],
+  lineIdx: number,
+  fenceOpen: boolean[],
+): boolean {
+  if (lineIdx < 0 || lineIdx >= lines.length) return false;
+
+  // Boundary case: the line itself is a fence delimiter. The splice would
+  // either consume the opener (orphaning the closer) or vice versa, leaving
+  // the file structurally invalid. Treat as "inside" for gating purposes.
+  // Surfaced by fork #84 where the regex fallback findBlockReferenceInContent
+  // walks back from `^block-id` and captures the opening fence as startLine
+  // — the count-up-to-lineIdx loop below misses it because the toggle would
+  // happen AT lineIdx, not before. Symmetric to the table separator-row
+  // handling at the bottom of this function.
+  if (lines[lineIdx].trim().startsWith("```")) return true;
+
+  // Fenced code block: precomputed open-state up to lineIdx.
+  if (fenceOpen[lineIdx]) return true;
+
+  // Markdown table: target line itself must be a table row.
+  const target = lines[lineIdx].trim();
+  const isTableRow = (s: string) => s.startsWith("|") && s.endsWith("|");
+  // Separator row signature: pipes + dashes + optional colons (alignment),
+  // no other content. Matches `|---|---|`, `| --- | --- |`, `|:--:|---:|`.
+  const isSeparator = (s: string) =>
+    /^\|[\s:|-]+\|$/.test(s) && s.includes("---");
+  if (!isTableRow(target)) return false;
+  // Target is itself the separator row → trivially inside a table.
+  if (isSeparator(target)) return true;
+
+  // Walk up looking for separator (the data-row case: target is below it).
+  for (let i = lineIdx - 1; i >= 0; i--) {
+    const t = lines[i].trim();
+    if (t === "" || !isTableRow(t)) break;
+    if (isSeparator(t)) return true;
+  }
+  // Walk down looking for separator (the header-row case: target is above it).
+  for (let i = lineIdx + 1; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (t === "" || !isTableRow(t)) break;
+    if (isSeparator(t)) return true;
+  }
+  return false;
+}
+
+/**
  * Detect whether a given line is inside a markdown table (between a header
  * row and the surrounding data rows, with a `|---|...|` separator) or
  * inside a fenced code block (between matching ``` markers). Used by the
@@ -181,49 +250,11 @@ export function isInsideTableOrFencedCode(
   lines: string[],
   lineIdx: number,
 ): boolean {
-  if (lineIdx < 0 || lineIdx >= lines.length) return false;
-
-  // Boundary case: the line itself is a fence delimiter. The splice would
-  // either consume the opener (orphaning the closer) or vice versa, leaving
-  // the file structurally invalid. Treat as "inside" for gating purposes.
-  // Surfaced by fork #84 where the regex fallback findBlockReferenceInContent
-  // walks back from `^block-id` and captures the opening fence as startLine
-  // — the count-up-to-lineIdx loop below misses it because the toggle would
-  // happen AT lineIdx, not before. Symmetric to the table separator-row
-  // handling at the bottom of this function.
-  if (lines[lineIdx].trim().startsWith("```")) return true;
-
-  // Fenced code block: count ``` markers up to lineIdx.
-  let inFence = false;
-  for (let i = 0; i < lineIdx; i++) {
-    if (lines[i].trim().startsWith("```")) inFence = !inFence;
-  }
-  if (inFence) return true;
-
-  // Markdown table: target line itself must be a table row.
-  const target = lines[lineIdx].trim();
-  const isTableRow = (s: string) => s.startsWith("|") && s.endsWith("|");
-  // Separator row signature: pipes + dashes + optional colons (alignment),
-  // no other content. Matches `|---|---|`, `| --- | --- |`, `|:--:|---:|`.
-  const isSeparator = (s: string) =>
-    /^\|[\s:|-]+\|$/.test(s) && s.includes("---");
-  if (!isTableRow(target)) return false;
-  // Target is itself the separator row → trivially inside a table.
-  if (isSeparator(target)) return true;
-
-  // Walk up looking for separator (the data-row case: target is below it).
-  for (let i = lineIdx - 1; i >= 0; i--) {
-    const t = lines[i].trim();
-    if (t === "" || !isTableRow(t)) break;
-    if (isSeparator(t)) return true;
-  }
-  // Walk down looking for separator (the header-row case: target is above it).
-  for (let i = lineIdx + 1; i < lines.length; i++) {
-    const t = lines[i].trim();
-    if (t === "" || !isTableRow(t)) break;
-    if (isSeparator(t)) return true;
-  }
-  return false;
+  return isInsideTableOrFencedCodeAt(
+    lines,
+    lineIdx,
+    computeFenceOpenState(lines),
+  );
 }
 
 /**
@@ -255,8 +286,11 @@ export function isBlockRangeStructurallyUnsafe(
   startLine: number,
   endLine: number,
 ): boolean {
+  // Single O(n) fence pass shared across the range — previously each
+  // iteration rescanned from line 0, making this O(n²) on large files.
+  const fenceOpen = computeFenceOpenState(lines);
   for (let i = startLine; i <= endLine; i++) {
-    if (isInsideTableOrFencedCode(lines, i)) return true;
+    if (isInsideTableOrFencedCodeAt(lines, i, fenceOpen)) return true;
   }
   return false;
 }
@@ -481,7 +515,10 @@ export async function applyPatch(
   app: App,
   file: TFile,
   args: PatchArgs,
-): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
   const targetDelimiter = args.targetDelimiter ?? "::";
   // Default createTargetIfMissing: true for heading/frontmatter, false for block
   // (see issue #71 — block in table is not indexed by metadataCache).
@@ -501,7 +538,11 @@ export async function applyPatch(
     await app.fileManager.processFrontMatter(file, (fm) => {
       const existing = fm[args.target];
       if (args.operation === "replace") {
-        const plan = planFrontmatterReplace(existing, args.content, args.target);
+        const plan = planFrontmatterReplace(
+          existing,
+          args.content,
+          args.target,
+        );
         if (plan.kind === "reject") {
           rejection = plan.message;
           return;
@@ -547,7 +588,11 @@ export async function applyPatch(
     // matches even when the heading is nested (e.g. "A" → "Top::A").
     let resolvedTarget = args.target;
     if (!args.target.includes(targetDelimiter)) {
-      const fullPath = resolveHeadingPath(rawContent, args.target, targetDelimiter);
+      const fullPath = resolveHeadingPath(
+        rawContent,
+        args.target,
+        targetDelimiter,
+      );
       if (fullPath) resolvedTarget = fullPath;
     }
 
@@ -567,7 +612,9 @@ export async function applyPatch(
       // Heading not found — respect createTargetIfMissing.
       if (!createIfMissing) {
         return {
-          content: [{ type: "text", text: `Heading not found: ${args.target}` }],
+          content: [
+            { type: "text", text: `Heading not found: ${args.target}` },
+          ],
           isError: true,
         };
       }
@@ -579,13 +626,17 @@ export async function applyPatch(
 
     // Find the end of this heading's section: the next heading of same or
     // higher level (lower number means higher in hierarchy), or EOF.
-    const headingLevel = (lines[headingLine].match(/^(#+)/))?.[1].length ?? 1;
+    const headingLevel = lines[headingLine].match(/^(#+)/)?.[1].length ?? 1;
 
     // 0.3.9 #16 parity: reject root-orphan H2+ when createTargetIfMissing=false.
     // The legacy LRA chain enforced this via markdown-patch's indexer; the
     // 0.4.0 in-process port missed the gate (folotp round-3 regression on
     // the actual HTTP-embedded chain — see fork #80, #83).
-    if (headingLevel >= 2 && !createIfMissing && !hasParentH1(lines, headingLine)) {
+    if (
+      headingLevel >= 2 &&
+      !createIfMissing &&
+      !hasParentH1(lines, headingLine)
+    ) {
       return {
         content: [
           {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToVaultFile.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-import { appendToVaultFileHandler, appendToVaultFileSchema } from "./appendToVaultFile";
+import {
+  appendToVaultFileHandler,
+  appendToVaultFileSchema,
+} from "./appendToVaultFile";
 import {
   getMockFolders,
   mockApp,
@@ -12,7 +15,9 @@ beforeEach(() => resetMockVault());
 
 describe("append_to_vault_file tool", () => {
   test("schema declares the tool name", () => {
-    expect(appendToVaultFileSchema.get("name")?.toString()).toContain("append_to_vault_file");
+    expect(appendToVaultFileSchema.get("name")?.toString()).toContain(
+      "append_to_vault_file",
+    );
   });
 
   test("appends to existing file with newline normalization", async () => {
@@ -51,6 +56,17 @@ describe("append_to_vault_file tool", () => {
     const file = app.vault.getAbstractFileByPath("Logs/2026/05/today.md");
     expect(file).not.toBeNull();
     expect(await app.vault.read(file as never)).toBe("First\n\n");
+  });
+
+  test("FIX 5: returns isError (does not throw) when path is a folder", async () => {
+    setMockFolder("Logs");
+    const app = mockApp();
+    const result = await appendToVaultFileHandler({
+      arguments: { path: "Logs", content: "x" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/folder, not a file/i);
   });
 
   test("does NOT call createFolder on the modify branch — folder set unchanged", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToVaultFile.ts
@@ -22,11 +22,28 @@ export type AppendToVaultFileContext = {
 
 export async function appendToVaultFileHandler(
   ctx: AppendToVaultFileContext,
-): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
   const normalized = normalizeAppendBody(ctx.arguments.content, "append");
   const existing = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
 
   if (existing) {
+    // A folder here would make `vault.read(... as TFile)` throw an
+    // uncaught error, bypassing the isError contract. Duck-type the
+    // same way the directory tools do (TFolder has `children`).
+    if ((existing as { children?: unknown }).children !== undefined) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Path ${ctx.arguments.path} is a folder, not a file.`,
+          },
+        ],
+        isError: true,
+      };
+    }
     const tfile = existing as TFile;
     const current = await ctx.app.vault.read(tfile);
     await ctx.app.vault.modify(tfile, current + normalized);

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultFile.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-import { createVaultFileHandler, createVaultFileSchema } from "./createVaultFile";
+import {
+  createVaultFileHandler,
+  createVaultFileSchema,
+} from "./createVaultFile";
 import {
   getMockFolders,
   mockApp,
@@ -76,6 +79,17 @@ describe("create_vault_file tool", () => {
     });
     expect(result.isError).toBeUndefined();
     expect(getMockFolders()).toEqual(["Existing"]);
+  });
+
+  test("FIX 5: returns isError (does not throw) when path is a folder", async () => {
+    setMockFolder("Notes");
+    const app = mockApp();
+    const result = await createVaultFileHandler({
+      arguments: { path: "Notes", content: "x" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/folder, not a file/i);
   });
 
   test("overwrites existing file when target exists", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultFile.ts
@@ -29,6 +29,20 @@ export async function createVaultFileHandler(
 }> {
   const existing = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
   if (existing) {
+    // A folder at this path would make `vault.modify(... as TFile)` throw
+    // an uncaught error, bypassing the isError contract. Duck-type the
+    // same way the directory tools do (TFolder has `children`).
+    if ((existing as { children?: unknown }).children !== undefined) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Path ${ctx.arguments.path} is a folder, not a file.`,
+          },
+        ],
+        isError: true,
+      };
+    }
     await ctx.app.vault.modify(existing as TFile, ctx.arguments.content);
   } else {
     await ensureParentFolderExists(ctx.app, ctx.arguments.path);

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.test.ts
@@ -95,7 +95,9 @@ describe("execute_template tool", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/templater|not available|not installed/i);
+    expect(result.content[0].text).toMatch(
+      /templater|not available|not installed/i,
+    );
   });
 
   test("returns error when template file not found in vault", async () => {
@@ -163,7 +165,8 @@ describe("execute_template tool", () => {
     expect(parsed.path).toBe("Output/note.md");
 
     // Verify the file was actually created in the mock vault
-    const createdFile = plugin.app.vault.getAbstractFileByPath("Output/note.md");
+    const createdFile =
+      plugin.app.vault.getAbstractFileByPath("Output/note.md");
     expect(createdFile).not.toBeNull();
   });
 
@@ -243,6 +246,79 @@ describe("execute_template tool", () => {
       undefined,
     );
     expect((result as Record<string, unknown>).mcpTools).toBeUndefined();
+  });
+
+  test("FIX 4: concurrent execute_template calls are serialized (no patch/restore race)", async () => {
+    setMockFile("a.md", "X");
+
+    // A templater whose render is async + slow, and which actually
+    // invokes the patched generate_object so each call observes the
+    // accessor THAT call installed. If the mutex were absent, call B's
+    // patch (and finally-restore) would interleave with call A's render
+    // and one of them would see the wrong / restored generate_object.
+    function makeRacyTemplater() {
+      const seen: string[] = [];
+      const t = {
+        functions_generator: {
+          generate_object: async (): Promise<Record<string, unknown>> => ({}),
+        },
+        create_running_config: () => ({}),
+        read_and_parse_template: async () => {
+          // Render reaches into the (currently-patched) generate_object
+          // and records which prompt accessor is live right now.
+          const fns = await t.functions_generator.generate_object();
+          const accessor = (fns as { mcpTools?: { prompt: PromptArg } })
+            .mcpTools?.prompt;
+          // Yield so a second concurrent call would interleave here if
+          // the critical section were not serialized.
+          await new Promise((r) => setTimeout(r, 10));
+          seen.push(accessor ? accessor("who") : "<none>");
+          await new Promise((r) => setTimeout(r, 10));
+          // Read again AFTER the yield: must still be this call's accessor.
+          const fns2 = await t.functions_generator.generate_object();
+          const accessor2 = (fns2 as { mcpTools?: { prompt: PromptArg } })
+            .mcpTools?.prompt;
+          seen.push(accessor2 ? accessor2("who") : "<none>");
+          return "RENDERED";
+        },
+        _seen: seen,
+      };
+      return t;
+    }
+    type PromptArg = (name: string) => string;
+
+    const fakeTemplater = makeRacyTemplater();
+    const plugin = mockPluginWithTemplater(
+      fakeTemplater as unknown as ReturnType<typeof makeFakeTemplater>,
+    );
+
+    const callA = executeTemplateHandler({
+      arguments: { templatePath: "a.md", arguments: { who: "A" } },
+      app: plugin.app,
+      plugin,
+    });
+    const callB = executeTemplateHandler({
+      arguments: { templatePath: "a.md", arguments: { who: "B" } },
+      app: plugin.app,
+      plugin,
+    });
+
+    const [rA, rB] = await Promise.all([callA, callB]);
+    expect(rA.isError).toBeUndefined();
+    expect(rB.isError).toBeUndefined();
+
+    // Serialized → each pair of reads is internally consistent: the
+    // first call sees [X, X], the second sees [Y, Y] (never [A, B] or
+    // [<none>, …] which a patch/restore race would produce).
+    expect(fakeTemplater._seen).toHaveLength(4);
+    const [a1, a2, b1, b2] = fakeTemplater._seen;
+    expect(a1).toBe(a2);
+    expect(b1).toBe(b2);
+    expect(new Set(fakeTemplater._seen)).toEqual(new Set(["A", "B"]));
+
+    // generate_object fully restored (non-injecting) after both finish.
+    const restored = await fakeTemplater.functions_generator.generate_object();
+    expect((restored as Record<string, unknown>).mcpTools).toBeUndefined();
   });
 
   test("issue #19: read_and_parse_template error surfaces as isError result with verbatim message (no double prefix)", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
@@ -3,6 +3,13 @@ import type { App, TFile } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import { Templater, type PromptArgAccessor } from "shared";
 import { ensureParentFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
+import { createMutex } from "$/features/command-permissions";
+
+// Serializes the global monkey-patch of `generate_object`: concurrent
+// execute_template calls would otherwise restore each other's patch
+// mid-render and corrupt the injected `mcpTools` accessor. Feature-local
+// (NOT the settings mutex) so a slow template never blocks settings I/O.
+const templateExecutionMutex = createMutex();
 
 export const executeTemplateSchema = type({
   name: '"execute_template"',
@@ -90,63 +97,83 @@ export async function executeTemplateHandler(
   const argMap: Record<string, string> = ctx.arguments.arguments ?? {};
 
   // Build the PromptArgAccessor that templates can call via tp.user.mcpTools.prompt(name)
-  const prompt: PromptArgAccessor = (argName: string) =>
-    argMap[argName] ?? "";
+  const prompt: PromptArgAccessor = (argName: string) => argMap[argName] ?? "";
 
-  // Save the original generate_object so we can restore it after execution.
-  // We temporarily override it to inject our `mcpTools.prompt` accessor into
-  // the functions object — matching exactly what main.ts does for the REST
-  // endpoint handler.
-  const oldGenerateObject =
-    templater.functions_generator.generate_object.bind(
-      templater.functions_generator,
-    );
+  // Serialize the patch→render→restore window: a concurrent call would
+  // restore this call's `generate_object` mid-render and corrupt the
+  // injected accessor.
+  return templateExecutionMutex.run(async () => {
+    // Save the original generate_object so we can restore it after execution.
+    // We temporarily override it to inject our `mcpTools.prompt` accessor into
+    // the functions object — matching exactly what main.ts does for the REST
+    // endpoint handler.
+    const oldGenerateObject =
+      templater.functions_generator.generate_object.bind(
+        templater.functions_generator,
+      );
 
-  templater.functions_generator.generate_object = async function (
-    config,
-    functions_mode,
-  ) {
-    const functions = await oldGenerateObject(config, functions_mode);
-    Object.assign(functions, { mcpTools: { prompt } });
-    return functions;
-  };
+    templater.functions_generator.generate_object = async function (
+      config,
+      functions_mode,
+    ) {
+      const functions = await oldGenerateObject(config, functions_mode);
+      Object.assign(functions, { mcpTools: { prompt } });
+      return functions;
+    };
 
-  try {
-    // create_running_config needs a target file — use the template itself as a
-    // stand-in when no targetPath is provided (same pattern as main.ts).
-    const config = templater.create_running_config(
-      templateFile as unknown as TFile,
-      templateFile as unknown as TFile,
-      Templater.RunMode.CreateNewFromTemplate,
-    );
+    try {
+      // create_running_config needs a target file — use the template itself as a
+      // stand-in when no targetPath is provided (same pattern as main.ts).
+      const config = templater.create_running_config(
+        templateFile as unknown as TFile,
+        templateFile as unknown as TFile,
+        Templater.RunMode.CreateNewFromTemplate,
+      );
 
-    const processedContent = await templater.read_and_parse_template(config);
+      const processedContent = await templater.read_and_parse_template(config);
 
-    // Optionally create a vault file at targetPath.
-    //
-    // Issue #20 (folotp, 0.3.12 → ported here): the response includes
-    // `path` so callers chaining off the response (open-in-Obsidian,
-    // follow-up patch, link-rewrite) don't have to re-track the
-    // targetPath themselves. `path` reflects what THIS handler operated
-    // on (`ctx.arguments.targetPath`), not where Templater may have
-    // moved the rendered file via `tp.file.move()` in the prelude —
-    // that's a side effect of the rendering pass and produces a
-    // separate file at the move target. The contract is "the path this
-    // handler operated on", semantically forward-compatible with a
-    // future refactor that delegates to
-    // `templater.create_new_note_from_template(...)`.
-    if (createFile && ctx.arguments.targetPath) {
-      await ensureParentFolderExists(ctx.app, ctx.arguments.targetPath);
-      await ctx.app.vault.create(ctx.arguments.targetPath, processedContent);
+      // Optionally create a vault file at targetPath.
+      //
+      // Issue #20 (folotp, 0.3.12 → ported here): the response includes
+      // `path` so callers chaining off the response (open-in-Obsidian,
+      // follow-up patch, link-rewrite) don't have to re-track the
+      // targetPath themselves. `path` reflects what THIS handler operated
+      // on (`ctx.arguments.targetPath`), not where Templater may have
+      // moved the rendered file via `tp.file.move()` in the prelude —
+      // that's a side effect of the rendering pass and produces a
+      // separate file at the move target. The contract is "the path this
+      // handler operated on", semantically forward-compatible with a
+      // future refactor that delegates to
+      // `templater.create_new_note_from_template(...)`.
+      if (createFile && ctx.arguments.targetPath) {
+        await ensureParentFolderExists(ctx.app, ctx.arguments.targetPath);
+        await ctx.app.vault.create(ctx.arguments.targetPath, processedContent);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  message: "Template executed and file created successfully",
+                  content: processedContent,
+                  path: ctx.arguments.targetPath,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
       return {
         content: [
           {
             type: "text",
             text: JSON.stringify(
               {
-                message: "Template executed and file created successfully",
+                message: "Template executed without creating a file",
                 content: processedContent,
-                path: ctx.arguments.targetPath,
               },
               null,
               2,
@@ -154,43 +181,27 @@ export async function executeTemplateHandler(
           },
         ],
       };
+    } catch (error) {
+      // Issue #19 (folotp): surface the underlying Templater message verbatim
+      // through the `isError`-style result instead of letting it propagate to
+      // the registry's catch — that path wraps the error in McpError, which
+      // some clients then double-prefix as `MCP error -32603: MCP error -32603:
+      // <text>`. Returning `isError: true` keeps the message clean and matches
+      // the convention used by the other vault tools.
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Template execution failed: ${message}`,
+          },
+        ],
+        isError: true,
+      };
+    } finally {
+      // Always restore generate_object — even when an error is thrown — to
+      // avoid leaking the mcpTools injection into subsequent template runs.
+      templater.functions_generator.generate_object = oldGenerateObject;
     }
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(
-            {
-              message: "Template executed without creating a file",
-              content: processedContent,
-            },
-            null,
-            2,
-          ),
-        },
-      ],
-    };
-  } catch (error) {
-    // Issue #19 (folotp): surface the underlying Templater message verbatim
-    // through the `isError`-style result instead of letting it propagate to
-    // the registry's catch — that path wraps the error in McpError, which
-    // some clients then double-prefix as `MCP error -32603: MCP error -32603:
-    // <text>`. Returning `isError: true` keeps the message clean and matches
-    // the convention used by the other vault tools.
-    const message = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Template execution failed: ${message}`,
-        },
-      ],
-      isError: true,
-    };
-  } finally {
-    // Always restore generate_object — even when an error is thrown — to
-    // avoid leaking the mcpTools injection into subsequent template runs.
-    templater.functions_generator.generate_object = oldGenerateObject;
-  }
+  });
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.test.ts
@@ -45,7 +45,12 @@ describe("fetch tool", () => {
       headers: { "content-type": "text/plain" },
     });
     const result = await fetchHandler({
-      arguments: { url: "https://x.com", format: "html", startIndex: 50, maxLength: 30 },
+      arguments: {
+        url: "https://x.com",
+        format: "html",
+        startIndex: 50,
+        maxLength: 30,
+      },
     });
     const text = result.content[0].text as string;
     expect(text.length).toBeLessThanOrEqual(200); // 30 + truncation hint
@@ -80,6 +85,61 @@ describe("fetch tool", () => {
       arguments: { url: "https://example.com" },
     });
     expect(result.content[0].type).toBe("text");
+  });
+
+  // ── FIX 1: SSRF / local-file-read guard ──────────────────────────────────
+  test.each([
+    ["file:///etc/passwd", /scheme/i],
+    ["data:text/plain,hello", /scheme/i],
+    ["blob:https://x/abc", /scheme/i],
+    ["http://127.0.0.1/admin", /internal|loopback/i],
+    ["http://localhost:8080/", /internal|loopback/i],
+    ["http://10.0.0.5/", /internal|loopback/i],
+    ["http://192.168.1.1/", /internal|loopback/i],
+    ["http://169.254.169.254/latest/meta-data/", /internal|loopback/i],
+    ["http://[::1]/", /internal|loopback/i],
+    ["http://printer.local/", /internal|loopback/i],
+    ["not a url", /invalid url/i],
+  ])("rejects %s without performing a request", async (url, pattern) => {
+    const result = await fetchHandler({ arguments: { url } });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Fetch rejected/);
+    expect(result.content[0].text).toMatch(pattern);
+  });
+
+  test("accepts a normal public https URL", async () => {
+    setMockRequestUrl("https://example.com", {
+      status: 200,
+      text: "<p>ok</p>",
+      headers: { "content-type": "text/html" },
+    });
+    const result = await fetchHandler({
+      arguments: { url: "https://example.com" },
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("ok");
+  });
+
+  // ── FIX 2: maxLength clamp ───────────────────────────────────────────────
+  test("clamps an absurd maxLength to the 500k ceiling", async () => {
+    const text = "Y".repeat(600_000);
+    setMockRequestUrl("https://big.com", {
+      status: 200,
+      text,
+      headers: { "content-type": "text/plain" },
+    });
+    const result = await fetchHandler({
+      arguments: {
+        url: "https://big.com",
+        format: "html",
+        maxLength: 5_000_000,
+      },
+    });
+    const resultText = result.content[0].text as string;
+    // Ceiling is 500_000; the remaining 100_000 chars must be truncated,
+    // so the slice cannot exceed ceiling + the (small) truncation note.
+    expect(resultText).toMatch(/truncated|remaining/i);
+    expect(resultText.length).toBeLessThan(500_000 + 500);
   });
 
   test("defaults maxLength to 5000 if not provided", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.ts
@@ -4,6 +4,72 @@ import TurndownService from "turndown";
 
 const DEFAULT_MAX_LENGTH = 5000;
 
+// Hard ceiling on returned characters: an unbounded `maxLength` lets an
+// MCP client request a multi-MB slice and OOM the renderer.
+const MAX_LENGTH_CEILING = 500_000;
+
+// `requestUrl` has no native timeout option; race it against this so a
+// hung host cannot pin the handler indefinitely.
+const REQUEST_TIMEOUT_MS = 30_000;
+
+// Loopback / link-local / RFC-1918 ranges that an MCP client (semi-
+// untrusted in this project's threat model) must not be able to reach
+// via `requestUrl`, which on desktop resolves internal hosts.
+function isPrivateOrLoopbackHost(hostname: string): boolean {
+  // Strip IPv6 brackets if present (URL.hostname keeps them for literals).
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+
+  if (
+    host === "localhost" ||
+    host.endsWith(".local") ||
+    host === "0.0.0.0" ||
+    host === "::" ||
+    host === "::1"
+  ) {
+    return true;
+  }
+
+  // IPv4 literal.
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if (a === 127) return true; // 127.0.0.0/8 loopback
+    if (a === 10) return true; // 10.0.0.0/8
+    if (a === 192 && b === 168) return true; // 192.168.0.0/16
+    if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+    return false;
+  }
+
+  // IPv6 literal: ::1 handled above; fc00::/7 = unique-local (fc/fd prefix).
+  if (host.includes(":")) {
+    if (/^f[cd][0-9a-f]{0,2}:/.test(host)) return true; // fc00::/7
+    if (/^fe[89ab][0-9a-f]:/.test(host)) return true; // fe80::/10 link-local
+  }
+
+  return false;
+}
+
+// Validate the URL before any request is made. Blocks the non-http(s)
+// schemes (file:/data:/blob: — the local-file-read vector) and
+// internal/loopback/RFC-1918 hosts (SSRF). DNS resolution is out of
+// scope, so DNS-rebinding to a private IP is NOT covered here.
+function validateFetchUrl(raw: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return "Invalid URL.";
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return `Unsupported URL scheme "${parsed.protocol}". Only http: and https: are allowed.`;
+  }
+  if (isPrivateOrLoopbackHost(parsed.hostname)) {
+    return `Refusing to fetch internal/loopback host "${parsed.hostname}".`;
+  }
+  return null;
+}
+
 /**
  * Schema for the fetch MCP tool.
  *
@@ -15,7 +81,8 @@ export const fetchSchema = type({
   arguments: {
     // ArkType `string.url` uses the `isParsableUrl` predicate, which is not
     // convertible to JSON Schema and would crash `tools/list`. URL validity
-    // is enforced at runtime by Obsidian's `requestUrl` (see handler).
+    // + scheme/host SSRF guard is enforced at runtime in the handler
+    // (`validateFetchUrl`).
     url: type("string").describe("URL to fetch."),
     "format?": type('"markdown"|"html"').describe(
       "Response format. Default markdown (HTML→MD via Turndown).",
@@ -63,20 +130,60 @@ export type FetchContext = {
  */
 export async function fetchHandler(
   ctx: FetchContext,
-): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
   const format = ctx.arguments.format ?? "markdown";
-  const maxLength = ctx.arguments.maxLength ?? DEFAULT_MAX_LENGTH;
+  const maxLength = Math.min(
+    ctx.arguments.maxLength ?? DEFAULT_MAX_LENGTH,
+    MAX_LENGTH_CEILING,
+  );
   const startIndex = ctx.arguments.startIndex ?? 0;
+
+  const urlError = validateFetchUrl(ctx.arguments.url);
+  if (urlError) {
+    return {
+      content: [{ type: "text", text: `Fetch rejected: ${urlError}` }],
+      isError: true,
+    };
+  }
 
   let response;
   try {
-    response = await requestUrl({ url: ctx.arguments.url });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error("__FETCH_TIMEOUT__")),
+        REQUEST_TIMEOUT_MS,
+      );
+    });
+    try {
+      response = await Promise.race([
+        requestUrl({ url: ctx.arguments.url }),
+        timeout,
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === "__FETCH_TIMEOUT__") {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Fetch failed: request timed out after ${REQUEST_TIMEOUT_MS}ms.`,
+          },
+        ],
+        isError: true,
+      };
+    }
     return {
       content: [
         {
           type: "text",
-          text: `Fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+          text: `Fetch failed: ${message}`,
         },
       ],
       isError: true,

--- a/packages/shared/src/types/prompts.test.ts
+++ b/packages/shared/src/types/prompts.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { type } from "arktype";
+import { PromptFrontmatterSchema } from "./prompts";
+
+// FIX 6: `tags` must be `string[]` AND contain the required literal.
+// A mixed array (e.g. `[42, "mcp-tools-prompt"]`) must be rejected so a
+// non-string element cannot slip past the tag predicate.
+describe("PromptFrontmatterSchema.tags", () => {
+  test("accepts a string array containing the required tag", () => {
+    const r = PromptFrontmatterSchema({
+      tags: ["foo", "mcp-tools-prompt"],
+      description: "ok",
+    });
+    expect(r instanceof type.errors).toBe(false);
+  });
+
+  test("rejects a mixed array with a non-string element", () => {
+    const r = PromptFrontmatterSchema({
+      tags: [42, "mcp-tools-prompt"],
+    });
+    expect(r instanceof type.errors).toBe(true);
+  });
+
+  test("rejects an all-string array missing the required tag", () => {
+    const r = PromptFrontmatterSchema({ tags: ["foo", "bar"] });
+    expect(r instanceof type.errors).toBe(true);
+  });
+
+  test("rejects when tags is not an array at all", () => {
+    const r = PromptFrontmatterSchema({ tags: "mcp-tools-prompt" });
+    expect(r instanceof type.errors).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 (final) input/boundary hardening — 7 independent, file-disjoint fixes in one PR. File-disjoint from open PRs #129/#130/#131. No version bump, no behavior change outside these 7.

### HIGH
1. **SSRF / local-file read in `fetch`** — `validateFetchUrl()` runs before `requestUrl`: rejects any scheme other than `http:`/`https:` (blocks `file:`/`data:`/`blob:` — the local-read vector) and rejects `localhost`, `*.local`, `0.0.0.0`, `[::]`, and loopback/RFC-1918/link-local IP literals (127/8, ::1, 10/8, 172.16/12, 192.168/16, 169.254/16, fc00::/7, fe80::/10). Returns an `isError` MCP result, never throws. DNS-rebinding is **not** covered (no DNS resolution — documented residual).
3. **Shell-exec hardening** — `nodeDetect.ts` + `preWarm.ts` no longer build interpolated shell command strings; switched to no-shell `execFile`. The injectable `runner` seam is preserved but reshaped from `(command)` → `(file, args[, opts])`, so a binary path containing shell metacharacters can no longer inject.

### MEDIUM
2. **`fetch` resource bounds** — effective `maxLength` clamped to `Math.min(req, 500_000)` (OOM guard); `requestUrl` raced against a 30s `setTimeout`-backed `Promise.race` (Obsidian `requestUrl` has no native timeout option), returning an `isError` "request timed out" result.
4. **`executeTemplate` concurrency** — the global `generate_object` monkey-patch/restore window is serialized with a dedicated module-level `createMutex()` local to the feature (NOT `globalSettingsMutex` — avoids the slow-template-blocks-settings / settings-write deadlock coupling).
5. **`createVaultFile` / `appendToVaultFile` folder guard** — duck-typed (`.children !== undefined`, same pattern as the directory tools) so a folder path returns an `isError` result instead of throwing past the handler contract.

### LOW
6. **`prompts` schema** — `PromptFrontmatterSchema.tags` was already `string[]` + literal-narrow on `main` (rejects mixed arrays); added a regression test locking that contract (the plan's premise of an accepting mixed array did not match current `origin/main`).
7. **`patchHelpers` perf** — fence state precomputed once (single O(n) pass) so `isBlockRangeStructurallyUnsafe` is O(n) instead of O(n²) on large files. Pure refactor, byte-identical behavior; #80/#81/#84 safety tests unchanged & green.

## Test plan

- [x] `bun run check` (repo root) → 0 errors, all packages
- [x] `cd packages/obsidian-plugin && bun test` → 743 pass, 2 fail — the **only** failures are the known pre-existing environmental `port.test.ts` cases ("port 27201 in use", a real Obsidian holds it); zero new failures
- [x] `cd packages/shared && bun test` → 21 pass, 0 fail (4 new prompts-schema tests)
- [x] fetch rejects `file://`, `data:`, `blob:`, `http://127.0.0.1`, `http://localhost`, private IPs, `[::1]`, `*.local`; accepts normal `https://`; clamps absurd `maxLength`
- [x] nodeDetect/preWarm runner seam reshaped `(file,args)` + shell-metacharacter no-injection regression tests
- [x] executeTemplate two-overlapping-calls serialization test
- [x] create/appendToVaultFile return `isError` (not throw) on a folder path
- [x] patchHelpers #80/#81/#84 regression suite unchanged & green

🤖 Generated with [Claude Code](https://claude.com/claude-code)