### PR TITLE
docs(changelog): populate [Unreleased] for 0.4.10 + CLAUDE.md version sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ## [Unreleased]
 
+### Added
+
+- **Heading patching now works on notes with no H1.** `patch_vault_file`
+  and `patch_active_file` heading targets succeed on the common
+  Obsidian pattern of a frontmatter `title:` with the body starting at
+  `##` — a file with no `#` heading at all has an unambiguous root and
+  is accepted automatically. A new optional `allowRootHeadings`
+  parameter opts in to the same for the ambiguous case where an H1
+  exists elsewhere in the note (default off; the existing fail-loud
+  guard is unchanged for that case without it).
+
+### Fixed
+
+- **Heading `replace` no longer destroys content around fenced code
+  (data integrity).** Replacing a heading section whose body contained
+  a fenced code block with `##` lines inside silently truncated at the
+  first in-fence `##`, leaving the rest of the block (and the section
+  tail) orphaned in the file while reporting success. The section
+  boundary now treats lines inside ` ``` ` / `~~~` fences as opaque,
+  for both `patch_vault_file` and `patch_active_file`.
+- **`get_vault_file_partial` frontmatter mode gives an actionable
+  error.** When a frontmatter block is present but Obsidian's metadata
+  cache could not parse it (commonly an unquoted scalar whose value
+  contains `": "`), the tool reported a misleading "File has no
+  frontmatter"; it now names the likely cause and the fix.
+
 ## [0.4.9] — 2026-05-17
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,11 @@ One shipped component on the 0.4.x line:
 
 Why operations go through Obsidian APIs rather than reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the plugin invoke other Obsidian plugins (Templater, Dataview) through their APIs.
 
-Current line: **`main` = 0.4.8** — the standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16); no separate binary, native semantic search via Transformers.js. **Accepted & listed in the Obsidian community plugin store** (id `mcp-tools-istefox`, 2026-05-16; Obsidian shows a standard "not manually reviewed by Obsidian staff" disclaimer — automated review path). The `packages/mcp-server` binary and `features/mcp-server-install` installer are retired. The 0.3.x stdio/binary line is archived at `archive/main-0.3.12` (abandoned; tags retained). The `[Unreleased]` block in `CHANGELOG.md` accumulates the next cut; consult `CHANGELOG.md` for its current contents (do not enumerate here — it drifts). License: MIT.
+Current line: **`main` = 0.4.10** — the standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16); no separate binary, native semantic search via Transformers.js. **Accepted & listed in the Obsidian community plugin store** (id `mcp-tools-istefox`, 2026-05-16; Obsidian shows a standard "not manually reviewed by Obsidian staff" disclaimer — automated review path). The `packages/mcp-server` binary and `features/mcp-server-install` installer are retired. The 0.3.x stdio/binary line is archived at `archive/main-0.3.12` (abandoned; tags retained). The `[Unreleased]` block in `CHANGELOG.md` accumulates the next cut; consult `CHANGELOG.md` for its current contents (do not enumerate here — it drifts). License: MIT.
 
 ### Branch protection policy
 
-**`main` is the production line** — standalone in-process HTTP MCP server, currently **0.4.8** (0.4.x promoted to `main` 2026-05-16; accepted & listed in the Obsidian community store). The historical rule "don't merge `feat/http-embedded` → `main` until Stefano decides the 0.4.0 bump" is **discharged**: the promotion has happened; `main` IS the 0.4.x line. Normal branch + PR discipline now applies.
+**`main` is the production line** — standalone in-process HTTP MCP server, currently **0.4.10** (0.4.x promoted to `main` 2026-05-16; accepted & listed in the Obsidian community store). The historical rule "don't merge `feat/http-embedded` → `main` until Stefano decides the 0.4.0 bump" is **discharged**: the promotion has happened; `main` IS the 0.4.x line. Normal branch + PR discipline now applies.
 
 `feat/http-embedded` was **retired (deleted from origin) 2026-05-16** — it was 0-ahead/29-behind `main` at the time, so nothing was lost (it was removed from the `General` ruleset first, keeping `main` protection intact). `main` is the sole, authoritative line.
 
@@ -309,9 +309,9 @@ Active traps in the current tree. Historical bugs already fixed are in `git log`
 
 3. **`bun run check` at the repo root** (again) — shared-package changes cascade; both runtime packages must still type-check.
 
-## Project status (2026-05-16)
+## Project status (2026-05-18)
 
-- `main` at **0.4.8** — standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16). Tools: 29. `minAppVersion: 1.7.2`. Distributed via the **Obsidian community store** (accepted & listed, id `mcp-tools-istefox`) **and** BRAT. Tag stack `0.4.0` → `0.4.8`.
+- `main` at **0.4.10** — standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16). Tools: 29. `minAppVersion: 1.7.2`. Distributed via the **Obsidian community store** (accepted & listed, id `mcp-tools-istefox`) **and** BRAT. Tag stack `0.4.0` → `0.4.10`.
 - `archive/main-0.3.12` — the retired 0.3.x stdio/binary line (20 MCP tools). Preserved for historical reference; HEAD `76fa012` 2026-04-28; tag stack `0.3.0` → `0.3.12`. No active development.
 - **Community store: ACCEPTED & LISTED** (2026-05-16) — id `mcp-tools-istefox` in `obsidianmd/obsidian-releases/community-plugins.json`; installable in-app + via BRAT. Obsidian shows a standard "not manually reviewed by Obsidian staff" disclaimer (automated review path; high-risk `fs`/`child_process` capability disclosures, which are intrinsic and were deliberately NOT removed). The legacy PR-based submission `obsidianmd/obsidian-releases#11919` was closed (process moved to the community.obsidian.md portal). Consult `CHANGELOG.md` for the current `[Unreleased]` state.
 


### PR DESCRIPTION
## Summary

Pre-release CHANGELOG population for **0.4.10** (mirrors the #133 → 0.4.9 pattern) plus the release-gate CLAUDE.md version sync.

- `CHANGELOG.md` `[Unreleased]`: **Added** #139 (H1-free heading patching + `allowRootHeadings`), **Fixed** #137 (heading-replace fenced-code data destruction) and #138 (`get_vault_file_partial` actionable frontmatter error). User-notable prose only, no issue numbers in the body (existing style).
- `CLAUDE.md`: `Current line` / branch-protection / `## Project status` bumped `0.4.8` → `0.4.10` (the 0.4.9 release left this drifted; swept now per the release-gate rule). Status snapshot date → 2026-05-18.

No code changes. The `[0.4.10]` retitle + version-file bump + tag happen on the `release/0.4.10` branch next, per the documented flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)