### PR TITLE
fix(get_vault_file_partial): actionable error when Obsidian's cache drops frontmatter (#138)

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.test.ts
@@ -107,6 +107,60 @@ describe("get_vault_file_partial tool", () => {
       expect(r.content[0].text).toContain("File has no frontmatter");
     });
 
+    // ── #138: cache-empty disambiguation ──────────────────────────────
+    // The tool reflects Obsidian's MetadataCache and never re-parses YAML
+    // (a second parser would diverge from the rest of Obsidian). When a
+    // frontmatter block IS present but the cache exposed nothing (Obsidian's
+    // own parser dropped it — e.g. an unquoted scalar containing ": "), the
+    // error must be actionable, not the misleading "File has no frontmatter".
+    test("#138: fence present but cache empty → actionable parse-divergence error", async () => {
+      setMockFile(
+        "repro.md",
+        [
+          "---",
+          "id: t-repro-018",
+          'purpose: Verify partial-read behavior with patch_vault_file targetType: "block"',
+          "---",
+          "",
+          "# Body",
+        ].join("\n"),
+      );
+      // No setMockMetadata → simulates Obsidian's cache dropping the block.
+      const r = await getVaultFilePartialHandler({
+        arguments: {
+          filename: "repro.md",
+          mode: "frontmatter",
+          target: "purpose",
+        },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).not.toContain("File has no frontmatter");
+      expect(r.content[0].text).toContain("metadata cache");
+      expect(r.content[0].text).toContain(": ");
+    });
+
+    test("#138 R4: empty fence (--- / ---) → still 'File has no frontmatter'", async () => {
+      setMockFile("empty-fm.md", ["---", "---", "", "# Body"].join("\n"));
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "empty-fm.md", mode: "frontmatter", target: "x" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain("File has no frontmatter");
+    });
+
+    test("#138 R5: opening --- with no closing fence → actionable error, not 'no frontmatter'", async () => {
+      setMockFile("malformed.md", ["---", "foo: bar", "still no close"].join("\n"));
+      const r = await getVaultFilePartialHandler({
+        arguments: { filename: "malformed.md", mode: "frontmatter", target: "foo" },
+        app: mockApp(),
+      });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).not.toContain("File has no frontmatter");
+      expect(r.content[0].text).toContain("metadata cache");
+    });
+
     test("supports special-character keys", async () => {
       setMockFile("note.md", "");
       setMockMetadata("note.md", {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
@@ -197,9 +197,32 @@ export async function getVaultFilePartialHandler(
   if (mode === "frontmatter") {
     const fm = cache.frontmatter;
     if (!fm || Object.keys(fm).length === 0) {
-      return errorResponse(
-        `File has no frontmatter: ${filename}.`,
-      );
+      // This tool reflects Obsidian's MetadataCache and never re-parses
+      // YAML independently — a second parser would diverge from what the
+      // rest of Obsidian (UI, Linter, other plugins) sees (#138). When the
+      // cache is empty, disambiguate "genuinely no frontmatter" from "a
+      // frontmatter block exists but Obsidian's own parser dropped it" so
+      // the error is actionable instead of misleading.
+      const fmLines = (await ctx.app.vault.cachedRead(file)).split("\n");
+      let blockHasContent = false;
+      if (fmLines[0]?.trim() === "---") {
+        let closeIdx = -1;
+        for (let i = 1; i < fmLines.length; i++) {
+          if (fmLines[i].trim() === "---") {
+            closeIdx = i;
+            break;
+          }
+        }
+        const region =
+          closeIdx === -1 ? fmLines.slice(1) : fmLines.slice(1, closeIdx);
+        blockHasContent = region.some((l) => l.trim() !== "");
+      }
+      if (blockHasContent) {
+        return errorResponse(
+          `Frontmatter block present in ${filename} but Obsidian's metadata cache exposed no fields — its YAML parser could not read it. Common cause: an unquoted scalar whose value contains ": " (e.g. \`key: a value with: a colon\`); quote the value (\`key: "a value with: a colon"\`). This tool reflects Obsidian's cache and does not re-parse YAML independently, so the source file must be fixed.`,
+        );
+      }
+      return errorResponse(`File has no frontmatter: ${filename}.`);
     }
     const key = target!.trim();
     if (!(key in fm)) {


### PR DESCRIPTION
## Summary

Addresses #138 — `get_vault_file_partial mode="frontmatter"` returned the misleading `"File has no frontmatter"` for files whose frontmatter contains an unquoted scalar with an embedded `": "` (invalid for a plain block scalar).

## Root-cause correction (verified against the code)

The issue hypothesizes a *strict YAML parser* in the tool. **There is none** — `getVaultFilePartial.ts` has zero YAML/parse code; `mode="frontmatter"` reads **only** `app.metadataCache.getFileCache().frontmatter` (Obsidian's own permissive cache). The field is dropped by **Obsidian's** parser because `purpose: … targetType: "block"` is not a valid plain block scalar (a plain scalar may not contain `": "`). The tool faithfully reflects an empty cache.

Consequences for the proposed fixes:
- **Option 1 ("align with Obsidian's cache")** is already the behavior — the tool *is* the cache. Returning the value would require re-introducing an independent parser, recreating the strict-vs-permissive divergence the issue explicitly wants to avoid, and violating the project rule against bypassing Obsidian's metadata cache.
- **Option 2 (actionable error)** — implemented here.

## Change

When the cache is empty, structurally inspect the raw text (`vault.cachedRead`, split by line): if a non-empty `---` … `---` block exists (or an unclosed opening `---`), return an actionable error naming the likely cause (`": "` in an unquoted scalar) and the fix (quote it), and stating that the tool reflects Obsidian's cache by design so the file must be fixed at the source. Empty fences (`---`/`---`) and fence-less files keep the original `"File has no frontmatter"` message.

## Tests (TDD)

- `#138`: fence + malformed scalar, cache empty → actionable error, **not** "File has no frontmatter".
- `#138 R4`: empty fence → still "File has no frontmatter" (control, unchanged).
- `#138 R5`: opening `---` with no close → actionable error (previously masked).
- Pre-existing "no frontmatter at all" (fence-less) test still green.

## Verification

- `bun run check`: `shared` + `obsidian-plugin` clean (`test-site` failure is the pre-existing unrelated `vite` drift).
- `bun test` (obsidian-plugin): 748 pass; the 3 `bindWithFallback` fails are the documented local-port env non-issue, not a regression.
- Local prod build blocked by the same pre-existing, unrelated Svelte toolchain drift (reproduces on clean `main`); CI's clean build is authoritative.

Read-only path; no data-corruption surface. Single-file behavioral change (error message path) + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)