### PR TITLE
feat(0.4): rename_heading + rewrite-safety hardening (#68; builds on #143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ## [Unreleased]
 
+### Added
+
+- **`rename_heading` tool** — renames a heading in a vault file and
+  rewrites every backlinking reference (wikilinks, markdown links, and
+  subheading-path links) across the vault so links keep resolving.
+  Multi-match is disambiguated with an optional `from.level`; an
+  ambiguous match, a name collision with an existing heading, or a
+  mid-walk write failure each fail loud with a specific `errorCode`
+  and a recoverable file list.
+
 ## [0.4.10] — 2026-05-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guidance for Claude Code (and similar AI agents) working in this repository.
 
 One shipped component on the 0.4.x line:
 
-1. **Obsidian plugin** — hosts an in-process HTTP MCP server (port 27200 default), writes `claude_desktop_config.json`, exposes all 29 MCP tools and prompts over streamable-HTTP. No separate binary. Semantic search via native Transformers.js (no Smart Connections dependency).
+1. **Obsidian plugin** — hosts an in-process HTTP MCP server (port 27200 default), writes `claude_desktop_config.json`, exposes all 30 MCP tools and prompts over streamable-HTTP. No separate binary. Semantic search via native Transformers.js (no Smart Connections dependency).
 
 Why operations go through Obsidian APIs rather than reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the plugin invoke other Obsidian plugins (Templater, Dataview) through their APIs.
 
@@ -153,7 +153,7 @@ Rules:
 
 Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are exposed.
 
-### Tools (29 total, 0.4.x)
+### Tools (30 total, 0.4.x)
 
 **Vault file management** — `packages/obsidian-plugin/src/features/mcp-tools/tools/`:
 
@@ -172,6 +172,7 @@ Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are expos
 | `append_to_vault_file` | Append to an arbitrary file. |
 | `patch_vault_file` | Heading/block/frontmatter-aware insert into a file. |
 | `delete_vault_file` | Delete a file. |
+| `rename_heading` | Rename a heading in a file and rewrite every backlinking reference (wikilinks, markdown links, subheading-path links) across the vault so links keep resolving. |
 | `search_vault` | Search via Dataview DQL or JsonLogic query. |
 | `search_vault_simple` | Plain text search with context window. |
 
@@ -311,7 +312,7 @@ Active traps in the current tree. Historical bugs already fixed are in `git log`
 
 ## Project status (2026-05-18)
 
-- `main` at **0.4.10** — standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16). Tools: 29. `minAppVersion: 1.7.2`. Distributed via the **Obsidian community store** (accepted & listed, id `mcp-tools-istefox`) **and** BRAT. Tag stack `0.4.0` → `0.4.10`.
+- `main` at **0.4.10** — standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16). Tools: 30. `minAppVersion: 1.7.2`. Distributed via the **Obsidian community store** (accepted & listed, id `mcp-tools-istefox`) **and** BRAT. Tag stack `0.4.0` → `0.4.10`.
 - `archive/main-0.3.12` — the retired 0.3.x stdio/binary line (20 MCP tools). Preserved for historical reference; HEAD `76fa012` 2026-04-28; tag stack `0.3.0` → `0.3.12`. No active development.
 - **Community store: ACCEPTED & LISTED** (2026-05-16) — id `mcp-tools-istefox` in `obsidianmd/obsidian-releases/community-plugins.json`; installable in-app + via BRAT. Obsidian shows a standard "not manually reviewed by Obsidian staff" disclaimer (automated review path; high-risk `fs`/`child_process` capability disclosures, which are intrinsic and were deliberately NOT removed). The legacy PR-based submission `obsidianmd/obsidian-releases#11919` was closed (process moved to the community.obsidian.md portal). Consult `CHANGELOG.md` for the current `[Unreleased]` state.
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Starting with **0.4.0**, the plugin hosts the MCP server **in-process inside Obs
 - **HTTP-native MCP clients** (Claude Code, Cursor, Cline, Continue, Windsurf, VS Code) connect directly to the local HTTP endpoint.
 - **Claude Desktop** (which speaks only stdio MCP) connects through the official `npx mcp-remote` bridge — a two-line config the plugin generates for you.
 - **Native semantic search** runs entirely on-device via Transformers.js + `Xenova/all-MiniLM-L6-v2` (~25 MB, downloaded once and cached). No cloud, no Smart Connections requirement.
-- **Local REST API is now optional**: only the `search_vault` tool (Dataview DQL / JsonLogic queries) needs it, and that tool returns an actionable error if it isn't installed. The other 28 tools work without it. [^4]
+- **Local REST API is now optional**: only the `search_vault` tool (Dataview DQL / JsonLogic queries) needs it, and that tool returns an actionable error if it isn't installed. The other 29 tools work without it. [^4]
 
 ## Features
 
 When connected to an MCP-compatible client, this plugin enables:
 
-- **Vault access** — read, write, and patch notes through 17 typed tools (`get_vault_file`, `create_vault_file`, `patch_vault_file`, `rename_vault_file`, `list_vault_files`, `create_vault_directory`, `delete_vault_directory`, …) with native binary content for images and audio. Missing parent directories on a `create`/`append` path are auto-created. `rename_vault_file` preserves link integrity across the vault via `app.fileManager.renameFile`.
+- **Vault access** — read, write, and patch notes through 18 typed tools (`get_vault_file`, `create_vault_file`, `patch_vault_file`, `rename_vault_file`, `rename_heading`, `list_vault_files`, `create_vault_directory`, `delete_vault_directory`, …) with native binary content for images and audio. Missing parent directories on a `create`/`append` path are auto-created. `rename_vault_file` preserves link integrity across the vault via `app.fileManager.renameFile`; `rename_heading` renames a heading in place and rewrites every wikilink / markdown link / subheading-path reference pointing at it across the vault.
 - **Native semantic search** — `search_vault_smart` over an on-device MiniLM index, with optional fallback to Smart Connections if it is installed. Provider tri-state setting (`auto` / `native` / `smart-connections`) under the plugin settings.
 - **Plain-text + structured search** — `search_vault_simple` (text + context windows) and `search_vault` (DQL / JsonLogic via Local REST API).
 - **Template execution** — invoke Templater templates as MCP tool calls with dynamic parameters.
@@ -34,7 +34,7 @@ When connected to an MCP-compatible client, this plugin enables:
 - **Partial-read access** — `get_vault_file_partial` returns one of four slices of a file without loading the whole body: a single `frontmatter` field, the markdown section under a `heading` (nested paths via `targetDelimiter`, default `"::"`), the markdown range of a `block` reference, or a structured `document-map` outline (heading list + block-id list + frontmatter-field list, zero file I/O). Useful for context-window economics on large notes — spot-check a frontmatter field or grab a single section without paying for the full read.
 - **Graph navigation** — `get_outgoing_links` returns the body, embed, and frontmatter links emanating from a file (with resolved `targetPath` and `resolved` flag); `get_backlinks` returns every file that links to a given target, with per-source count. Both read-only, both backed by `app.metadataCache.resolvedLinks` / `getFirstLinkpathDest`.
 
-29 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
+30 MCP tools in total. Full list in the plugin's settings → **Tools available** section.
 
 ## Prerequisites
 
@@ -128,7 +128,7 @@ Click **Copy config for streamable-http clients**. The snippet uses the generic 
 
 ### Verifying the setup
 
-Once configured, your client should expose **29 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
+Once configured, your client should expose **30 MCP tools** from this server, plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
 
 To verify the connection works end-to-end, ask the agent to call `get_server_info`. A successful response confirms the client can reach the in-process server and the bearer token is correct. For deeper inspection (request/response logs, tool schema inspection without an LLM in the loop), use [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector):
 
