### PR TITLE
fix(patch_vault_file): honor fenced code in heading section walker (#137)

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeAppendBody,
   findBlockReferenceInContent,
   findBlockPositionFromCache,
+  findHeadingSectionEnd,
   planFrontmatterReplace,
   planFrontmatterAppend,
 } from "./patchHelpers";
@@ -414,5 +415,106 @@ describe("isBlockRangeStructurallyUnsafe", () => {
   test("rejects when the resolved range covers a fence-delimiter line only", () => {
     const lines = ["before", "```", "after"];
     expect(isBlockRangeStructurallyUnsafe(lines, 1, 1)).toBe(true);
+  });
+});
+
+describe("findHeadingSectionEnd (#137 — heading-branch fenced-code guard)", () => {
+  // R1: ```-fenced block with internal `## …` lines must not be treated as
+  // section boundaries; the real boundary is the next sibling heading.
+  test("R1: backtick fence with internal ## → boundary is the real next H2", () => {
+    const lines = [
+      "## Section A", // 0  target
+      "",
+      "Préambule.",
+      "",
+      "```text", // 4  fence open
+      "## Identity", // 5  NOT a boundary (in fence)
+      "paste",
+      "## Language", // 7  NOT a boundary (in fence)
+      "more",
+      "```", // 9  fence close
+      "",
+      "Postambule.",
+      "",
+      "## Section B", // 13 the real boundary
+      "",
+      "Autre.",
+    ];
+    expect(findHeadingSectionEnd(lines, 0, 2)).toBe(13);
+  });
+
+  // R2: same, with ~~~ fences (CommonMark §4.5 allows ~~~ as a fence char).
+  test("R2: tilde fence with internal ## → boundary is the real next H2", () => {
+    const lines = [
+      "## Section A", // 0
+      "",
+      "~~~text", // 2  fence open
+      "## Identity", // 3  NOT a boundary (in fence)
+      "## Language", // 4  NOT a boundary (in fence)
+      "~~~", // 5  fence close
+      "",
+      "## Section B", // 7  the real boundary
+    ];
+    expect(findHeadingSectionEnd(lines, 0, 2)).toBe(7);
+  });
+
+  // R3: no fenced block (control) — existing behaviour preserved.
+  test("R3: no fence → boundary is the next sibling heading", () => {
+    const lines = ["## A", "", "body", "", "## B", "tail"];
+    expect(findHeadingSectionEnd(lines, 0, 2)).toBe(4);
+  });
+
+  // R4: fence with no internal ## (control) — existing behaviour preserved.
+  test("R4: fence without internal headings → next sibling heading", () => {
+    const lines = [
+      "## A",
+      "",
+      "```js",
+      "const x = 1;",
+      "```",
+      "",
+      "## B",
+    ];
+    expect(findHeadingSectionEnd(lines, 0, 2)).toBe(6);
+  });
+
+  // R5: nested fences (four-backtick wrapping three-backtick) — the inner
+  // ## sample line stays opaque; boundary is the post-outer-close heading.
+  test("R5: nested fences → inner ## opaque, outer boundary honoured", () => {
+    const lines = [
+      "## A", // 0
+      "````md", // 1  outer open (4 backticks)
+      "## not a heading", // 2  NOT a boundary (in outer fence)
+      "```js", // 3  inner sample fence
+      "code();",
+      "```", // 5  inner close
+      "more sample",
+      "````", // 7  outer close
+      "## B", // 8  the real boundary
+      "body B",
+    ];
+    expect(findHeadingSectionEnd(lines, 0, 2)).toBe(8);
+  });
+
+  // R6: indented fence inside a list item — recognised as a fence (trim),
+  // a column-0 ## inside the paste is not a premature boundary.
+  test("R6: indented fence in a list → column-0 ## inside stays opaque", () => {
+    const lines = [
+      "## A", // 0
+      "- list intro", // 1
+      "  ```text", // 2  indented fence open
+      "## paste line", // 3  NOT a boundary (in fence)
+      "  ```", // 4  indented fence close
+      "## B", // 5  the real boundary
+      "end",
+    ];
+    expect(findHeadingSectionEnd(lines, 0, 2)).toBe(5);
+  });
+
+  // Control: a deeper heading inside the section is not a boundary; only a
+  // heading of the same level or shallower closes it. Runs to EOF here.
+  test("deeper heading is not a boundary; section runs to EOF", () => {
+    const lines = ["## A", "", "### sub", "x", "#### deeper", "y"];
+    expect(findHeadingSectionEnd(lines, 0, 2)).toBe(6);
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
@@ -156,7 +156,11 @@ function computeFenceOpenState(lines: string[]): boolean[] {
     // The toggle at line `i` affects lines AFTER `i`, exactly matching
     // the original `for (i = 0; i < lineIdx; i++)` semantics.
     fenceOpen[i] = inFence;
-    if (lines[i].trim().startsWith("```")) inFence = !inFence;
+    // CommonMark §4.5: ``` and ~~~ are both fence delimiters. Naive toggle
+    // (no fence-char/length matching) — matches the existing simplification
+    // and is sufficient for the block (#84) and heading (#137) guards.
+    const t = lines[i].trim();
+    if (t.startsWith("```") || t.startsWith("~~~")) inFence = !inFence;
   }
   return fenceOpen;
 }
@@ -293,6 +297,43 @@ export function isBlockRangeStructurallyUnsafe(
     if (isInsideTableOrFencedCodeAt(lines, i, fenceOpen)) return true;
   }
   return false;
+}
+
+/**
+ * Compute the exclusive end line of a heading's section: the first
+ * subsequent line that is a heading of the same level or shallower
+ * (level number <= `headingLevel`), skipping any line inside a fenced
+ * code block.
+ *
+ * A `## …` line inside a ``` or ~~~ fence is opaque text (CommonMark
+ * §4.5), not a section boundary. Treating it as one silently truncates
+ * a `replace` and leaves the rest of the fence (further `##` lines, the
+ * closing delimiter, the section postamble) orphaned after the new body
+ * — the heading-branch analog of the #84 block-branch bug (fork #137).
+ * The block branch already guards via `isInsideTableOrFencedCode`; this
+ * is the symmetric guard for the heading section walker.
+ *
+ * Args:
+ *   lines: File content split on "\n".
+ *   headingLine: 0-indexed line of the resolved target heading.
+ *   headingLevel: The target heading's level (1-6).
+ *
+ * Returns:
+ *   Exclusive 0-indexed end index; `lines.length` if the section runs
+ *   to EOF.
+ */
+export function findHeadingSectionEnd(
+  lines: string[],
+  headingLine: number,
+  headingLevel: number,
+): number {
+  const fenceOpen = computeFenceOpenState(lines);
+  for (let i = headingLine + 1; i < lines.length; i++) {
+    if (fenceOpen[i]) continue;
+    const m = lines[i].match(/^(#{1,6})\s/);
+    if (m && m[1].length <= headingLevel) return i;
+  }
+  return lines.length;
 }
 
 /**
@@ -647,14 +688,9 @@ export async function applyPatch(
         isError: true,
       };
     }
-    let sectionEnd = lines.length; // exclusive index of last section line
-    for (let i = headingLine + 1; i < lines.length; i++) {
-      const m = lines[i].match(/^(#{1,6})\s/);
-      if (m && m[1].length <= headingLevel) {
-        sectionEnd = i;
-        break;
-      }
-    }
+    // Section end is fence-aware: a `## …` line inside a ``` / ~~~ block
+    // is not a boundary (fork #137 — silent destruction on `replace`).
+    const sectionEnd = findHeadingSectionEnd(lines, headingLine, headingLevel);
 
     // The section body is the lines between the heading and the next heading.
     // We want to insert content just before sectionEnd (append) or just after

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.test.ts
@@ -617,4 +617,81 @@ describe("patch_vault_file — block-in-fenced-code via regex-fallback (#84)", (
     expect(final).toContain("```");
     expect(final).toContain("code");
   });
+
+  // ── #137: heading-branch fenced-code silent-destruction regression ────
+  test("issue #137: heading replace honours fenced code with internal ## (no orphan tail)", async () => {
+    const fixture = [
+      "---",
+      "title: fixture",
+      "type: test",
+      "---",
+      "",
+      "# Root",
+      "",
+      "## Section A",
+      "",
+      "Préambule prose.",
+      "",
+      "```text",
+      "## Identity",
+      "Bloc en mode paste.",
+      "## Language",
+      "Suite du bloc.",
+      "```",
+      "",
+      "Postambule prose.",
+      "",
+      "## Section B",
+      "",
+      "Autre contenu.",
+      "",
+    ].join("\n");
+    setMockFile("Tests/fixture-heading-fenced.md", fixture);
+    const app = mockApp();
+    const newBody = [
+      "Nouveau corps de Section A.",
+      "",
+      "```text",
+      "## Identity",
+      "Bloc remplacé.",
+      "## Language",
+      "Bloc remplacé suite.",
+      "```",
+      "",
+      "Postambule réécrit.",
+      "",
+    ].join("\n");
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Tests/fixture-heading-fenced.md",
+        target: "Root::Section A",
+        targetType: "heading",
+        operation: "replace",
+        targetDelimiter: "::",
+        createTargetIfMissing: false,
+        content: newBody,
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath(
+      "Tests/fixture-heading-fenced.md",
+    );
+    if (!file) throw new Error("expected file");
+    const final = await app.vault.read(file as never);
+
+    // New body landed.
+    expect(final).toContain("Nouveau corps de Section A.");
+    expect(final).toContain("Bloc remplacé.");
+    expect(final).toContain("Postambule réécrit.");
+    // Next section intact, exactly once.
+    expect(final).toContain("## Section B");
+    expect(final).toContain("Autre contenu.");
+    expect(final.match(/^## Section B$/gm)?.length).toBe(1);
+    // The original in-fence tail must be GONE — its survival is the #137
+    // silent-destruction signature (orphan headings + dangling fence).
+    expect(final).not.toContain("Bloc en mode paste.");
+    expect(final).not.toContain("Suite du bloc.");
+    expect(final).not.toContain("Postambule prose.");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #137 — `patch_vault_file targetType:"heading" operation:"replace"` silently corrupted files when the target section contained a fenced code block with internal `## …` lines. The heading-branch section walker tested every line against `^#{1,6}\s` with **no fenced-code state**, so it stopped at the first `##` inside the fence and orphaned the rest (further `##` lines promoted to real headings, dangling close delimiter, section postamble) — returning `"File patched successfully"` with no `isError`.

This is the **heading-branch analog of #84** (block-branch, fixed in 0.4.2 via `isInsideTableOrFencedCode`). The 0.4.2 guard was never applied to the heading walker.

## Change

- Extract the inline `sectionEnd` loop into the exported pure helper **`findHeadingSectionEnd(lines, headingLine, headingLevel)`**, gated by the existing `computeFenceOpenState` O(n) pass.
- Extend `computeFenceOpenState` to recognize **`~~~`** fences as well as ` ``` ` (CommonMark §4.5). Naive toggle, matching the existing simplification level. This symmetrically hardens the **block** guard too (`~~~`-fenced block-ids were a latent #84-class gap); no source/test depended on the old `~~~`-blind behavior.

## Tests (TDD — RED reproduced folotp's exact corruption, then GREEN)

- `findHeadingSectionEnd` unit cases **R1-R6** from the issue (backtick fence, `~~~` fence, no-fence control, fence-without-`##` control, nested fences, indented list fence) + a deeper-heading control.
- End-to-end regression in `patchVaultFile.test.ts` using folotp's **exact #137 fixture**; asserts the original in-fence tail is gone (its survival is the silent-destruction signature).

## Verification

- `bun run check`: `shared` + `obsidian-plugin` clean. (`test-site` check fails pre-existing/unrelated — the known dev-only `vite` override drift; not touched here.)
- `bun test` (obsidian-plugin): 745 pass; the 3 `bindWithFallback` fails are the documented local-port env non-issue (a local Obsidian holding 27200), not a regression — CI is clean.
- Local prod build is blocked by a pre-existing, unrelated Svelte toolchain drift (reproduces on clean `main`); CI's clean `--frozen-lockfile` build is authoritative.

Single-file behavioral change (`patchHelpers.ts`) + tests. No public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)