### PR TITLE
chore(ci): drop retired feat/http-embedded from CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 # On-PR validation: typecheck + bundle build-smoke + tests across the
-# workspace. Runs on every push to main / feat/http-embedded and on
-# every PR targeting either branch. The build step here is a smoke
+# workspace. Runs on every push to main and on every PR targeting
+# main. The build step here is a smoke
 # check that catches a non-buildable bundle (e.g. Svelte/patch version
 # drift — #150). release.yml stays separate (tag-triggered) and owns
 # the release build: release env + zip + upload + attestation.
@@ -15,11 +15,9 @@ on:
   push:
     branches:
       - main
-      - feat/http-embedded
   pull_request:
     branches:
       - main
-      - feat/http-embedded
 
 # Cancel an older in-flight run for the same ref when a new push lands.
 # A redundant test run on a stale commit is wasted CI time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ If you ever encounter a "GH013: Repository rule violations" error, the operation
 | Test | `bun:test` (native) |
 | Format | Prettier 3 (`.prettierrc.yaml`) — 2-space indent, 80 col |
 | Build | `packages/obsidian-plugin/bun.config.ts` (Bun bundler) → plugin `main.js`. No binary. `__dirname`/`__filename`/`import.meta.*` are neutralized in the `define` block for a reproducible cross-machine bundle (Obsidian store build-verification) |
-| CI | GitHub Actions — `ci.yml` (typecheck + bundle build-smoke + workspace tests on push/PR to `main` & `feat/http-embedded`); `release.yml` (tag-triggered) builds plugin assets (`main.js` + `manifest.json`) + GitHub build-provenance attestation |
+| CI | GitHub Actions — `ci.yml` (typecheck + bundle build-smoke + workspace tests on push/PR to `main`); `release.yml` (tag-triggered) builds plugin assets (`main.js` + `manifest.json`) + GitHub build-provenance attestation |
 
 Path alias inside every package: **`$/*` → `src/*`**. Use it instead of relative imports across feature boundaries.
 
@@ -287,7 +287,7 @@ Active traps in the current tree. Historical bugs already fixed are in `git log`
   - **Stubbing `os.homedir()`**: use `spyOn(os, "homedir").mockReturnValue(tmpRoot)` — Bun/Node cache HOME early, so runtime `process.env.HOME = …` is not reliable. See `config.test.ts` and `uninstall.test.ts`.
   - **Installer integration tests** use real shell scripts as fake binaries (tmpdir, `mode: 0o755`) instead of mocking `child_process.exec`. See `status.integration.test.ts`. macOS-guarded (shebang approach is Unix-only).
 - **Still uncovered**: `installMcpServer` orchestration wrapper, `downloadFile` (HTTP + stream), Svelte component rendering (covered only by `svelte-check` and manual `bun run link` smoke tests).
-- CI: `.github/workflows/ci.yml` runs on every push/PR to `main` or `feat/http-embedded` — `bun install --frozen-lockfile`, `bun run check` (workspace typecheck), `bun run build` (bundle build-smoke, #150), then `bun test` in `packages/shared` and `packages/obsidian-plugin`. `.github/workflows/release.yml` is separate (tag push): builds the plugin assets + GitHub build-provenance attestation (no binary, no cross-compile). Keep tests green locally — CI gates the PR.
+- CI: `.github/workflows/ci.yml` runs on every push/PR to `main` — `bun install --frozen-lockfile`, `bun run check` (workspace typecheck), `bun run build` (bundle build-smoke, #150), then `bun test` in `packages/shared` and `packages/obsidian-plugin`. `.github/workflows/release.yml` is separate (tag push): builds the plugin assets + GitHub build-provenance attestation (no binary, no cross-compile). Keep tests green locally — CI gates the PR.
 
 ## Pre-commit checklist
 


### PR DESCRIPTION
## Summary

- `feat/http-embedded` was retired (deleted from origin) 2026-05-16 at 0-ahead. Remove it from `ci.yml` `push.branches` and `pull_request.branches` so any accidental future recreation of that branch name cannot reactivate CI on an unprotected ref.
- Sync the two stale doc rows in `CLAUDE.md` (Stack table CI row line 56 + Testing & CI section line 290). Historical references (discharge note line 19, ruleset history line 33) are preserved.

Surfaced by a review-triage-fix cycle over the recent CI/doc merges (PRs #148–#153).

## Test plan

- [ ] CI `build-smoke` job runs and passes on this PR (this is the validation that the trigger still fires for `pull_request` against `main`).
- [ ] `git grep 'feat/http-embedded' .github/workflows/` returns zero matches.
- [ ] `git grep 'feat/http-embedded' CLAUDE.md` returns only lines 19 + 33 (historical).