### PR TITLE
feat(patch_vault_file): allow root H2+ in H1-free docs; allowRootHeadings opt-in (#139)

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   hasParentH1,
+  hasAnyH1,
   isInsideTableOrFencedCode,
   isBlockRangeStructurallyUnsafe,
   resolveHeadingPath,
@@ -252,6 +253,30 @@ describe("hasParentH1", () => {
   test("ignores `#` characters that are not at column 0 of a heading line", () => {
     const lines = ["Some prose with # not-a-heading", "## Real"];
     expect(hasParentH1(lines, 1)).toBe(false);
+  });
+});
+
+describe("hasAnyH1 (#139 — narrowed-A: whole-file H1 detection)", () => {
+  test("true when an H1 exists anywhere, including after the target", () => {
+    const lines = ["## Early", "", "# Later H1", "", "## Under"];
+    expect(hasAnyH1(lines)).toBe(true);
+  });
+
+  test("true when H1 is the only heading", () => {
+    expect(hasAnyH1(["# Only"])).toBe(true);
+  });
+
+  test("false for an entirely H1-free document (frontmatter + H2s)", () => {
+    const lines = ["---", "title: My Note", "---", "", "## A", "", "## B"];
+    expect(hasAnyH1(lines)).toBe(false);
+  });
+
+  test("false on empty input", () => {
+    expect(hasAnyH1([])).toBe(false);
+  });
+
+  test("ignores `#` not at column 0 of a heading line", () => {
+    expect(hasAnyH1(["prose with # not-a-heading", "## H2"])).toBe(false);
   });
 });
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
@@ -144,6 +144,24 @@ export function hasParentH1(lines: string[], headingLine: number): boolean {
 }
 
 /**
+ * Whether the document contains any level-1 (`# `) heading at all. Used by
+ * the #139 narrowed-A relaxation of the H2-root guard: a root-orphan H2 is
+ * only structurally ambiguous when an H1 exists *elsewhere* (a mixed
+ * document). An entirely H1-free file — the common Obsidian
+ * frontmatter-`title:` pattern, body starting at `##` — has an
+ * unambiguous root and is safe to patch.
+ *
+ * Args:
+ *   lines: The file content split on `\n`.
+ *
+ * Returns:
+ *   true if any line is a level-1 heading (`/^#\s/`), false otherwise.
+ */
+export function hasAnyH1(lines: string[]): boolean {
+  return lines.some((l) => /^#\s/.test(l));
+}
+
+/**
  * Precompute, in a single O(n) pass, whether each line sits inside an
  * open fenced code block — i.e. `fenceOpen[i]` is the value the old
  * `count ``` up to lineIdx` loop would have produced for `lineIdx = i`.
@@ -483,6 +501,7 @@ export type PatchArgs = {
   content: string;
   targetDelimiter?: string;
   createTargetIfMissing?: boolean;
+  allowRootHeadings?: boolean;
 };
 
 /**
@@ -628,20 +647,25 @@ export async function applyPatch(
     // higher level (lower number means higher in hierarchy), or EOF.
     const headingLevel = lines[headingLine].match(/^(#+)/)?.[1].length ?? 1;
 
-    // 0.3.9 #16 parity: reject root-orphan H2+ when createTargetIfMissing=false.
-    // The legacy LRA chain enforced this via markdown-patch's indexer; the
-    // 0.4.0 in-process port missed the gate (folotp round-3 regression on
-    // the actual HTTP-embedded chain — see fork #80, #83).
+    // 0.3.9 #16 parity: reject root-orphan H2+ when createTargetIfMissing=false
+    // (legacy LRA enforced this via markdown-patch's indexer; the 0.4.0
+    // in-process port missed it — fork #80, #83). #139 narrowed this: the
+    // section boundary is only ambiguous when an H1 exists *elsewhere* (a
+    // mixed document). An entirely H1-free file (frontmatter-`title:`
+    // pattern) has an unambiguous root and is allowed; `allowRootHeadings`
+    // is the explicit opt-in for the mixed case.
     if (
       headingLevel >= 2 &&
       !createIfMissing &&
-      !hasParentH1(lines, headingLine)
+      !hasParentH1(lines, headingLine) &&
+      !args.allowRootHeadings &&
+      hasAnyH1(lines)
     ) {
       return {
         content: [
           {
             type: "text",
-            text: `Heading "${args.target}" is a level-${headingLevel} heading at the root of the file with no level-1 (#) parent. Refusing to patch a root-orphan heading; the section boundary is ambiguous. Add an explicit level-1 heading or pass createTargetIfMissing:true to bypass.`,
+            text: `Heading "${args.target}" is a level-${headingLevel} heading with no level-1 (#) parent, while the document does contain an H1 elsewhere — the section boundary is ambiguous. Refusing to patch. Pass allowRootHeadings:true to target it explicitly, or createTargetIfMissing:true to bypass. (Files with no H1 at all are accepted automatically.)`,
           },
         ],
         isError: true,

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.test.ts
@@ -270,8 +270,12 @@ describe("patch_active_file tool", () => {
   // mis-identification was corrected (soak round 3, issues #80/#81 thread).
   // See issues #80 (H2-root) and #81 (block-in-table/fenced-code).
 
-  test("#80: rejects level-2 root-orphan heading replace when createTargetIfMissing=false", async () => {
-    setMockFile("a.md", "## RootHeading\n\nBody content.\n");
+  test("#80 (mixed doc) still rejects root-orphan H2 when an H1 exists elsewhere (createTargetIfMissing=false)", async () => {
+    // #139 narrowed the guard: an entirely H1-free file is now allowed
+    // (the legit frontmatter-title pattern). A mixed doc — H1 present but
+    // not a parent of the target H2 — remains ambiguous, so #80's reject
+    // is preserved here.
+    setMockFile("a.md", "## RootHeading\n\nBody content.\n\n# Real Title\n\nx\n");
     setMockActiveFile("a.md");
     const result = await patchActiveFileHandler({
       arguments: {
@@ -284,7 +288,26 @@ describe("patch_active_file tool", () => {
       app: mockApp(),
     });
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/level-2 heading at the root/i);
+    expect(result.content[0].text).toMatch(/level-2 heading with no level-1/i);
+  });
+
+  test("#139 narrowed-A: entirely H1-free active file → root H2 replace succeeds (no flag)", async () => {
+    setMockFile(
+      "a.md",
+      "---\ntitle: My Note\n---\n\n## Introduction\n\nSome content.\n\n## Conclusion\n\nMore.\n",
+    );
+    setMockActiveFile("a.md");
+    const result = await patchActiveFileHandler({
+      arguments: {
+        operation: "replace",
+        targetType: "heading",
+        target: "Introduction",
+        createTargetIfMissing: false,
+        content: "Updated.\n",
+      },
+      app: mockApp(),
+    });
+    expect(result.isError).toBeUndefined();
   });
 
   test("#80: succeeds on H2 nested under H1 (control)", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
@@ -4,6 +4,7 @@ import {
   resolveHeadingPath,
   findBlockPositionFromCache,
   hasParentH1,
+  hasAnyH1,
   isBlockRangeStructurallyUnsafe,
   normalizeAppendBody,
   planFrontmatterReplace,
@@ -24,6 +25,9 @@ export const patchActiveFileSchema = type({
     ),
     "targetDelimiter?": "string",
     "createTargetIfMissing?": "boolean",
+    "allowRootHeadings?": type("boolean").describe(
+      "When true, allow targeting a level-2-or-deeper heading with no level-1 (#) parent even when the document contains an H1 elsewhere (the ambiguous 'mixed' case the H2-root guard rejects with createTargetIfMissing=false). Files with no H1 at all are accepted without this flag. Default false.",
+    ),
   },
 }).describe(
   "Patches the currently active note relative to a heading, block reference, or frontmatter key.",
@@ -37,6 +41,7 @@ export type PatchActiveFileContext = {
     content: string;
     targetDelimiter?: string;
     createTargetIfMissing?: boolean;
+    allowRootHeadings?: boolean;
   };
   app: App;
 };
@@ -171,19 +176,23 @@ export async function applyPatch(
 
     // 0.3.9 #16 parity: reject root-orphan H2+ when createTargetIfMissing=false.
     // Mirror of the gate in services/patchHelpers.ts:applyPatch — see fork #80,
-    // #83. The two applyPatch impls are duplicated; the shared
-    // hasParentH1 helper keeps the policy in one place.
+    // #83. #139 narrowed it: ambiguous only when an H1 exists elsewhere
+    // (mixed doc); an H1-free file is allowed, `allowRootHeadings` is the
+    // explicit opt-in for the mixed case. The shared hasParentH1/hasAnyH1
+    // helpers keep the policy in one place across the two applyPatch impls.
     if (
       headingLine !== -1 &&
       headingLevel >= 2 &&
       !createIfMissing &&
-      !hasParentH1(lines, headingLine)
+      !hasParentH1(lines, headingLine) &&
+      !args.allowRootHeadings &&
+      hasAnyH1(lines)
     ) {
       return {
         content: [
           {
             type: "text",
-            text: `Heading "${args.target}" is a level-${headingLevel} heading at the root of the file with no level-1 (#) parent. Refusing to patch a root-orphan heading; the section boundary is ambiguous. Add an explicit level-1 heading or pass createTargetIfMissing:true to bypass.`,
+            text: `Heading "${args.target}" is a level-${headingLevel} heading with no level-1 (#) parent, while the document does contain an H1 elsewhere — the section boundary is ambiguous. Refusing to patch. Pass allowRootHeadings:true to target it explicitly, or createTargetIfMissing:true to bypass. (Files with no H1 at all are accepted automatically.)`,
           },
         ],
         isError: true,

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.test.ts
@@ -345,9 +345,13 @@ describe("patch_vault_file tool", () => {
 // (soak round 3, issues #80/#81 thread). See issues #80 and #81.
 
 describe("patch_vault_file — H2-root reject (#80)", () => {
-  test("rejects level-2 root-orphan heading replace when createTargetIfMissing=false (folotp R1)", async () => {
-    // Folotp's fixture verbatim: a root-level H2 with no H1 parent.
-    setMockFile("Notes/r1.md", "## RootHeading\n\nBody content.\n");
+  test("#80 (mixed doc) still rejects root-orphan H2 when an H1 exists elsewhere (createTargetIfMissing=false)", async () => {
+    // #139 narrowed the H2-root guard: a *mixed* document (an H1 exists
+    // somewhere, but the target H2 has no H1 parent) is still ambiguous,
+    // so the #80 reject is preserved here. The H1-free sub-case that #80
+    // originally filed is now intentionally allowed — see the #139 tests.
+    const fixture = "## RootHeading\n\nBody content.\n\n# Real Title\n\n## Under\n\nx\n";
+    setMockFile("Notes/r1.md", fixture);
     const app = mockApp();
     const result = await patchVaultFileHandler({
       arguments: {
@@ -361,12 +365,12 @@ describe("patch_vault_file — H2-root reject (#80)", () => {
       app,
     });
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/level-2 heading at the root/i);
+    expect(result.content[0].text).toMatch(/level-2 heading with no level-1/i);
     // File content must be unchanged.
     const file = app.vault.getAbstractFileByPath("Notes/r1.md");
     if (!file) throw new Error("expected file");
     const final = await app.vault.read(file as never);
-    expect(final).toBe("## RootHeading\n\nBody content.\n");
+    expect(final).toBe(fixture);
   });
 
   test("succeeds on H2 nested under H1 (control: not root-orphan)", async () => {
@@ -403,8 +407,8 @@ describe("patch_vault_file — H2-root reject (#80)", () => {
     expect(result.isError).toBeUndefined();
   });
 
-  test("rejects level-3 root-orphan heading symmetrically (parity)", async () => {
-    setMockFile("Notes/r1d.md", "### Deep\n\nBody.\n");
+  test("#80 (mixed doc) rejects level-3 root-orphan heading symmetrically (parity)", async () => {
+    setMockFile("Notes/r1d.md", "### Deep\n\nBody.\n\n# Real Title\n\nx\n");
     const app = mockApp();
     const result = await patchVaultFileHandler({
       arguments: {
@@ -418,7 +422,83 @@ describe("patch_vault_file — H2-root reject (#80)", () => {
       app,
     });
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/level-3 heading at the root/i);
+    expect(result.content[0].text).toMatch(/level-3 heading with no level-1/i);
+  });
+
+  // ── #139: B (explicit allowRootHeadings) + narrowed-A (H1-free file) ──
+  test("#139 narrowed-A: entirely H1-free file → root H2 replace succeeds (createTargetIfMissing=false, no flag)", async () => {
+    // folotp's #139 fixture: title via frontmatter, body starts at H2.
+    const fixture =
+      "---\ntitle: My Note\n---\n\n## Introduction\n\nSome content here.\n\n## Conclusion\n\nMore content.\n";
+    setMockFile("Notes/h1free.md", fixture);
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/h1free.md",
+        operation: "replace",
+        targetType: "heading",
+        target: "Introduction",
+        createTargetIfMissing: false,
+        content: "Updated content.\n",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/h1free.md");
+    if (!file) throw new Error("expected file");
+    const final = await app.vault.read(file as never);
+    expect(final).toContain("Updated content.");
+    expect(final).not.toContain("Some content here.");
+    expect(final).toContain("## Conclusion");
+    expect(final).toContain("More content.");
+  });
+
+  test("#139 B: mixed doc + allowRootHeadings:true → root-orphan H2 replace bypasses the guard", async () => {
+    setMockFile(
+      "Notes/optin.md",
+      "## Orphan\n\nold\n\n# Real Title\n\n## Under\n\ny\n",
+    );
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/optin.md",
+        operation: "replace",
+        targetType: "heading",
+        target: "Orphan",
+        createTargetIfMissing: false,
+        allowRootHeadings: true,
+        content: "REPLACED.\n",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Notes/optin.md");
+    if (!file) throw new Error("expected file");
+    const final = await app.vault.read(file as never);
+    expect(final).toContain("REPLACED.");
+    expect(final).not.toContain("old");
+    expect(final).toContain("# Real Title");
+  });
+
+  test("#139: mixed doc, no flag → still rejected (contract: narrowed-A does not weaken the ambiguous case)", async () => {
+    setMockFile(
+      "Notes/mixed.md",
+      "## Orphan\n\nbody\n\n# Real Title\n\n## Under\n\nz\n",
+    );
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/mixed.md",
+        operation: "replace",
+        targetType: "heading",
+        target: "Orphan",
+        createTargetIfMissing: false,
+        content: "X.\n",
+      },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/level-2 heading with no level-1/i);
   });
 });
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
@@ -21,6 +21,9 @@ export const patchVaultFileSchema = type({
     "createTargetIfMissing?": type("boolean").describe(
       "When true, creates the target if not found. Defaults to true for heading/frontmatter, false for block. Note: with the default `true` for headings, patching a level-2-or-deeper heading on a file that has no parent H1 will silently create the section instead of failing loud — pass `false` explicitly to get the H2-root reject guard if your vault treats a missing H1 as an integrity error.",
     ),
+    "allowRootHeadings?": type("boolean").describe(
+      "When true, allow targeting a level-2-or-deeper heading that has no level-1 (#) parent even in a document that contains an H1 elsewhere (the ambiguous 'mixed' case the H2-root guard otherwise rejects with createTargetIfMissing=false). Files with no H1 at all are already accepted without this flag. Default false.",
+    ),
   },
 }).describe(
   "Patches a vault file relative to a heading, block reference, or frontmatter key. Unlike patch_active_file, operates on any file by vault-relative path.",
@@ -35,6 +38,7 @@ export type PatchVaultFileContext = {
     content: string;
     targetDelimiter?: string;
     createTargetIfMissing?: boolean;
+    allowRootHeadings?: boolean;
   };
   app: App;
 };


### PR DESCRIPTION
## Summary

Implements #139 with **B + narrowed-A** (the agreed design).

The H2-root guard (#80) rejected *every* level-2+ heading with no H1 parent when `createTargetIfMissing=false`, returning JSON-RPC -32602. That blocks heading patching entirely on the common Obsidian convention: note title via frontmatter `title:`, body starting directly at `##`.

## Change

- **Narrowed-A:** the section boundary is only ambiguous when an H1 exists **elsewhere** in the document (a *mixed* doc). An entirely H1-free file has an unambiguous root and is now accepted **automatically, no flag**. New shared pure helper `hasAnyH1(lines)`.
- **B:** explicit opt-in `allowRootHeadings: true` (default false) bypasses the guard for the mixed/ambiguous case.
- Applied symmetrically to **both** `applyPatch` impls (`patchHelpers.ts` shared + the duplicated one in `patchActiveFile.ts`) and **both** tool schemas (`patch_vault_file`, `patch_active_file`), since the guard and `PatchArgs` are shared across the two tools.
- Reject message updated to name both bypasses and to state H1-free files are auto-accepted.

## #80 is preserved (not gutted)

The genuinely ambiguous case — an H1 present but not a parent of the target H2 — **still rejects** without the flag. The #80 reject tests were repurposed to that mixed shape and remain green; only the H1-free sub-case #80 originally filed is intentionally superseded. folotp authored both #80 and #139, so this is the reporter's own contract refinement, made explicit in comments and tests.

## Tests (TDD)

- `hasAnyH1` unit cases (H1 anywhere incl. after target, only-H1, H1-free w/ frontmatter, empty, non-col-0 `#`).
- `#139` narrowed-A: entirely H1-free file → root H2 replace **succeeds** (vault + active), folotp's exact fixture.
- `#139` B: mixed doc + `allowRootHeadings:true` → bypasses, succeeds.
- `#139` regression: mixed doc, no flag → **still rejects** (contract guard).
- #80 reject tests repurposed to mixed fixtures, still green (level-2 & level-3 parity, vault & active).

## Verification

- `bun run check`: `shared` + `obsidian-plugin` clean (`test-site` failure is the pre-existing unrelated `vite` drift).
- `bun test` (obsidian-plugin): 746 pass; the 3 `bindWithFallback` fails are the documented local-port env non-issue, not a regression.
- Local prod build blocked by the same pre-existing, unrelated Svelte toolchain drift (reproduces on clean `main`); CI's clean build is authoritative.

Not stacked on #140/#141 — branched off `main`; will rebase after those merge (adjacent edits in the `applyPatch` heading branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)