### PR TITLE
docs(readme): troubleshooting for post-upgrade "Server disconnected"

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,13 @@ If you encounter issues:
 - **Check**: open the plugin settings → **Quick setup for clients** → the **Node.js detection** panel reports whether `node` and `npx` are reachable on the path Obsidian inherits when launched from Finder/Spotlight (a common gap on macOS for users who installed Node via Homebrew).
 - **Fix**: if the panel shows "Not found", click **Install via Homebrew** (macOS) or follow the platform-specific link to install Node manually. Restart Obsidian after installing.
 
+### "Server disconnected" after updating from a pre-0.4.9 build
+
+- **Symptom**: Claude Desktop shows `MCP mcp-tools-istefox: Server disconnected`; its logs show `ECONNREFUSED 127.0.0.1:<port>`.
+- **Cause**: pre-0.4.9 builds could fail to release the server port on Obsidian reload/disable and "walk" to the next one (27200 → 27201 → …), so `claude_desktop_config.json` may point at an old walked port while 0.4.9 now correctly binds the default. 0.4.9 fixes the walk; the stale config is a one-time leftover from the old build, not a recurring issue.
+- **Fix**: **fully quit Claude Desktop (Cmd+Q on macOS) and reopen it** — Claude Desktop only re-reads `claude_desktop_config.json` at launch; closing the window or an in-app restart is not enough. With auto-write on (the default) the plugin keeps the config in sync afterward.
+- Still failing? Confirm the port in `claude_desktop_config.json` (`http://127.0.0.1:<port>/mcp`) matches the port the plugin logs on start (Settings → **Open Logs**), ensure only one Obsidian vault has the plugin enabled (two instances contend for the port), then fully restart Claude Desktop again.
+
 ### `tool/call` returns HTTP 401
 
 - The bearer token in your client config does not match the plugin's current token. Open the plugin settings → **Bearer token** → click **Show** to reveal the current token and **Copy** to copy it. Update your client config and restart the client.


### PR DESCRIPTION
## Summary

Adds a Troubleshooting subsection to the README for the predictable upgrade-cohort failure: after updating from a **pre-0.4.9** build, Claude Desktop shows `MCP mcp-tools-istefox: Server disconnected` because `claude_desktop_config.json` still points at a port the old build "walked" to (27200 → 27201 → …), while 0.4.9 now correctly binds the default.

- Symptom / cause / fix in the existing Symptom-Cause-Fix bullet style, placed between "Claude Desktop can't reach the server" and the HTTP 401 entry (connection-level issues grouped before auth-level).
- Fix = **full Claude Desktop quit (Cmd+Q) + reopen** (Claude only re-reads its config at launch — a Claude-Desktop limitation, not the plugin's); honest framing that this is a one-time migration artifact, not a recurring 0.4.9 issue.
- Mirrors the troubleshooting note appended to the **0.4.9 GitHub release body** so the guidance is durable (release notes age out; README doesn't).

Diagnosed from a real reproduction this session (ECONNREFUSED on a walked port; plugin on 27200, config on 27201; resolved by aligning the config + full Claude restart).

README-only; `bun run check` unaffected (no code).

## Test plan

- [x] Renders under `## Troubleshooting`, anchor/TOC unaffected
- [ ] Review wording, then merge at your discretion

🤖 Generated with [Claude Code](https://claude.com/claude-code)