### PR TITLE
chore(gitignore): ignore semantic-search store runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,10 @@ main.js
 bin/
 docs/planning/
 data.json
+# semantic-search store runtime artifacts (written at the repo root by
+# dev/test runs that exercise the vector store; never committed)
+embeddings.bin
+embeddings.index.json*
 tmp/
 
 # Local strategy / private notes & session scaffolding (never in the public repo)


### PR DESCRIPTION
## Summary

`embeddings.bin` / `embeddings.index.json` (+ the `.writing` flush sentinel from #130) are written at the repo root by dev/test runs that exercise the semantic-search vector store. They are runtime data, never committed, but persistently showed as untracked in `git status`. Ignore them next to `data.json` (same category: local plugin/runtime state).

- One-line glob `embeddings.index.json*` also covers the `.writing` sentinel.
- `git check-ignore` confirms both existing untracked files are now ignored.

`.gitignore`-only; no code, `bun run check` unaffected.

## Test plan

- [x] `git check-ignore embeddings.bin embeddings.index.json` → both ignored
- [x] `git status` clean of the embeddings artifacts
- [ ] Merge at your discretion

🤖 Generated with [Claude Code](https://claude.com/claude-code)