### PR TITLE
docs: condense .gitignore note, clarify toolchain pinning scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,11 +181,8 @@ dist
 # Finder (MacOS) folder config
 .DS_Store
 
-# Built plugin bundle — emitted at the REPO ROOT by `bun run build`
-# (bun.config.ts `outdir: "../.."`). The shipped artifact AND the file
-# Obsidian loads via `bun run link` symlinks. Gitignored (never
-# committed) but NOT scratch — do not delete it; a missing main.js
-# breaks every dev-linked vault (real MCP outage 2026-05-19).
+# Built plugin bundle (outdir ../..) — gitignored but NOT scratch.
+# Do not delete: dev-linked vaults load it. See CLAUDE.md Gotchas.
 main.js
 
 # Scratch pad

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ If you ever encounter a "GH013: Repository rule violations" error, the operation
 | Layer | Tech |
 |---|---|
 | Monorepo | Bun workspaces (`bun.lock`) — **do not use npm/yarn/pnpm** |
-| Toolchain pinning | `mise.toml` + `release.yml` (bun pinned `1.3.12` — reproducible builds; do not revert to `latest`) |
+| Toolchain pinning | `mise.toml` + `release.yml` (bun pinned `1.3.12` — reproducible builds; do not revert to `latest`). `ci.yml` deliberately uses `latest` (see Pending #3). |
 | Language | TypeScript 5, strict mode, `verbatimModuleSyntax: true` |
 | Runtime validation | **ArkType** (`arktype` 2.0.0-rc.30) at every external boundary |
 | MCP | `@modelcontextprotocol/sdk` 1.29.0 |


### PR DESCRIPTION
## Summary

Two small doc edits surfaced by a review-triage-fix cycle:

- `.gitignore` `main.js` block: reduce the 5-line discursive comment to 2 lines that keep the load-bearing facts (gitignored but not scratch, do-not-delete + dev-linked vaults rationale) and defer detail to `CLAUDE.md` Gotchas, where the outage context already lives.
- `CLAUDE.md` Stack table, Toolchain pinning row: add `(release.yml only)` and a Pending #3 cross-reference so a reader does not infer `ci.yml` is pinned too — it deliberately runs on `bun-version: latest` (deferred divergence documented in #150).

## Test plan

- [ ] No behaviour change (docs + comment only). CI typecheck/build-smoke/tests should pass unchanged.
- [ ] `main.js` still ignored by git (`git check-ignore main.js` returns the path).