@@ -397,4 +397,4 @@ See [GitHub Releases](https://github.com/istefox/obsidian-mcp-connector/releases
 [^1]: For information about Claude data privacy and security, see [Claude AI's data usage policy](https://support.anthropic.com/en/articles/8325621-i-would-like-to-input-sensitive-data-into-free-claude-ai-or-claude-pro-who-can-view-my-conversations).
 [^2]: For more information about the Model Context Protocol, see [MCP Introduction](https://modelcontextprotocol.io/introduction).
 [^3]: For a list of available MCP Clients, see [MCP Example Clients](https://modelcontextprotocol.io/clients).
-[^4]: Local REST API was a hard requirement on the 0.3.x line. Starting with 0.4.0 it is optional and only enables the `search_vault` tool (DQL / JsonLogic queries). The other 28 tools work without it; `search_vault` returns an actionable error if it isn't installed. As of `0.4.5`, `search_vault` reads the LRA host and port from the plugin's live settings instead of a hardcoded `127.0.0.1:27124`, so reconfiguring LRA's listen port no longer requires a plugin restart.
+[^4]: Local REST API was a hard requirement on the 0.3.x line. Starting with 0.4.0 it is optional and only enables the `search_vault` tool (DQL / JsonLogic queries). The other 29 tools work without it; `search_vault` returns an actionable error if it isn't installed. As of `0.4.5`, `search_vault` reads the LRA host and port from the plugin's live settings instead of a hardcoded `127.0.0.1:27124`, so reconfiguring LRA's listen port no longer requires a plugin restart.

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -50,6 +50,10 @@ import {
   renameVaultFileSchema,
 } from "./tools/renameVaultFile";
 import {
+  renameHeadingHandler,
+  renameHeadingSchema,
+} from "./tools/renameHeading";
+import {
   createVaultDirectoryHandler,
   createVaultDirectorySchema,
 } from "./tools/createVaultDirectory";
@@ -173,6 +177,9 @@ export async function registerTools(
   );
   registry.register(renameVaultFileSchema, async ({ arguments: args }) =>
     renameVaultFileHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(renameHeadingSchema, async ({ arguments: args }) =>
+    renameHeadingHandler({ arguments: args, app: ctx.app }),
   );
   registry.register(createVaultDirectorySchema, async ({ arguments: args }) =>
     createVaultDirectoryHandler({ arguments: args, app: ctx.app }),

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, test } from "bun:test";
+import {
+  findSourceHeading,
+  checkHeadingCollision,
+  rewriteSourceHeadingLine,
+  rewriteBacklinker,
+  planRename,
+  type HeadingCacheEntry,
+  type ResolveLinkpath,
+} from "./headingRename";
+
+/** Build a `HeadingCacheEntry` succinctly for fixtures. */
+function h(text: string, level: number, line: number): HeadingCacheEntry {
+  return { heading: text, level, position: { start: { line } } };
+}
+
+/**
+ * Simplest possible resolver: treat `linkpath` as a vault path with `.md`
+ * appended (or used verbatim if already there). Backlinker tests use the
+ * "real" vault paths so this is enough for unit coverage.
+ */
+const resolveBasic: ResolveLinkpath = (linkpath) =>
+  linkpath.endsWith(".md") ? linkpath : `${linkpath}.md`;
+
+describe("headingRename — findSourceHeading", () => {
+  test("returns the unique match when only one heading matches", () => {
+    const lines = ["# Intro", "body", "## Details"];
+    const headings = [h("Intro", 1, 0), h("Details", 2, 2)];
+    const r = findSourceHeading(headings, lines, { text: "Intro" });
+    expect(r).toMatchObject({ line: 0, level: 1, text: "Intro" });
+  });
+
+  test("returns heading-not-found when no match", () => {
+    const r = findSourceHeading([h("Foo", 1, 0)], ["# Foo"], { text: "Bar" });
+    expect(r).toMatchObject({
+      errorCode: "heading-not-found",
+    });
+  });
+
+  test("disambiguates by level when level is provided", () => {
+    const headings = [h("Title", 1, 0), h("Title", 3, 4)];
+    const lines = ["# Title", "", "", "", "### Title"];
+    const r = findSourceHeading(headings, lines, { text: "Title", level: 3 });
+    expect(r).toMatchObject({ line: 4, level: 3, text: "Title" });
+  });
+
+  test("returns ambiguous-heading with candidates when multiple match", () => {
+    const headings = [h("Section", 1, 0), h("Section", 2, 4)];
+    const lines = ["# Section", "", "", "", "## Section"];
+    const r = findSourceHeading(headings, lines, { text: "Section" });
+    expect(r).toMatchObject({
+      errorCode: "ambiguous-heading",
+    });
+    if ("errorCode" in r && r.errorCode === "ambiguous-heading") {
+      expect(r.candidates).toHaveLength(2);
+      expect(r.candidates.map((c) => c.line)).toEqual([0, 4]);
+      expect(r.candidates.map((c) => c.level)).toEqual([1, 2]);
+    }
+  });
+
+  test("RFC edge case #3 — match is case-sensitive", () => {
+    const headings = [h("Section", 1, 0)];
+    const lines = ["# Section"];
+    const r = findSourceHeading(headings, lines, { text: "section" });
+    expect(r).toMatchObject({ errorCode: "heading-not-found" });
+  });
+
+  test("RFC edge case #2 — skips headings inside fenced code blocks", () => {
+    // Synthetic: a heading line that lives inside a fence. Obsidian's
+    // cache normally excludes these but the defensive guard kicks in.
+    const lines = ["```", "# Not a heading", "```", "# Real heading"];
+    const headings = [h("Not a heading", 1, 1), h("Real heading", 1, 3)];
+    const r = findSourceHeading(headings, lines, { text: "Not a heading" });
+    expect(r).toMatchObject({ errorCode: "heading-not-found" });
+    const ok = findSourceHeading(headings, lines, { text: "Real heading" });
+    expect(ok).toMatchObject({ line: 3 });
+  });
+});
+
+describe("headingRename — checkHeadingCollision (RFC edge case #1)", () => {
+  test("flags collision when `to` already exists at same level", () => {
+    const headings = [h("From", 2, 0), h("To", 2, 4)];
+    const lines = ["## From", "", "", "", "## To"];
+    const r = checkHeadingCollision(headings, lines, "To", 2, 0);
+    expect(r).toMatchObject({ errorCode: "heading-collision" });
+  });
+
+  test("allows when same text exists at a different level", () => {
+    const headings = [h("From", 2, 0), h("To", 3, 4)];
+    const lines = ["## From", "", "", "", "### To"];
+    const r = checkHeadingCollision(headings, lines, "To", 2, 0);
+    expect(r).toBeNull();
+  });
+
+  test("ignores the matched heading itself in the collision search", () => {
+    const headings = [h("From", 2, 0)];
+    const lines = ["## From"];
+    // Renaming from "From" to "Whatever" should NOT collide with itself.
+    const r = checkHeadingCollision(headings, lines, "Whatever", 2, 0);
+    expect(r).toBeNull();
+  });
+});
+
+describe("headingRename — rewriteSourceHeadingLine", () => {
+  test("replaces the heading text while preserving the `#` prefix", () => {
+    const lines = ["## Old", "body"];
+    const out = rewriteSourceHeadingLine(lines, 0, "New");
+    expect(out).toEqual(["## New", "body"]);
+  });
+
+  test("preserves trailing block-id suffix (^abc)", () => {
+    const lines = ["### Old ^abc-123", "body"];
+    const out = rewriteSourceHeadingLine(lines, 0, "Renamed");
+    expect(out).toEqual(["### Renamed ^abc-123", "body"]);
+  });
+
+  test("preserves leading whitespace on the heading line", () => {
+    const lines = ["  ## Old"];
+    const out = rewriteSourceHeadingLine(lines, 0, "New");
+    expect(out).toEqual(["  ## New"]);
+  });
+
+  test("preserves trailing whitespace", () => {
+    const lines = ["## Old   "];
+    const out = rewriteSourceHeadingLine(lines, 0, "New");
+    expect(out).toEqual(["## New   "]);
+  });
+});
+
+describe("headingRename — rewriteBacklinker", () => {
+  test("rewrites a simple wikilink `[[note#heading]]`", () => {
+    const r = rewriteBacklinker(
+      "See [[source#Old]] for details.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("See [[source#New]] for details.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("rewrites a wikilink with alias `[[note#heading|alias]]`", () => {
+    const r = rewriteBacklinker(
+      "Check [[source#Old|the old name]] please.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Check [[source#New|the old name]] please.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("rewrites a markdown link `[text](note.md#heading)`", () => {
+    const r = rewriteBacklinker(
+      "Read [the section](source.md#Old) carefully.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Read [the section](source.md#New) carefully.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("rewrites a markdown link with URL-encoded heading", () => {
+    const r = rewriteBacklinker(
+      "See [doc](source.md#My%20Old%20Heading).",
+      "My Old Heading",
+      "Renamed Heading",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("See [doc](source.md#Renamed%20Heading).");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("RFC edge case #4 — rewrites subheading-path link (leaf segment)", () => {
+    const r = rewriteBacklinker(
+      "See [[source#Parent > Old]] there.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("See [[source#Parent > New]] there.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("RFC edge case #4 — rewrites subheading-path link (non-leaf segment)", () => {
+    const r = rewriteBacklinker(
+      "See [[source#Old > Child]] there.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("See [[source#New > Child]] there.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("does NOT rewrite a link pointing at a different note", () => {
+    const r = rewriteBacklinker(
+      "See [[other#Old]] there.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("See [[other#Old]] there.");
+    expect(r.rewriteCount).toBe(0);
+  });
+
+  test("does NOT rewrite a link with the wrong heading text (case-sensitive)", () => {
+    const r = rewriteBacklinker(
+      "See [[source#old]] (lowercase).",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("See [[source#old]] (lowercase).");
+    expect(r.rewriteCount).toBe(0);
+  });
+
+  test("rewrites multiple occurrences in the same file", () => {
+    const r = rewriteBacklinker(
+      "First [[source#Old]] then [[source#Old|alias]] and again [[source#Old]].",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe(
+      "First [[source#New]] then [[source#New|alias]] and again [[source#New]].",
+    );
+    expect(r.rewriteCount).toBe(3);
+  });
+
+  test("handles same-file references with `[[#heading]]` shape", () => {
+    const r = rewriteBacklinker(
+      "Self-ref: [[#Old]] inside source itself.",
+      "Old",
+      "New",
+      "source.md",
+      "source.md", // backlinker IS the source — same-file refs use empty notePart
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Self-ref: [[#New]] inside source itself.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("RFC edge case #7 — heading text containing `|` does not break tokenization", () => {
+    // Heading text `A|B` is rare but legal. The wikilink for it would be
+    // `[[source#A|B]]` which is ambiguous with `[[source#A` + alias `B]]`.
+    // Per Obsidian's grammar the LAST `|` separates the alias, so this
+    // round-trips correctly when there is no alias (treats `B]]` as the
+    // heading suffix and rewrites it intact).
+    const r = rewriteBacklinker(
+      "Look at [[source#A|B|alias]] here.",
+      "A|B",
+      "C|D",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Look at [[source#C|D|alias]] here.");
+    expect(r.rewriteCount).toBe(1);
+  });
+});
+
+describe("headingRename — planRename (integration)", () => {
+  test("happy path with one source rename + two backlinkers", () => {
+    const sourceText = "# Title\n## Old\nbody\n## Other";
+    const sourceHeadings = [
+      h("Title", 1, 0),
+      h("Old", 2, 1),
+      h("Other", 2, 3),
+    ];
+    const backlinkers = {
+      "a.md": "See [[source#Old]].",
+      "b.md": "Also [[source#Old|alias]].",
+      "c.md": "Unrelated [[other#Old]].",
+    };
+    const r = planRename({
+      sourcePath: "source.md",
+      sourceText,
+      sourceHeadings,
+      from: { text: "Old" },
+      to: "Renamed",
+      backlinkers,
+      resolve: resolveBasic,
+    });
+    if ("errorCode" in r) throw new Error(`unexpected error: ${r.message}`);
+    expect(r.source.newText).toBe("# Title\n## Renamed\nbody\n## Other");
+    expect(r.source.matchedHeading.line).toBe(1);
+    // c.md links to a different note → not in the backlinker patches list
+    expect(r.backlinkers.map((b) => b.path).sort()).toEqual(["a.md", "b.md"]);
+    expect(r.linkRewriteCount).toBe(2);
+  });
+
+  test("returns heading-not-found error before doing anything else", () => {
+    const r = planRename({
+      sourcePath: "source.md",
+      sourceText: "# Other",
+      sourceHeadings: [h("Other", 1, 0)],
+      from: { text: "Missing" },
+      to: "Whatever",
+      backlinkers: { "a.md": "[[source#Missing]]" },
+      resolve: resolveBasic,
+    });
+    expect(r).toMatchObject({ errorCode: "heading-not-found" });
+  });
+
+  test("returns ambiguous-heading error with candidates", () => {
+    const r = planRename({
+      sourcePath: "source.md",
+      sourceText: "## Foo\n\n\n\n## Foo",
+      sourceHeadings: [h("Foo", 2, 0), h("Foo", 2, 4)],
+      from: { text: "Foo" },
+      to: "Bar",
+      backlinkers: {},
+      resolve: resolveBasic,
+    });
+    expect(r).toMatchObject({ errorCode: "ambiguous-heading" });
+    if ("errorCode" in r && r.errorCode === "ambiguous-heading") {
+      expect(r.candidates).toHaveLength(2);
+    }
+  });
+
+  test("returns heading-collision error when `to` already exists at same level", () => {
+    const r = planRename({
+      sourcePath: "source.md",
+      sourceText: "## Old\n\n\n\n## Existing",
+      sourceHeadings: [h("Old", 2, 0), h("Existing", 2, 4)],
+      from: { text: "Old" },
+      to: "Existing",
+      backlinkers: {},
+      resolve: resolveBasic,
+    });
+    expect(r).toMatchObject({ errorCode: "heading-collision" });
+  });
+
+  test("returns heading-collision error on no-op rename (from === to)", () => {
+    const r = planRename({
+      sourcePath: "source.md",
+      sourceText: "## Same",
+      sourceHeadings: [h("Same", 2, 0)],
+      from: { text: "Same" },
+      to: "Same",
+      backlinkers: {},
+      resolve: resolveBasic,
+    });
+    expect(r).toMatchObject({ errorCode: "heading-collision" });
+  });
+
+  test("emits an empty backlinkers list (and linkRewriteCount=0) when no file references the heading", () => {
+    const r = planRename({
+      sourcePath: "source.md",
+      sourceText: "## Old",
+      sourceHeadings: [h("Old", 2, 0)],
+      from: { text: "Old" },
+      to: "New",
+      backlinkers: { "a.md": "no links here" },
+      resolve: resolveBasic,
+    });
+    if ("errorCode" in r) throw new Error(`unexpected error: ${r.message}`);
+    expect(r.backlinkers).toEqual([]);
+    expect(r.linkRewriteCount).toBe(0);
+    expect(r.source.newText).toBe("## New");
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.test.ts
@@ -104,25 +104,25 @@ describe("headingRename — checkHeadingCollision (RFC edge case #1)", () => {
 describe("headingRename — rewriteSourceHeadingLine", () => {
   test("replaces the heading text while preserving the `#` prefix", () => {
     const lines = ["## Old", "body"];
-    const out = rewriteSourceHeadingLine(lines, 0, "New");
+    const out = rewriteSourceHeadingLine(lines, 0, "New", 2);
     expect(out).toEqual(["## New", "body"]);
   });
 
   test("preserves trailing block-id suffix (^abc)", () => {
     const lines = ["### Old ^abc-123", "body"];
-    const out = rewriteSourceHeadingLine(lines, 0, "Renamed");
+    const out = rewriteSourceHeadingLine(lines, 0, "Renamed", 3);
     expect(out).toEqual(["### Renamed ^abc-123", "body"]);
   });
 
   test("preserves leading whitespace on the heading line", () => {
     const lines = ["  ## Old"];
-    const out = rewriteSourceHeadingLine(lines, 0, "New");
+    const out = rewriteSourceHeadingLine(lines, 0, "New", 2);
     expect(out).toEqual(["  ## New"]);
   });
 
   test("preserves trailing whitespace", () => {
     const lines = ["## Old   "];
-    const out = rewriteSourceHeadingLine(lines, 0, "New");
+    const out = rewriteSourceHeadingLine(lines, 0, "New", 2);
     expect(out).toEqual(["## New   "]);
   });
 });
@@ -276,6 +276,76 @@ describe("headingRename — rewriteBacklinker", () => {
     );
     expect(r.newText).toBe("Look at [[source#C|D|alias]] here.");
     expect(r.rewriteCount).toBe(1);
+  });
+});
+
+describe("headingRename — rewriteBacklinker fenced-code guard (#143 C2)", () => {
+  test("C2: a wikilink inside a ``` fenced block is NOT rewritten", () => {
+    const text = [
+      "Real: [[source#Old]] here.",
+      "```",
+      "Code sample: [[source#Old]] is literal text.",
+      "```",
+      "After: [[source#Old]] again.",
+    ].join("\n");
+    const r = rewriteBacklinker(
+      text,
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe(
+      [
+        "Real: [[source#New]] here.",
+        "```",
+        "Code sample: [[source#Old]] is literal text.",
+        "```",
+        "After: [[source#New]] again.",
+      ].join("\n"),
+    );
+    expect(r.rewriteCount).toBe(2);
+  });
+
+  test("C2: a markdown link inside a ~~~ fenced block is NOT rewritten", () => {
+    const text = ["~~~", "[doc](source.md#Old)", "~~~", "[doc](source.md#Old)"].join(
+      "\n",
+    );
+    const r = rewriteBacklinker(
+      text,
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe(
+      ["~~~", "[doc](source.md#Old)", "~~~", "[doc](source.md#New)"].join("\n"),
+    );
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("H4: a renamed heading containing [ ] is URL-encoded in markdown links", () => {
+    const r = rewriteBacklinker(
+      "See [doc](source.md#Old).",
+      "Old",
+      "New [1]",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("See [doc](source.md#New%20%5B1%5D).");
+    expect(r.rewriteCount).toBe(1);
+  });
+});
+
+describe("headingRename — rewriteSourceHeadingLine level fallback (#143 H2)", () => {
+  test("H2: regex-miss fallback uses the known level, not hardcoded H1", () => {
+    // `##Old` (no space after the hashes) does not match the heading-line
+    // regex, so the fallback path is taken. It must emit the real level.
+    const out = rewriteSourceHeadingLine(["##Old", "body"], 0, "New", 2);
+    expect(out).toEqual(["## New", "body"]);
   });
 });
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.ts
@@ -1,0 +1,490 @@
+/**
+ * Pure walker for `rename_heading` — produces a rewrite plan (source file
+ * patch + per-backlinker patches) without touching the Obsidian app or
+ * the filesystem. The MCP tool wrapper in `tools/renameHeading.ts` is the
+ * I/O layer that loads texts, calls into this module, then applies the
+ * resulting plan via `vault.modify`.
+ *
+ * Design contract (issue #68, @folotp RFC + @istefox triage 2026-04-29 +
+ * bridge 2026-05-13 + gate-cleared 2026-05-16):
+ *
+ * - Option A (manual reference walk via documented APIs). No minified-modal
+ *   hack, no UI driving.
+ * - Tool surface: `{ path, from: { text, level? }, to }` → `{ ok,
+ *   updatedFiles, linkRewriteCount }` on success; `errorCode` discriminator
+ *   on failure (`heading-not-found`, `ambiguous-heading` with `candidates`,
+ *   `heading-collision`).
+ * - Seven edge cases triagged in the RFC close-out, all addressed here:
+ *   (1) heading collision → `heading-collision`; (2) headings inside code
+ *   fences/callouts → skipped during the source scan via
+ *   `isInsideTableOrFencedCode`; (3) case-sensitive heading match; (4)
+ *   subheading-path links (`[[note#Parent > heading]]`) → rewrite the
+ *   matching path component; (5) frontmatter aliases out of scope for v1;
+ *   (6) atomicity handled by the tool wrapper's two-phase commit (`plan` →
+ *   `apply`); (7) special-char tokenizer for pipe and the literal ` > `
+ *   subheading separator.
+ */
+
+import { isInsideTableOrFencedCode } from "./patchHelpers";
+
+/** Match descriptor for the heading the caller wants to rename. */
+export type HeadingFrom = {
+  text: string;
+  /** When omitted, ambiguity across levels surfaces as `ambiguous-heading`. */
+  level?: number;
+};
+
+/** One candidate heading in a multi-match scenario. */
+export type HeadingCandidate = {
+  line: number;
+  level: number;
+  text: string;
+};
+
+export type RenameError =
+  | {
+      errorCode: "heading-not-found";
+      message: string;
+    }
+  | {
+      errorCode: "ambiguous-heading";
+      message: string;
+      candidates: HeadingCandidate[];
+    }
+  | {
+      errorCode: "heading-collision";
+      message: string;
+    };
+
+/** Per-backlinker rewrite descriptor produced by `planRename`. */
+export type BacklinkerPatch = {
+  path: string;
+  newText: string;
+  /** Count of distinct link occurrences rewritten in this file. */
+  rewriteCount: number;
+};
+
+/** Source-file rewrite descriptor. */
+export type SourcePatch = {
+  path: string;
+  newText: string;
+  matchedHeading: HeadingCandidate;
+};
+
+export type RenamePlan = {
+  source: SourcePatch;
+  backlinkers: BacklinkerPatch[];
+  /** Sum of `rewriteCount` across all backlinkers, NOT including the source heading replacement itself. */
+  linkRewriteCount: number;
+};
+
+/**
+ * Minimal shape from Obsidian's `MetadataCache.getFileCache().headings`.
+ * Pinned here so this module stays decoupled from `obsidian.d.ts` and is
+ * unit-testable with raw fixtures.
+ */
+export type HeadingCacheEntry = {
+  heading: string;
+  level: number;
+  position: { start: { line: number } };
+};
+
+/**
+ * Signature the walker uses to ask "does this link path resolve to the
+ * source file?" The wrapper in `tools/renameHeading.ts` passes a closure
+ * around `app.metadataCache.getFirstLinkpathDest(linkpath, sourcePath)`
+ * so default-shortest-path resolution works exactly like Obsidian's. In
+ * tests, a simple basename-match implementation is enough.
+ *
+ * Returns the canonical vault-relative path of the resolved target, or
+ * `null` when the link does not resolve.
+ */
+export type ResolveLinkpath = (
+  linkpath: string,
+  fromPath: string,
+) => string | null;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Heading match in source file
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find the heading in the source file matching `from`. Respects the
+ * RFC's case-sensitive contract and skips entries that the metadata
+ * cache emits for lines inside fenced code blocks (defensive — Obsidian
+ * normally excludes those, but `isInsideTableOrFencedCode` is the
+ * project's canonical guard and we apply it here for consistency).
+ *
+ * Returns either a unique match, an ambiguity error with candidates, or
+ * a not-found error.
+ */
+export function findSourceHeading(
+  headings: HeadingCacheEntry[],
+  lines: string[],
+  from: HeadingFrom,
+): HeadingCandidate | RenameError {
+  const matches: HeadingCandidate[] = [];
+  for (const h of headings) {
+    if (h.heading !== from.text) continue;
+    if (from.level !== undefined && h.level !== from.level) continue;
+    // Defensive code-fence skip. Obsidian's cache already excludes
+    // fenced-code lines from `headings`, but if a future bug or a
+    // synthetic test fixture inserts one, treat it as not-a-heading.
+    if (isInsideTableOrFencedCode(lines, h.position.start.line)) continue;
+    matches.push({
+      line: h.position.start.line,
+      level: h.level,
+      text: h.heading,
+    });
+  }
+
+  if (matches.length === 0) {
+    const levelClause =
+      from.level !== undefined ? ` at level ${from.level}` : "";
+    return {
+      errorCode: "heading-not-found",
+      message: `Heading not found: "${from.text}"${levelClause}.`,
+    };
+  }
+  if (matches.length > 1) {
+    return {
+      errorCode: "ambiguous-heading",
+      message: `Ambiguous heading match for "${from.text}": ${matches.length} candidates. Pass \`from.level\` to disambiguate.`,
+      candidates: matches,
+    };
+  }
+  return matches[0];
+}
+
+/**
+ * Check whether the target heading text already exists in the source
+ * file at the SAME level as the matched heading. RFC edge case #1: same
+ * fail-loud bias as `rename_vault_file` destination-exists. Only the
+ * same-level check matters — a level-1 "Notes" and a level-3 "Notes" are
+ * distinct headings in Obsidian's link resolution.
+ */
+export function checkHeadingCollision(
+  headings: HeadingCacheEntry[],
+  lines: string[],
+  to: string,
+  matchedLevel: number,
+  matchedLine: number,
+): RenameError | null {
+  for (const h of headings) {
+    if (h.position.start.line === matchedLine) continue;
+    if (h.heading !== to) continue;
+    if (h.level !== matchedLevel) continue;
+    if (isInsideTableOrFencedCode(lines, h.position.start.line)) continue;
+    return {
+      errorCode: "heading-collision",
+      message: `Heading collision: "${to}" already exists at level ${matchedLevel} on line ${h.position.start.line + 1}. Refusing to rename; resolve the collision first or rename the existing heading instead.`,
+    };
+  }
+  return null;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Source-file rewrite
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Replace the heading text on its line, preserving the leading `#`
+ * markers, any leading whitespace, and any trailing block-id (e.g. ` ^id`)
+ * or trailing whitespace. Returns the new full source text.
+ *
+ * RFC edge-case-adjacent: heading lines can carry a `^block-id` sibling
+ * (`## Foo ^abc`). The block id must be preserved verbatim — the
+ * regex captures the heading body between the `#` prefix and an optional
+ * trailing ` ^id` suffix.
+ */
+export function rewriteSourceHeadingLine(
+  lines: string[],
+  matchedLine: number,
+  newText: string,
+): string[] {
+  const original = lines[matchedLine];
+  // ^(\s*#{1,6}\s+) — `#` markers + required space after
+  // (.+?)             — heading text (lazy, so the trailing parts don't
+  //                     get swallowed)
+  // (\s+\^\S+)?       — optional block id `^abc` suffix
+  // (\s*)$            — optional trailing whitespace
+  const re = /^(\s*#{1,6}\s+)(.+?)(\s+\^\S+)?(\s*)$/;
+  const m = original.match(re);
+  if (!m) {
+    // Should not happen in practice — Obsidian's cache only flags lines
+    // whose plain-text form matches this shape — but if a synthetic
+    // fixture violates it, fall back to a whole-line replace using the
+    // matched-heading's level (inferred elsewhere; here we conservatively
+    // overwrite with `# newText` which is incorrect for non-h1 but at
+    // least observable in tests). The handler guard in `findSourceHeading`
+    // is the primary defense.
+    const out = lines.slice();
+    out[matchedLine] = `# ${newText}`;
+    return out;
+  }
+  const [, prefix, , blockId = "", trailing = ""] = m;
+  const out = lines.slice();
+  out[matchedLine] = `${prefix}${newText}${blockId}${trailing}`;
+  return out;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Link rewrite in backlinkers
+// ────────────────────────────────────────────────────────────────────────────
+
+const SUBHEADING_SEP = " > ";
+
+/**
+ * URL-decode the heading fragment of a markdown link, if present. Obsidian
+ * encodes spaces and special characters in markdown-link targets (e.g.
+ * `[text](note.md#My%20Heading)`). The tokenizer compares decoded text
+ * against the heading we're renaming.
+ */
+function decodeHeadingFragment(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * URL-encode the heading fragment back for use in a markdown link.
+ * Obsidian uses `%20` for spaces; mirror that.
+ */
+function encodeHeadingFragment(raw: string): string {
+  // `encodeURIComponent` is too aggressive (encodes `!` `'` `(` `)`
+  // which Obsidian leaves alone). Apply a narrow subset.
+  return raw
+    .replace(/%/g, "%25") // must be first
+    .replace(/ /g, "%20")
+    .replace(/#/g, "%23")
+    .replace(/\?/g, "%3F")
+    .replace(/&/g, "%26");
+}
+
+/**
+ * Split a heading path string on the ` > ` separator. Empty segments
+ * collapse — `"Parent  >  Child"` (extra spaces) still resolves to
+ * `["Parent", "Child"]` because we trim each segment.
+ *
+ * Returns the segment list and the boolean `hadPath` (true if there was
+ * at least one separator).
+ */
+function splitHeadingPath(raw: string): {
+  segments: string[];
+  hadPath: boolean;
+} {
+  if (!raw.includes(SUBHEADING_SEP)) {
+    return { segments: [raw], hadPath: false };
+  }
+  const segments = raw.split(SUBHEADING_SEP).map((s) => s.trim());
+  return { segments, hadPath: true };
+}
+
+/**
+ * Rewrite any segment of the heading-path that equals `oldHeading` to
+ * `newHeading`. Edge case (#4): a renamed heading can appear as the leaf
+ * OR as a non-leaf node in a path link.
+ *
+ * Returns the rewritten heading reference, or `null` if no segment
+ * matched (caller skips the link).
+ */
+function rewriteHeadingPath(
+  raw: string,
+  oldHeading: string,
+  newHeading: string,
+): string | null {
+  const { segments, hadPath } = splitHeadingPath(raw);
+  let changed = false;
+  const rewritten = segments.map((s) => {
+    if (s === oldHeading) {
+      changed = true;
+      return newHeading;
+    }
+    return s;
+  });
+  if (!changed) return null;
+  return hadPath ? rewritten.join(SUBHEADING_SEP) : rewritten[0];
+}
+
+/**
+ * Rewrite all matching heading-links inside a single backlinker file.
+ * Returns the new text and the count of distinct links rewritten.
+ *
+ * Patterns handled (RFC + 2026-04-29 triage edge case #7 tokenizer):
+ *  - `[[note#heading]]`
+ *  - `[[note#heading|alias]]`
+ *  - `[text](note.md#heading)` (with URL-encoded heading fragments)
+ *  - Subheading paths in either of the above
+ *
+ * Out of scope (v1, per RFC edge case #5): frontmatter aliases.
+ */
+export function rewriteBacklinker(
+  text: string,
+  oldHeading: string,
+  newHeading: string,
+  sourcePath: string,
+  backlinkerPath: string,
+  resolve: ResolveLinkpath,
+): { newText: string; rewriteCount: number } {
+  let rewriteCount = 0;
+
+  // ── Wikilinks `[[note#heading]]` and `[[note#heading|alias]]` ─────────────
+  //
+  // Tokenizer approach (RFC edge case #7): scan for `[[` … `]]`, split on
+  // the FIRST `#` (note part vs heading part), then on the LAST `|` (alias).
+  // Regex-only solutions struggle with `|` inside the alias text; the
+  // first-`#`/last-`|` split is unambiguous in Obsidian's grammar.
+  //
+  // We bail to a single regex first to find candidate spans, then parse
+  // each candidate by hand.
+  const wikilinkRe = /\[\[([^\]]+?)\]\]/g;
+  let textAfterWikilinks = text.replace(wikilinkRe, (full, inner) => {
+    const hashIdx = (inner as string).indexOf("#");
+    if (hashIdx === -1) return full; // no heading fragment → leave it
+    const notePart = (inner as string).slice(0, hashIdx);
+    const rest = (inner as string).slice(hashIdx + 1);
+    const pipeIdx = rest.lastIndexOf("|");
+    const headingPart = pipeIdx === -1 ? rest : rest.slice(0, pipeIdx);
+    const aliasPart = pipeIdx === -1 ? "" : rest.slice(pipeIdx);
+
+    // Resolve `notePart` to a vault path. Empty notePart (`[[#heading]]`)
+    // is a same-file reference — resolve against the backlinker itself.
+    const linkpath = notePart === "" ? backlinkerPath : notePart;
+    const resolved = resolve(linkpath, backlinkerPath);
+    if (resolved !== sourcePath) return full;
+
+    const rewritten = rewriteHeadingPath(headingPart, oldHeading, newHeading);
+    if (rewritten === null) return full;
+
+    rewriteCount++;
+    return `[[${notePart}#${rewritten}${aliasPart}]]`;
+  });
+
+  // ── Markdown links `[text](note.md#heading)` ──────────────────────────────
+  //
+  // Pattern: `[…](…)`. The URL portion can be a vault path with optional
+  // `#fragment`. We do NOT match autolinks (`<url>`) — those don't carry
+  // heading fragments in Obsidian's link surface.
+  const mdLinkRe = /\[([^\]]*)\]\(([^)]+)\)/g;
+  textAfterWikilinks = textAfterWikilinks.replace(
+    mdLinkRe,
+    (full, linkText, url) => {
+      const hashIdx = (url as string).indexOf("#");
+      if (hashIdx === -1) return full;
+      const notePart = (url as string).slice(0, hashIdx);
+      const headingPartEncoded = (url as string).slice(hashIdx + 1);
+      // Strip a trailing `.md` for resolution; the link target on disk
+      // includes it but `getFirstLinkpathDest` accepts either form.
+      const resolved = resolve(notePart, backlinkerPath);
+      if (resolved !== sourcePath) return full;
+
+      const headingPart = decodeHeadingFragment(headingPartEncoded);
+      const rewritten = rewriteHeadingPath(headingPart, oldHeading, newHeading);
+      if (rewritten === null) return full;
+
+      rewriteCount++;
+      return `[${linkText}](${notePart}#${encodeHeadingFragment(rewritten)})`;
+    },
+  );
+
+  return { newText: textAfterWikilinks, rewriteCount };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Plan generator
+// ────────────────────────────────────────────────────────────────────────────
+
+export type PlanRenameArgs = {
+  sourcePath: string;
+  sourceText: string;
+  sourceHeadings: HeadingCacheEntry[];
+  from: HeadingFrom;
+  to: string;
+  /** Map of vault-relative path → file text for every backlinker file. */
+  backlinkers: Record<string, string>;
+  resolve: ResolveLinkpath;
+};
+
+/**
+ * Produce a complete rewrite plan or return a single typed error.
+ * Two-phase commit (RFC edge case #6) is the wrapper's responsibility:
+ * this function only computes the plan; the wrapper applies it and
+ * surfaces `partial-failure` on mid-walk write errors.
+ */
+export function planRename(args: PlanRenameArgs): RenamePlan | RenameError {
+  const lines = args.sourceText.split("\n");
+
+  const matched = findSourceHeading(args.sourceHeadings, lines, args.from);
+  if ("errorCode" in matched) return matched;
+
+  // Same heading text + same level → no-op; treat as collision since
+  // applying the rename would leave the file unchanged and confuse the
+  // updatedFiles contract.
+  if (matched.text === args.to) {
+    return {
+      errorCode: "heading-collision",
+      message: `Heading "${args.to}" is already the current heading text (line ${matched.line + 1}, level ${matched.level}). No-op rename.`,
+    };
+  }
+
+  const collision = checkHeadingCollision(
+    args.sourceHeadings,
+    lines,
+    args.to,
+    matched.level,
+    matched.line,
+  );
+  if (collision) return collision;
+
+  const newSourceLines = rewriteSourceHeadingLine(lines, matched.line, args.to);
+  const sourceTextAfterLineRewrite = newSourceLines.join("\n");
+
+  // Also rewrite any self-references inside the source file (e.g.
+  // TOC entries like `[[#Old]]` or `[[source#Old]]` that point back to
+  // this file's own heading). The source patch incorporates both the
+  // heading-line replacement and the self-link rewrites in one go.
+  const selfRefRewrite = rewriteBacklinker(
+    sourceTextAfterLineRewrite,
+    matched.text,
+    args.to,
+    args.sourcePath,
+    args.sourcePath,
+    args.resolve,
+  );
+
+  const sourcePatch: SourcePatch = {
+    path: args.sourcePath,
+    newText: selfRefRewrite.newText,
+    matchedHeading: matched,
+  };
+
+  const backlinkers: BacklinkerPatch[] = [];
+  let linkRewriteCount = selfRefRewrite.rewriteCount;
+
+  for (const [path, text] of Object.entries(args.backlinkers)) {
+    // Skip the source file itself if the wrapper accidentally included it
+    // in the backlinker map — self-refs are handled above as part of the
+    // source patch.
+    if (path === args.sourcePath) continue;
+    const { newText, rewriteCount } = rewriteBacklinker(
+      text,
+      matched.text,
+      args.to,
+      args.sourcePath,
+      path,
+      args.resolve,
+    );
+    if (rewriteCount === 0) continue; // backlinker reference was structural
+    // but did not target this heading
+    backlinkers.push({ path, newText, rewriteCount });
+    linkRewriteCount += rewriteCount;
+  }
+
+  return {
+    source: sourcePatch,
+    backlinkers,
+    linkRewriteCount,
+  };
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.ts
@@ -201,6 +201,7 @@ export function rewriteSourceHeadingLine(
   lines: string[],
   matchedLine: number,
   newText: string,
+  level: number,
 ): string[] {
   const original = lines[matchedLine];
   // ^(\s*#{1,6}\s+) — `#` markers + required space after
@@ -211,15 +212,12 @@ export function rewriteSourceHeadingLine(
   const re = /^(\s*#{1,6}\s+)(.+?)(\s+\^\S+)?(\s*)$/;
   const m = original.match(re);
   if (!m) {
-    // Should not happen in practice — Obsidian's cache only flags lines
-    // whose plain-text form matches this shape — but if a synthetic
-    // fixture violates it, fall back to a whole-line replace using the
-    // matched-heading's level (inferred elsewhere; here we conservatively
-    // overwrite with `# newText` which is incorrect for non-h1 but at
-    // least observable in tests). The handler guard in `findSourceHeading`
-    // is the primary defense.
+    // Defensive fallback for a heading line whose shape the regex does not
+    // capture (unusual whitespace, control chars). Preserve the heading's
+    // real level — a hardcoded H1 would silently change document structure
+    // and break the very links this tool exists to keep resolving.
     const out = lines.slice();
-    out[matchedLine] = `# ${newText}`;
+    out[matchedLine] = `${"#".repeat(level)} ${newText}`;
     return out;
   }
   const [, prefix, , blockId = "", trailing = ""] = m;
@@ -260,7 +258,9 @@ function encodeHeadingFragment(raw: string): string {
     .replace(/ /g, "%20")
     .replace(/#/g, "%23")
     .replace(/\?/g, "%3F")
-    .replace(/&/g, "%26");
+    .replace(/&/g, "%26")
+    .replace(/\[/g, "%5B")
+    .replace(/\]/g, "%5D");
 }
 
 /**
@@ -330,53 +330,42 @@ export function rewriteBacklinker(
 ): { newText: string; rewriteCount: number } {
   let rewriteCount = 0;
 
-  // ── Wikilinks `[[note#heading]]` and `[[note#heading|alias]]` ─────────────
-  //
-  // Tokenizer approach (RFC edge case #7): scan for `[[` … `]]`, split on
-  // the FIRST `#` (note part vs heading part), then on the LAST `|` (alias).
-  // Regex-only solutions struggle with `|` inside the alias text; the
-  // first-`#`/last-`|` split is unambiguous in Obsidian's grammar.
-  //
-  // We bail to a single regex first to find candidate spans, then parse
-  // each candidate by hand.
+  // Tokenizer approach (RFC edge case #7): for each link, split on the
+  // FIRST `#` (note vs heading), then on the LAST `|` (alias). Regex-only
+  // solutions struggle with `|` inside the alias text.
   const wikilinkRe = /\[\[([^\]]+?)\]\]/g;
-  let textAfterWikilinks = text.replace(wikilinkRe, (full, inner) => {
-    const hashIdx = (inner as string).indexOf("#");
-    if (hashIdx === -1) return full; // no heading fragment → leave it
-    const notePart = (inner as string).slice(0, hashIdx);
-    const rest = (inner as string).slice(hashIdx + 1);
-    const pipeIdx = rest.lastIndexOf("|");
-    const headingPart = pipeIdx === -1 ? rest : rest.slice(0, pipeIdx);
-    const aliasPart = pipeIdx === -1 ? "" : rest.slice(pipeIdx);
-
-    // Resolve `notePart` to a vault path. Empty notePart (`[[#heading]]`)
-    // is a same-file reference — resolve against the backlinker itself.
-    const linkpath = notePart === "" ? backlinkerPath : notePart;
-    const resolved = resolve(linkpath, backlinkerPath);
-    if (resolved !== sourcePath) return full;
-
-    const rewritten = rewriteHeadingPath(headingPart, oldHeading, newHeading);
-    if (rewritten === null) return full;
-
-    rewriteCount++;
-    return `[[${notePart}#${rewritten}${aliasPart}]]`;
-  });
-
-  // ── Markdown links `[text](note.md#heading)` ──────────────────────────────
-  //
-  // Pattern: `[…](…)`. The URL portion can be a vault path with optional
-  // `#fragment`. We do NOT match autolinks (`<url>`) — those don't carry
-  // heading fragments in Obsidian's link surface.
   const mdLinkRe = /\[([^\]]*)\]\(([^)]+)\)/g;
-  textAfterWikilinks = textAfterWikilinks.replace(
-    mdLinkRe,
-    (full, linkText, url) => {
+
+  const rewriteLine = (line: string): string => {
+    // ── Wikilinks `[[note#heading]]` / `[[note#heading|alias]]` ──────────
+    let out = line.replace(wikilinkRe, (full, inner) => {
+      const hashIdx = (inner as string).indexOf("#");
+      if (hashIdx === -1) return full; // no heading fragment → leave it
+      const notePart = (inner as string).slice(0, hashIdx);
+      const rest = (inner as string).slice(hashIdx + 1);
+      const pipeIdx = rest.lastIndexOf("|");
+      const headingPart = pipeIdx === -1 ? rest : rest.slice(0, pipeIdx);
+      const aliasPart = pipeIdx === -1 ? "" : rest.slice(pipeIdx);
+
+      // Empty notePart (`[[#heading]]`) is a same-file reference —
+      // resolve against the backlinker itself.
+      const linkpath = notePart === "" ? backlinkerPath : notePart;
+      const resolved = resolve(linkpath, backlinkerPath);
+      if (resolved !== sourcePath) return full;
+
+      const rewritten = rewriteHeadingPath(headingPart, oldHeading, newHeading);
+      if (rewritten === null) return full;
+
+      rewriteCount++;
+      return `[[${notePart}#${rewritten}${aliasPart}]]`;
+    });
+
+    // ── Markdown links `[text](note.md#heading)` ────────────────────────
+    out = out.replace(mdLinkRe, (full, linkText, url) => {
       const hashIdx = (url as string).indexOf("#");
       if (hashIdx === -1) return full;
       const notePart = (url as string).slice(0, hashIdx);
       const headingPartEncoded = (url as string).slice(hashIdx + 1);
-      // Strip a trailing `.md` for resolution; the link target on disk
-      // includes it but `getFirstLinkpathDest` accepts either form.
       const resolved = resolve(notePart, backlinkerPath);
       if (resolved !== sourcePath) return full;
 
@@ -386,10 +375,22 @@ export function rewriteBacklinker(
 
       rewriteCount++;
       return `[${linkText}](${notePart}#${encodeHeadingFragment(rewritten)})`;
-    },
+    });
+
+    return out;
+  };
+
+  // RFC edge case #2 / fork #137 bug class: a `[[…#…]]` or `[…](…#…)`
+  // sitting inside a fenced code block or a markdown table is literal
+  // text — Obsidian does not resolve it — so it must NOT be rewritten.
+  // Guard per line with the canonical `isInsideTableOrFencedCode` walk
+  // (the same guard the source scan uses; also covers `~~~` fences).
+  const lines = text.split("\n");
+  const outLines = lines.map((line, idx) =>
+    isInsideTableOrFencedCode(lines, idx) ? line : rewriteLine(line),
   );
 
-  return { newText: textAfterWikilinks, rewriteCount };
+  return { newText: outLines.join("\n"), rewriteCount };
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -438,7 +439,12 @@ export function planRename(args: PlanRenameArgs): RenamePlan | RenameError {
   );
   if (collision) return collision;
 
-  const newSourceLines = rewriteSourceHeadingLine(lines, matched.line, args.to);
+  const newSourceLines = rewriteSourceHeadingLine(
+    lines,
+    matched.line,
+    args.to,
+    matched.level,
+  );
   const sourceTextAfterLineRewrite = newSourceLines.join("\n");
 
   // Also rewrite any self-references inside the source file (e.g.

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  renameHeadingHandler,
+  renameHeadingSchema,
+} from "./renameHeading";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockMetadata,
+  setMockResolvedLinks,
+} from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+describe("rename_heading tool", () => {
+  test("schema declares the tool name", () => {
+    expect(renameHeadingSchema.get("name")?.toString()).toContain(
+      "rename_heading",
+    );
+  });
+
+  test("returns file-not-found when source path does not resolve", async () => {
+    const r = await renameHeadingHandler({
+      arguments: { path: "missing.md", from: { text: "Foo" }, to: "Bar" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.errorCode).toBe("file-not-found");
+  });
+
+  test("positive: rewrites the source heading and one backlinker", async () => {
+    setMockFile("source.md", "## Old heading\nbody");
+    setMockFile("back.md", "See [[source#Old heading]] please.");
+    setMockMetadata("source.md", {
+      headings: [{ heading: "Old heading", level: 2, line: 0 }],
+    });
+    setMockResolvedLinks("back.md", { "source.md": 1 });
+
+    const r = await renameHeadingHandler({
+      arguments: {
+        path: "source.md",
+        from: { text: "Old heading" },
+        to: "New heading",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.ok).toBe(true);
+    expect(payload.updatedFiles.sort()).toEqual(["back.md", "source.md"]);
+    expect(payload.linkRewriteCount).toBe(1);
+  });
+
+  test("returns heading-not-found from the walker when no heading matches", async () => {
+    setMockFile("source.md", "## Other");
+    setMockMetadata("source.md", {
+      headings: [{ heading: "Other", level: 2, line: 0 }],
+    });
+
+    const r = await renameHeadingHandler({
+      arguments: { path: "source.md", from: { text: "Missing" }, to: "X" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.errorCode).toBe("heading-not-found");
+  });
+
+  test("returns ambiguous-heading with candidates when level is omitted and multi-match", async () => {
+    setMockFile("source.md", "## Foo\n\n\n\n### Foo");
+    setMockMetadata("source.md", {
+      headings: [
+        { heading: "Foo", level: 2, line: 0 },
+        { heading: "Foo", level: 3, line: 4 },
+      ],
+    });
+
+    const r = await renameHeadingHandler({
+      arguments: { path: "source.md", from: { text: "Foo" }, to: "Bar" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.errorCode).toBe("ambiguous-heading");
+    expect(payload.candidates).toHaveLength(2);
+    expect(payload.candidates.map((c: { level: number }) => c.level)).toEqual([
+      2, 3,
+    ]);
+  });
+
+  test("`from.level` disambiguates between same-text headings at different levels", async () => {
+    setMockFile("source.md", "## Foo\nbody2\n\n### Foo\nbody3");
+    setMockMetadata("source.md", {
+      headings: [
+        { heading: "Foo", level: 2, line: 0 },
+        { heading: "Foo", level: 3, line: 3 },
+      ],
+    });
+
+    const r = await renameHeadingHandler({
+      arguments: {
+        path: "source.md",
+        from: { text: "Foo", level: 3 },
+        to: "Bar",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.ok).toBe(true);
+  });
+
+  test("returns heading-collision when `to` already exists at the same level", async () => {
+    setMockFile("source.md", "## Old\n\n\n\n## Existing");
+    setMockMetadata("source.md", {
+      headings: [
+        { heading: "Old", level: 2, line: 0 },
+        { heading: "Existing", level: 2, line: 4 },
+      ],
+    });
+
+    const r = await renameHeadingHandler({
+      arguments: {
+        path: "source.md",
+        from: { text: "Old" },
+        to: "Existing",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.errorCode).toBe("heading-collision");
+  });
+
+  test("rewrites self-references inside the source file (e.g. TOC entries)", async () => {
+    setMockFile(
+      "source.md",
+      "# Title\n[[#Old heading]] (TOC)\n\n## Old heading\nbody",
+    );
+    setMockMetadata("source.md", {
+      headings: [
+        { heading: "Title", level: 1, line: 0 },
+        { heading: "Old heading", level: 2, line: 3 },
+      ],
+    });
+    // No backlinkers in `resolvedLinks` — but the source itself has a
+    // self-reference that must be rewritten.
+
+    const r = await renameHeadingHandler({
+      arguments: {
+        path: "source.md",
+        from: { text: "Old heading" },
+        to: "New heading",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.updatedFiles).toEqual(["source.md"]);
+    expect(payload.linkRewriteCount).toBe(1); // self-ref rewrite counts
+  });
+
+  test("skips files in resolvedLinks that do not actually reference the heading", async () => {
+    setMockFile("source.md", "## Old");
+    setMockFile("noref.md", "I link to [[source]] without #fragment.");
+    setMockMetadata("source.md", {
+      headings: [{ heading: "Old", level: 2, line: 0 }],
+    });
+    // noref.md has a wikilink to source.md but with NO heading fragment.
+    setMockResolvedLinks("noref.md", { "source.md": 1 });
+
+    const r = await renameHeadingHandler({
+      arguments: { path: "source.md", from: { text: "Old" }, to: "New" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const payload = JSON.parse(r.content[0].text);
+    // Source updated, noref.md should NOT appear in updatedFiles because
+    // it had no heading-link to rewrite.
+    expect(payload.updatedFiles).toEqual(["source.md"]);
+    expect(payload.linkRewriteCount).toBe(0);
+  });
+
+  test("counts multiple link rewrites accurately across backlinkers", async () => {
+    setMockFile("source.md", "## Target");
+    setMockFile(
+      "a.md",
+      "Two refs: [[source#Target]] and [[source#Target|alias]].",
+    );
+    setMockFile(
+      "b.md",
+      "One ref: [text](source.md#Target).",
+    );
+    setMockMetadata("source.md", {
+      headings: [{ heading: "Target", level: 2, line: 0 }],
+    });
+    setMockResolvedLinks("a.md", { "source.md": 2 });
+    setMockResolvedLinks("b.md", { "source.md": 1 });
+
+    const r = await renameHeadingHandler({
+      arguments: { path: "source.md", from: { text: "Target" }, to: "Hit" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.updatedFiles.sort()).toEqual([
+      "a.md",
+      "b.md",
+      "source.md",
+    ]);
+    expect(payload.linkRewriteCount).toBe(3);
+  });
+
+  test("RFC edge case #4 — subheading-path link rewrite via the wrapper end-to-end", async () => {
+    setMockFile("source.md", "# Parent\n## Old\nbody");
+    setMockFile(
+      "back.md",
+      "Deep ref: [[source#Parent > Old]] and shallow [[source#Old]].",
+    );
+    setMockMetadata("source.md", {
+      headings: [
+        { heading: "Parent", level: 1, line: 0 },
+        { heading: "Old", level: 2, line: 1 },
+      ],
+    });
+    setMockResolvedLinks("back.md", { "source.md": 2 });
+
+    const r = await renameHeadingHandler({
+      arguments: { path: "source.md", from: { text: "Old" }, to: "Renamed" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.linkRewriteCount).toBe(2);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.test.ts
@@ -9,6 +9,8 @@ import {
   setMockFile,
   setMockMetadata,
   setMockResolvedLinks,
+  setMockModifyFail,
+  setMockReadMutation,
 } from "$/test-setup";
 
 beforeEach(() => resetMockVault());
@@ -234,5 +236,80 @@ describe("rename_heading tool", () => {
     expect(r.isError).toBeUndefined();
     const payload = JSON.parse(r.content[0].text);
     expect(payload.linkRewriteCount).toBe(2);
+  });
+
+  // ── #143 hardening: partial-failure (M2) + TOCTOU guard (H3) ──────────
+  test("M2: a backlinker write failure surfaces partial-failure with both lists", async () => {
+    setMockFile("source.md", "## Old\nbody");
+    setMockFile("ok.md", "Ref [[source#Old]].");
+    setMockFile("bad.md", "Ref [[source#Old]].");
+    setMockMetadata("source.md", {
+      headings: [{ heading: "Old", level: 2, line: 0 }],
+    });
+    setMockResolvedLinks("ok.md", { "source.md": 1 });
+    setMockResolvedLinks("bad.md", { "source.md": 1 });
+    setMockModifyFail("bad.md");
+
+    const r = await renameHeadingHandler({
+      arguments: { path: "source.md", from: { text: "Old" }, to: "New" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.errorCode).toBe("partial-failure");
+    expect(payload.updatedFiles.sort()).toEqual(["ok.md", "source.md"]);
+    expect(payload.failedFiles.map((f: { path: string }) => f.path)).toEqual([
+      "bad.md",
+    ]);
+  });
+
+  test("H3: a backlinker changed between plan and apply is not clobbered (partial-failure)", async () => {
+    setMockFile("source.md", "## Old\nbody");
+    setMockFile("back.md", "Ref [[source#Old]].");
+    setMockMetadata("source.md", {
+      headings: [{ heading: "Old", level: 2, line: 0 }],
+    });
+    setMockResolvedLinks("back.md", { "source.md": 1 });
+    // back.md is read once during planning, then mutates before apply.
+    setMockReadMutation("back.md", "Concurrently edited by the user.");
+
+    const r = await renameHeadingHandler({
+      arguments: { path: "source.md", from: { text: "Old" }, to: "New" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.errorCode).toBe("partial-failure");
+    expect(payload.failedFiles.map((f: { path: string }) => f.path)).toEqual([
+      "back.md",
+    ]);
+    // The concurrent edit must be preserved, not overwritten.
+    const back = mockApp().vault.getAbstractFileByPath("back.md");
+    expect(await mockApp().vault.read(back as never)).toBe(
+      "Concurrently edited by the user.",
+    );
+  });
+
+  test("H3: source changed between plan and apply aborts before any write", async () => {
+    setMockFile("source.md", "## Old\nbody");
+    setMockFile("back.md", "Ref [[source#Old]].");
+    setMockMetadata("source.md", {
+      headings: [{ heading: "Old", level: 2, line: 0 }],
+    });
+    setMockResolvedLinks("back.md", { "source.md": 1 });
+    setMockReadMutation("source.md", "## Concurrently renamed\nbody");
+
+    const r = await renameHeadingHandler({
+      arguments: { path: "source.md", from: { text: "Old" }, to: "New" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const payload = JSON.parse(r.content[0].text);
+    expect(payload.errorCode).toBe("source-write-failed");
+    // back.md untouched — abort happened before the backlinker loop.
+    const back = mockApp().vault.getAbstractFileByPath("back.md");
+    expect(await mockApp().vault.read(back as never)).toBe(
+      "Ref [[source#Old]].",
+    );
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
@@ -1,0 +1,252 @@
+import { type } from "arktype";
+import type { App, TFile } from "obsidian";
+
+import {
+  planRename,
+  type HeadingCacheEntry,
+  type RenameError,
+  type ResolveLinkpath,
+} from "../services/headingRename";
+
+export const renameHeadingSchema = type({
+  name: '"rename_heading"',
+  arguments: {
+    path: type("string>0").describe(
+      "Vault-relative path of the file containing the heading to rename.",
+    ),
+    from: {
+      text: type("string>0").describe(
+        "Exact (case-sensitive) heading text to match. Cache-derived; matching is case-sensitive, mirroring Obsidian's link resolution.",
+      ),
+      "level?": type("1<=number.integer<=6").describe(
+        "Heading level (1-6). Optional. When omitted, ambiguity across levels surfaces as `errorCode: ambiguous-heading` with a `candidates` array.",
+      ),
+    },
+    to: type("string>0").describe(
+      "New heading text. Must not match an existing same-level heading in the file (fail-loud per `heading-collision`).",
+    ),
+  },
+}).describe(
+  "Renames a heading in a vault file and rewrites every backlinking reference (wikilinks, markdown links, subheading-path links) across the vault to keep link integrity. Two-phase commit: dry-run plan first, then apply atomically. Fails loud on missing heading, multi-match ambiguity, or destination collision. Out of scope for v1: frontmatter aliases. Implements RFC #68.",
+);
+
+export type RenameHeadingContext = {
+  arguments: {
+    path: string;
+    from: { text: string; level?: number };
+    to: string;
+  };
+  app: App;
+};
+
+type MockCacheShape = {
+  headings?: Array<HeadingCacheEntry>;
+};
+
+function errorResponse(payload: {
+  errorCode: string;
+  message: string;
+  [k: string]: unknown;
+}): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    isError: true,
+  };
+}
+
+function successResponse(payload: {
+  ok: true;
+  updatedFiles: string[];
+  linkRewriteCount: number;
+}): { content: Array<{ type: "text"; text: string }> } {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+function partialFailureResponse(payload: {
+  errorCode: "partial-failure";
+  message: string;
+  updatedFiles: string[];
+  failedFiles: Array<{ path: string; error: string }>;
+  linkRewriteCount: number;
+}): { content: Array<{ type: "text"; text: string }>; isError: true } {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    isError: true,
+  };
+}
+
+/**
+ * Find every file in the vault that has a resolved link to `sourcePath`.
+ * Reads `app.metadataCache.resolvedLinks`, which is shaped as
+ * `Record<linkingFile, Record<targetFile, count>>`. Excludes the source
+ * file itself — self-references are handled inside the source patch.
+ */
+function findBacklinkerPaths(
+  resolvedLinks: Record<string, Record<string, number>>,
+  sourcePath: string,
+): string[] {
+  const out: string[] = [];
+  for (const [linkingPath, targets] of Object.entries(resolvedLinks)) {
+    if (linkingPath === sourcePath) continue;
+    if (sourcePath in targets) out.push(linkingPath);
+  }
+  return out;
+}
+
+export async function renameHeadingHandler(
+  ctx: RenameHeadingContext,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const { path, from, to } = ctx.arguments;
+
+  // ── 1. Load source file ─────────────────────────────────────────────────
+  const sourceFile = ctx.app.vault.getAbstractFileByPath(path) as TFile | null;
+  if (!sourceFile) {
+    return errorResponse({
+      errorCode: "file-not-found",
+      message: `Source file not found: ${path}`,
+    });
+  }
+
+  const sourceText = await ctx.app.vault.cachedRead(sourceFile);
+  const sourceCache = (ctx.app.metadataCache.getFileCache(sourceFile) ??
+    {}) as MockCacheShape;
+  const sourceHeadings = sourceCache.headings ?? [];
+
+  // ── 2. Identify backlinkers + load their text ───────────────────────────
+  const resolvedLinks =
+    (ctx.app.metadataCache as unknown as {
+      resolvedLinks?: Record<string, Record<string, number>>;
+    }).resolvedLinks ?? {};
+  const backlinkerPaths = findBacklinkerPaths(resolvedLinks, path);
+
+  const backlinkerTexts: Record<string, string> = {};
+  for (const bp of backlinkerPaths) {
+    const f = ctx.app.vault.getAbstractFileByPath(bp) as TFile | null;
+    if (!f) continue; // resolvedLinks can lag behind file deletes
+    try {
+      backlinkerTexts[bp] = await ctx.app.vault.cachedRead(f);
+    } catch {
+      // Read failures during PRE-WRITE plan-building are non-fatal —
+      // they surface as a partial-failure if/when we try to write.
+      continue;
+    }
+  }
+
+  // ── 3. Build `ResolveLinkpath` around the live metadataCache ────────────
+  // `getFirstLinkpathDest` honours the vault's default linker setting
+  // ("Use shortest path" / "Relative to file" / "Absolute"), so the
+  // walker's link-match predicate is identical to Obsidian's at runtime.
+  const resolve: ResolveLinkpath = (linkpath, fromPath) => {
+    const dest = (
+      ctx.app.metadataCache as unknown as {
+        getFirstLinkpathDest?: (
+          linkpath: string,
+          sourcePath: string,
+        ) => TFile | null;
+      }
+    ).getFirstLinkpathDest?.(linkpath, fromPath);
+    return dest?.path ?? null;
+  };
+
+  // ── 4. Compute the plan ─────────────────────────────────────────────────
+  const plan = planRename({
+    sourcePath: path,
+    sourceText,
+    sourceHeadings,
+    from,
+    to,
+    backlinkers: backlinkerTexts,
+    resolve,
+  });
+
+  if ("errorCode" in plan) {
+    return renameErrorToResponse(plan);
+  }
+
+  // ── 5. Phase-2 apply: write source, then each backlinker patch ──────────
+  //
+  // RFC edge case #6: two-phase commit. Phase 1 (plan computation) is
+  // pure and reports collisions / ambiguity before any I/O. Phase 2
+  // writes; on mid-walk failure we surface `partial-failure` with the
+  // accurate list of files that did and did not get the rewrite.
+  const updatedFiles: string[] = [];
+  const failedFiles: Array<{ path: string; error: string }> = [];
+
+  // Source first — if the source write fails, no backlinker has been
+  // touched yet, so the file system is unchanged.
+  try {
+    await ctx.app.vault.modify(sourceFile, plan.source.newText);
+    updatedFiles.push(plan.source.path);
+  } catch (e) {
+    return errorResponse({
+      errorCode: "source-write-failed",
+      message: `Failed to write source file: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  for (const bp of plan.backlinkers) {
+    const f = ctx.app.vault.getAbstractFileByPath(bp.path) as TFile | null;
+    if (!f) {
+      failedFiles.push({
+        path: bp.path,
+        error: "Backlinker file disappeared between plan and apply.",
+      });
+      continue;
+    }
+    try {
+      await ctx.app.vault.modify(f, bp.newText);
+      updatedFiles.push(bp.path);
+    } catch (e) {
+      failedFiles.push({
+        path: bp.path,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  if (failedFiles.length > 0) {
+    return partialFailureResponse({
+      errorCode: "partial-failure",
+      message: `Heading renamed but ${failedFiles.length} backlinker write(s) failed. The source file was updated; some references may still point at the old heading.`,
+      updatedFiles,
+      failedFiles,
+      linkRewriteCount: plan.linkRewriteCount,
+    });
+  }
+
+  return successResponse({
+    ok: true,
+    updatedFiles,
+    linkRewriteCount: plan.linkRewriteCount,
+  });
+}
+
+/**
+ * Map a `planRename` error to the MCP isError response shape, preserving
+ * the discriminator (`errorCode`) + payload (`candidates`, etc.) so the
+ * caller can branch on it.
+ */
+function renameErrorToResponse(err: RenameError): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  if (err.errorCode === "ambiguous-heading") {
+    return errorResponse({
+      errorCode: err.errorCode,
+      message: err.message,
+      candidates: err.candidates,
+    });
+  }
+  return errorResponse({
+    errorCode: err.errorCode,
+    message: err.message,
+  });
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
@@ -181,8 +181,18 @@ export async function renameHeadingHandler(
   const failedFiles: Array<{ path: string; error: string }> = [];
 
   // Source first — if the source write fails, no backlinker has been
-  // touched yet, so the file system is unchanged.
+  // touched yet, so the file system is unchanged. TOCTOU guard: the plan
+  // was built from a snapshot; if the file changed since (live editing in
+  // Obsidian), abort rather than clobber the concurrent edit.
   try {
+    const sourceNow = await ctx.app.vault.cachedRead(sourceFile);
+    if (sourceNow !== sourceText) {
+      return errorResponse({
+        errorCode: "source-write-failed",
+        message:
+          "Source file changed between plan and apply; aborted before any write to avoid overwriting a concurrent edit. Re-run the rename.",
+      });
+    }
     await ctx.app.vault.modify(sourceFile, plan.source.newText);
     updatedFiles.push(plan.source.path);
   } catch (e) {
@@ -202,6 +212,19 @@ export async function renameHeadingHandler(
       continue;
     }
     try {
+      // TOCTOU guard: the patch was computed from the plan-phase snapshot.
+      // If the file changed since, do NOT write the stale patch — surface
+      // it as a failed file so the caller can re-run, not a silent
+      // lost update.
+      const currentText = await ctx.app.vault.cachedRead(f);
+      if (currentText !== backlinkerTexts[bp.path]) {
+        failedFiles.push({
+          path: bp.path,
+          error:
+            "File changed between plan and apply; left untouched to avoid overwriting a concurrent edit. Re-run the rename.",
+        });
+        continue;
+      }
       await ctx.app.vault.modify(f, bp.newText);
       updatedFiles.push(bp.path);
     } catch (e) {

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -111,6 +111,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "list_vault_files",
         "patch_active_file",
         "patch_vault_file",
+        "rename_heading",
         "rename_vault_file",
         "search_vault",
         "search_vault_simple",
@@ -118,7 +119,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "show_file_in_obsidian",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(29);
+      expect(names).toHaveLength(30);
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -301,6 +301,11 @@ type MockVaultState = {
   // former (regression guard for fork issue #96).
   trashedPaths: string[];
   deletedPaths: string[];
+  // Test hooks for the rename_heading apply path (#143 hardening):
+  // paths whose `vault.modify` throws, and paths whose content mutates
+  // after the first read (TOCTOU / concurrent-edit simulation).
+  modifyFailPaths: Set<string>;
+  readMutations: Map<string, { content: string; firstReadSeen: boolean }>;
 };
 
 // Synthetic absolute filesystem prefix used by the mock `adapter.rmdir`
@@ -326,6 +331,8 @@ const _mockState: MockVaultState = {
   ignored: new Set(),
   trashedPaths: [],
   deletedPaths: [],
+  modifyFailPaths: new Set(),
+  readMutations: new Map(),
 };
 
 export function resetMockVault(): void {
@@ -349,6 +356,22 @@ export function resetMockVault(): void {
   _mockState.ignored.clear();
   _mockState.trashedPaths = [];
   _mockState.deletedPaths = [];
+  _mockState.modifyFailPaths.clear();
+  _mockState.readMutations.clear();
+}
+
+/** Make `vault.modify(file)` reject for `path` (rename_heading #143 M2). */
+export function setMockModifyFail(path: string): void {
+  _mockState.modifyFailPaths.add(path);
+}
+
+/**
+ * Simulate a concurrent edit: `path` reads its stored content the first
+ * time, then `mutated` on every subsequent read (rename_heading #143 H3
+ * TOCTOU guard).
+ */
+export function setMockReadMutation(path: string, mutated: string): void {
+  _mockState.readMutations.set(path, { content: mutated, firstReadSeen: false });
 }
 
 /** Paths routed through `fileManager.trashFile` (recoverable delete). */
@@ -632,6 +655,11 @@ export function mockApp(): App {
       const path = (file as unknown as MockTFile).path;
       const content = _mockState.files.get(path);
       if (content === undefined) throw new Error(`ENOENT: ${path}`);
+      const mut = _mockState.readMutations.get(path);
+      if (mut) {
+        if (mut.firstReadSeen) return mut.content;
+        mut.firstReadSeen = true;
+      }
       return content;
     },
     cachedRead: async (file: TFile): Promise<string> => {
@@ -672,6 +700,9 @@ export function mockApp(): App {
     },
     modify: async (file: TFile, content: string): Promise<void> => {
       const path = (file as unknown as MockTFile).path;
+      if (_mockState.modifyFailPaths.has(path)) {
+        throw new Error(`mock modify failure: ${path}`);
+      }
       _mockState.files.set(path, content);
     },
     append: async (file: TFile, content: string): Promise<void> => {


### PR DESCRIPTION
Implements #68. **Builds on @marcoaperez's #143** — his feature commit is preserved as the base of this branch (rebased onto current `main`, authorship intact); a second commit adds the rewrite-safety hardening surfaced reviewing #143. Opened as a separate PR because #143 was CONFLICTING (branched pre-0.4.10) and the fixes touch data-integrity paths.

The architecture is @marcoaperez's and faithful to the #68 contract (Option A pure walker; `from:{text,level?}`; the `errorCode` set; subheading-path rewrite; case-sensitive match; two-phase plan/apply; frontmatter out of scope). This PR only hardens the rewrite-safety details.

## Hardening (data-integrity blockers from the #143 review)

- **C2 — fenced-code guard.** `rewriteBacklinker` rewrote `[[note#h]]` / `[txt](note.md#h)` even inside ``` / `~~~` fences and tables in a *backlinker* — silent corruption of a third file (the #137 bug class, worse blast radius). Now processes per line and skips lines flagged by the canonical `isInsideTableOrFencedCode` guard (which, post-0.4.10, also covers `~~~`). Callout content is intentionally still rewritten (callouts render markdown).
- **H2 — level-aware source fallback.** `rewriteSourceHeadingLine` now takes the resolved level; the regex-miss fallback no longer hardcodes `# ` (H1), which would silently change document structure.
- **H4 — fragment encoding.** `encodeHeadingFragment` now encodes `[`→`%5B`, `]`→`%5D`; a renamed heading containing brackets no longer yields a broken `[txt](note.md#New [1])`.
- **H3 — TOCTOU guard.** The apply phase re-reads source and each backlinker; if a file changed between plan and apply (live editing in Obsidian) it aborts (source) or reports the file in `failedFiles` (backlinker) instead of overwriting the concurrent edit. The two-phase split was plan/apply, not transactional.

## Tests

C2 (``` and `~~~`), H4 (`[ ]` encoding), H2 (level fallback), plus the previously-missing **partial-failure (M2)** and **TOCTOU (H3, source + backlinker)** tool tests, via two minimal mock hooks (`setMockModifyFail`, `setMockReadMutation`). `headingRename.test.ts` 30→34, `renameHeading.test.ts` 11→14.

## Deliberately deferred

**M1 — pipe-without-alias wikilink** (`[[source#A|B]]` for a heading literally named `A|B`): the tokenizer's `lastIndexOf("|")` splits at the in-heading `|` and the rewrite is dropped. Left for the #68 RFC thread — "fail-loud vs tokenizer" on the special-char set (edge case #7) is a policy decision with design surface, not a mechanical fix; @folotp / @marcoaperez should weigh in. Documented, not silently shipped.

## Conventions

- CLAUDE.md MCP surface synced 29 → 30 (`rename_heading` row added; @marcoaperez's commit already synced README).
- The verbose `[Unreleased]` CHANGELOG block from #143 trimmed to a terse user-notable entry consistent with the rest of the file (CHANGELOG / documentation-discipline rule); the released `[0.4.10]` section is preserved.

## Verification

- `bun run check`: `shared` + `obsidian-plugin` clean.
- `bun test` (obsidian-plugin): 805 pass; the 3 `bindWithFallback` fails are the documented local-port env non-issue, not a regression.
- Local prod build blocked by the pre-existing unrelated Svelte toolchain drift (reproduces on clean `main`); CI's clean build is authoritative.

Credit for the feature is @marcoaperez's; this is the review-hardening layer on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)