### PR TITLE
docs: SPEC + ADRs for frontmatter properties (D) + periodic notes (C)

### DIFF
--- a/docs/architecture/ADR-0001-atomic-frontmatter-property-tools.md
+++ b/docs/architecture/ADR-0001-atomic-frontmatter-property-tools.md
@@ -1,0 +1,78 @@
+# ADR-0001 — Atomic frontmatter property tools (Module D)
+
+- **Status**: Proposed
+- **Date**: 2026-05-20
+- **Scope**: PR #1 / `feat/note-properties` — 4 new MCP tools
+
+## Context
+
+The current 30-tool surface lets agents read frontmatter (`get_vault_file_partial mode:"frontmatter"`, `get_active_file`) but the only write path is `patch_vault_file targetType:"frontmatter"`, which **replaces the entire YAML block**. For an agent that wants to set a single key (`priority: 5`, `status: done`, append one tag) this is clumsy and risk-prone: it has to read the whole block, mutate one field client-side, and re-emit — losing any concurrent edits the user made in between.
+
+Three sub-decisions are needed for a clean tool family:
+
+1. **Tool surface shape** — one op-discriminated tool, or N atomic tools?
+2. **Value schema** — how to express the YAML scalar/list type space at the MCP boundary, given that older MCP clients serialise booleans as strings?
+3. **Enumeration return shape** — how `list_property_values` reports a potentially-large, mixed-type distribution.
+
+Constraint from `CLAUDE.md`: tools are registered via `ToolRegistry`, schemas are ArkType, every untrusted boundary is validated; vault writes go through `app.fileManager.processFrontMatter` (atomic, metadata-cache-safe). Pattern in the rest of the repo: **atomic, action-named tools** — `rename_heading`, `list_tags`, `delete_active_file`, `append_to_vault_file`, not generic ops with a discriminator.
+
+## Decision
+
+Ship **4 atomic tools** under the `note_property` namespace, each doing exactly one thing:
+
+- `get_note_property(path, key) → value | null`
+- `set_note_property(path, key, value)` — value type: ArkType union `string | number | boolean | string[] | number[]`. Dates as ISO 8601 strings (Obsidian YAML has no native date type).
+- `delete_note_property(path, key)` — idempotent (absent key → no-op success).
+- `list_property_values(key, folder?, limit?=500)` — returns a wrapper object:
+
+```
+{
+  values: Array<{ value: <native type>, count: number }>,
+  truncated: boolean,
+  totalDistinct: number,
+}
+```
+
+`set_note_property` with `value: null` is documented to redirect internally to `delete_note_property` (zero-friction for agents that compute "clear this field" intent). YAML-illegal key characters are pre-validated → `errorCode: "invalid_key"`. All writes go through `processFrontMatter`. `list_property_values` iterates `app.metadataCache` in-memory — no file I/O — and preserves native types in `value` (a numeric `priority: 5` returns `5`, not `"5"`).
+
+## Alternatives considered
+
+1. **Single discriminator tool** `note_property(op: "get"|"set"|"delete"|"list", ...)`. **Rejected**: violates the repo pattern (`ToolRegistry` is per-tool, not per-discriminated-union); forces the model to think about the op enum on every call; clobbers ArkType's per-tool `.describe()` schema docs (each op has a different argument shape, so the description becomes a wall of conditionals). The 30→34 tool count is well within client-rendering bounds.
+
+2. **Two bulk-oriented tools** `get_note_properties(path) → {...}` + `set_note_properties(path, patch: {...})`. **Rejected**: bulk write was explicitly deferred (YAGNI per spec: per-call latency is sub-10 ms in-process, the multi-key case is uncommon); the bulk-read shape already exists via `get_vault_file_partial mode:"frontmatter"`; bulk write hides the per-key delete semantic that agents need (sentinel value vs missing key is a confusing contract).
+
+3. **JSON-string + type wrapper** `set_note_property(path, key, jsonValue: string, valueType: "string"|"number"|...)`. **Rejected**: pushes type discipline onto the agent at the wrong layer; ArkType union already expresses the space natively; the boolean-as-string MCP gotcha is solved centrally in `ToolRegistry` (`CLAUDE.md` Gotcha — boolean coercion), so the union resolves correctly.
+
+4. **Single-string value with server-side type inference** (`set_note_property(path, key, value: string)` and the server parses `"5"` → 5, `"true"` → boolean). **Rejected**: ambiguous (is `"5"` the string `"5"` or the number `5`?); the user's existing YAML may rely on the distinction; type inference is a footgun that surfaces as silent data corruption.
+
+5. **`Record<value, count>` return for `list_property_values`** (the `list_tags` shape). **Rejected**: JSON object keys are strings, which coerces native types away — a vault with `priority: 5` and `priority: "5"` would collapse to one entry. The array-of-objects wrapper preserves the distinction. Precedent: `getRecentFiles` already uses a wrapper return — this is the established pattern for "list with metadata about the list".
+
+## Consequences
+
+**Positive**:
+
+- Agents can mutate a single FM key in one call without read-modify-write race risk; the atomic `processFrontMatter` path is the canonical Obsidian-API write.
+- Native-type preservation in `list_property_values` keeps the schema honest for sloppy real-world vaults (mixed `string` / `number` for the same key).
+- Per-tool ArkType schemas keep the model-facing docs precise; `.describe()` on each field is unambiguous.
+- `list_property_values` uses `metadataCache` only → O(notes) memory scan, no file I/O, scales to 10k+ note vaults.
+
+**Negative**:
+
+- Tool count grows 30 → 34 (`CLAUDE.md` count note bumps in PR #1). Within comfortable bounds for Claude Desktop / Cursor / Cline tool-list rendering but non-zero.
+- The union value type is intentionally **not** mixed-type lists — a frontmatter list with both numbers and strings cannot round-trip through `set_note_property`. Spec accepts the trade-off; the bulk-replace `patch_vault_file` path remains available for those edge cases.
+- `value: null` → delete redirect is documented behaviour but depends on MCP clients passing `null` consistently (not coerced to missing arg). Flagged as an "open item" in the spec; pinned by unit test at implementation time.
+- `limit=500` default on `list_property_values` is a heuristic; vaults with >500 distinct values for a single key will see `truncated: true` and need to pass a higher limit. Acceptable — the wrapper tells them so explicitly.
+
+**Neutral**:
+
+- Coexists with `patch_vault_file targetType:"frontmatter"`: the latter remains the path for replacing the whole block, the new tools are the path for single-key ops. Two paths, two purposes; the `.describe()` docs make the choice clear.
+- Naming `note_property` (not `frontmatter_property`, not `yaml_property`) is semantic: agents reason about "the note's properties" the same way Obsidian's UI labels them.
+
+## References
+
+- Spec: `docs/design/2026-05-20-frontmatter-properties-and-periodic-notes.md` (Module D)
+- Repo pattern: `packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts`, `listTags.ts`, `getRecentFiles.ts`
+- `ToolRegistry`: `packages/obsidian-plugin/src/features/mcp-tools/` — boolean string-coercion centralised
+- `CLAUDE.md` — Tool registration pattern; Gotchas (boolean serialisation)
+- Obsidian API: `app.fileManager.processFrontMatter(file, cb)`, `app.metadataCache`
+- ADR-0002 — Periodic notes (sister module, ships as PR #2 after this lands)

--- a/docs/architecture/ADR-0002-periodic-notes-tools.md
+++ b/docs/architecture/ADR-0002-periodic-notes-tools.md
@@ -1,0 +1,99 @@
+# ADR-0002 — Daily / periodic notes tools (Module C)
+
+- **Status**: Proposed
+- **Date**: 2026-05-20
+- **Scope**: PR #2 / `feat/periodic-notes` — 3 new MCP tools + 1 detector service
+
+## Context
+
+Daily notes are the **single most common Obsidian workflow**: open today's note, append a bullet, move on. Today the only path for an MCP agent to do this is `execute_template` with foreknowledge of the user's path pattern (`Daily/{{date:YYYY-MM-DD}}.md` or whatever they configured) plus a Templater template that knows how to create one. Periodic variants (weekly review, monthly retrospective) are even more friction.
+
+Two coupled design choices:
+
+1. **Tool surface + date semantics** — is it one generic tool (`get_or_create_periodic_note(period, date?)`) or a split where daily gets a dedicated pair? How is `date?` expressed across periods (daily, weekly, monthly, quarterly, yearly)?
+2. **Plugin dependency** — the official **Daily Notes** core plugin and the community **Periodic Notes** plugin each carry the user's folder / format / template configuration. They may be **both on, one on, or both off**. Do we ignore them and impose our own defaults? Read their config but reimplement creation? Or delegate to their API?
+
+Constraints (`CLAUDE.md`): never touch the vault filesystem directly from a handler — go through Obsidian APIs so the metadata cache stays coherent, file locks on open notes are respected, and other plugins (Templater, Dataview) can hook in. Setup contract: features must not throw on missing dependencies; return `{ success: false, error }` and let the rest of the plugin load.
+
+## Decision
+
+### Tool surface — 3 tools, daily-dedicated split
+
+- `get_or_create_daily_note(date?) → { path, content, created }` — `date?` is ISO `YYYY-MM-DD`, default today (server-local timezone).
+- `append_to_daily_note(content, date?, underHeading?) → { path, appended }` — auto-creates the daily note if missing; `underHeading?` reuses the existing heading-walker from `patch_vault_file`; default is end-of-file append.
+- `get_or_create_periodic_note(period, date?) → { path, content, created }` — `period: "daily" | "weekly" | "monthly" | "quarterly" | "yearly"`.
+
+### Date format — ISO 8601 strict, period-specific
+
+| Period | Format | Example |
+|---|---|---|
+| daily | `YYYY-MM-DD` | `2026-05-20` |
+| weekly | `YYYY-Www` (ISO week) | `2026-W21` |
+| monthly | `YYYY-MM` | `2026-05` |
+| quarterly | `YYYY-QN` | `2026-Q2` |
+| yearly | `YYYY` | `2026` |
+
+Validated by ArkType regex at the boundary. Default = the period instance containing **today in the plugin process timezone**. In the in-process / desktop deployment that is the user's own machine (the 99% case). For headless / multi-host setups where the MCP server runs on a different host than the Obsidian client, an explicit `date` argument is the prescribed way to avoid TZ-driven off-by-one resolution. Documented in each tool's `.describe()`.
+
+### Plugin handling — graceful, delegate to plugin API when present
+
+A `services/periodicNotesDetector.ts` (unit-tested independently) reads at call time:
+
+- `app.internalPlugins.plugins["daily-notes"]` (core Daily Notes)
+- `app.plugins.plugins["periodic-notes"]` (community Periodic Notes)
+
+Behaviour matrix:
+
+| State | Behaviour |
+|---|---|
+| Daily Notes ON | Folder + format + template read from its config; creation via Daily Notes' API so the user's template (incl. `{{date}}` / `{{title}}` interpolations and Templater hooks) runs. |
+| Daily Notes OFF, Periodic Notes ON | Periodic Notes covers daily too — same API delegation. |
+| Both OFF | Fallback: folder = vault root, format = ISO 8601 strict, template = empty file. Documented in each tool's `.describe()`. |
+| Daily ON, Periodic OFF | Daily uses Daily Notes API; weekly/monthly/quarterly/yearly fall back to root + ISO + no template. |
+
+We do **not** second-guess the plugin's API — if it returns the wrong note during a user setting race, that's its problem to fix, not ours.
+
+## Alternatives considered
+
+1. **One generic tool only** `get_or_create_periodic_note(period, date?)` — drop `get_or_create_daily_note` and `append_to_daily_note`. **Rejected**: daily is ~90% of the workflow (per spec); making the agent specify `period: "daily"` on every call is friction at the wrong layer. Analogue to `getActiveFile` vs `getVaultFile` — the common case earns its own shortcut. Three tools is cheaper than the cognitive tax of one over-general one.
+
+2. **Five split tools** (one per period). **Rejected**: weekly/monthly/quarterly/yearly are low-frequency variants of the same operation; collapsing them behind a `period` discriminator keeps the surface tight. The asymmetry (daily dedicated, rest collapsed) tracks real usage frequency, not aesthetic uniformity.
+
+3. **Relative date aliases** (`"today"`, `"yesterday"`, `"last-week"`, `"this-month"`). **Rejected**: ambiguous (timezone? "yesterday" at 00:30 local?), not validatable by a regex, leak server-clock assumptions into the agent contract. ISO 8601 strict is unambiguous, parseable by ArkType, and the model can compute it from a clock context just as easily.
+
+4. **Roll our own folder/format/template logic** ignoring the plugins. **Rejected**: would create two sources of truth — a user with Daily Notes ON and our tool installed would get two different daily notes for the same date (Obsidian UI creates one path, MCP tool creates another). Vault metadata-cache integrity and user trust both lose.
+
+5. **Read plugin config but reimplement creation in-house** (avoid the dependency on the plugin's API surface). **Rejected**: misses template interpolation (Daily Notes runs the configured template engine, including Templater hooks if present); reimplementing template execution would duplicate logic the plugin already owns and inevitably drift. The plugin's API is the source of truth; we call it.
+
+6. **Add Periodic Notes plugin as a hard dependency** (require it installed). **Rejected**: violates the feature-setup contract — features must degrade gracefully; forcing a community plugin install on users who only want daily-note ergonomics is unacceptable; the fallback (ISO + root + no template) is a coherent vanilla baseline.
+
+## Consequences
+
+**Positive**:
+
+- Agents do "open today's daily note, append a bullet" in one tool call without knowing the user's folder layout.
+- Template interpolations (incl. Templater) Just Work when the user's plugins are configured — the MCP path produces the same note the Obsidian UI would.
+- Detector centralises plugin-state introspection; future periodic-aware tools (`list_periodic_notes`, `archive_old_dailies`) reuse it.
+- Graceful fallback means a vanilla Obsidian install (no Daily/Periodic Notes plugins) still gets working tools, just with ISO defaults — predictable, documented.
+
+**Negative**:
+
+- ISO week numbers (weekly period: `YYYY-Www`) require the model to think about ISO 8601 week-of-year, which it occasionally gets wrong (off-by-one on year boundaries). Mitigation: ArkType regex rejects malformed input loudly (`errorCode: "invalid_date_for_period"`), and the model can default to "current period" by omitting `date?`.
+- Daily note discovery when the user has a **custom non-ISO format** (e.g. `DD-MM-YYYY`) only works **with the plugin enabled** — the detector reads the format setting and matches. Without the plugin, only ISO is recognised; a pre-existing custom-format daily note would be invisible and the tool would create a duplicate at the ISO path. Acceptable: the precondition is documented; users with custom formats are by definition users who have the plugin.
+- Test plan splits: unit tests mock the plugin API; integration tests need a real plugin installed in the test vault; manual smoke through the TEST vault covers the live path. Adds a real-plugin path to the integration matrix.
+- Plugin API races (user toggles the format mid-call) are explicitly out of scope — single source of truth is the plugin, we don't add defensive logic.
+
+**Neutral**:
+
+- `obsidian-daily-notes-interface` may need to be added as a `dependencies` entry if not already transitively present (verified during implementation, per spec). Small, well-maintained, used by Periodic Notes itself — low supply-chain risk.
+- 4 → 7 added tools after both PRs (30 + 4 + 3 = 37 total). Bumped in `CLAUDE.md` tool-count note during PR #2.
+- `append_to_daily_note` with non-existent `underHeading` errors the same way `patch_vault_file` does today — consistent surface for heading-walker failures. Specifically: if the daily note had to be **auto-created in the same call** and its rendered template does not contain the requested heading, the call still returns `errorCode: "heading_not_found"` and the **auto-created file is left in place** (no rollback). The file's existence is the right end-state regardless of whether this particular append landed; the model adds the heading and retries.
+
+## References
+
+- Spec: `docs/design/2026-05-20-frontmatter-properties-and-periodic-notes.md` (Module C)
+- ADR-0001 — Atomic frontmatter property tools (sister module, ships as PR #1 first)
+- Obsidian APIs: `app.internalPlugins.plugins["daily-notes"]`, `app.plugins.plugins["periodic-notes"]`
+- External dep candidate: [`obsidian-daily-notes-interface`](https://github.com/liamcain/obsidian-daily-notes-interface)
+- Feature-setup contract: `.clinerules` (feature `index.ts` setup signature)
+- Repo pattern: `packages/obsidian-plugin/src/features/mcp-tools/tools/getActiveFile.ts` (analogue for the daily-dedicated shortcut shape)

--- a/docs/design/2026-05-20-frontmatter-properties-and-periodic-notes.md
+++ b/docs/design/2026-05-20-frontmatter-properties-and-periodic-notes.md
@@ -144,7 +144,13 @@ for single-key ops.
 
 #### `get_or_create_daily_note(date?) → { path, content, created }`
 
-- `date?: string` — ISO `YYYY-MM-DD`. Default: today (server-local timezone).
+- `date?: string` — ISO `YYYY-MM-DD`. Default: today in the **plugin
+  process timezone**, which in the in-process / desktop deployment is
+  the user's own machine TZ (the 99% case). In a headless or
+  multi-host setup where the MCP server runs on a different host than
+  the Obsidian client, an explicit `date: YYYY-MM-DD` should be passed
+  to avoid TZ-driven off-by-one errors. Documented verbatim in
+  `.describe()`.
 - Returns the existing note if present, otherwise creates it and returns
   the new file. `created: boolean` reflects which path was taken.
 
@@ -157,6 +163,15 @@ for single-key ops.
   end-of-file append (like `append_to_vault_file`).
 - If the daily note does not exist, it is auto-created first (same path as
   `get_or_create_daily_note`).
+- **`underHeading` resolution on an auto-created daily**: if the freshly
+  created file (empty or rendered from template) does not contain the
+  requested heading, the tool returns `errorCode: "heading_not_found"`.
+  The auto-created file is **left in place** (no rollback) — its
+  existence is the right end state regardless of whether this single
+  append landed. The model can then add the heading (`patch_vault_file`
+  or a subsequent `append_to_daily_note` without `underHeading`) and
+  retry. Strict-by-default, no silent end-of-file fallback (consistent
+  with `patch_vault_file targetType:"heading"`).
 
 #### `get_or_create_periodic_note(period, date?) → { path, content, created }`
 
@@ -193,7 +208,9 @@ unit-tested independently.
 | `date` malformed for the chosen period (e.g. `2026-W99`) | Pre-validated by ArkType regex; `errorCode: "invalid_date_for_period"`. |
 | Daily note exists with custom non-ISO format the plugin generates | Detector reads the plugin's format setting and matches. Without the plugin, only ISO is recognised. |
 | Plugin returns the wrong note (race during user setting change) | Out of scope — single source of truth is the plugin's API; we don't second-guess. |
-| `append_to_daily_note` with `underHeading` that doesn't exist | Error from the heading walker (same as `patch_vault_file` today). |
+| `append_to_daily_note` with `underHeading` that doesn't exist (existing daily) | Error from the heading walker (same as `patch_vault_file` today). |
+| `append_to_daily_note` with `underHeading` that doesn't exist (auto-created daily, this call) | `errorCode: "heading_not_found"`; auto-created file is **not** rolled back. Model adds heading + retries. |
+| User disables the Daily Notes plugin **after** notes have been created with its custom format | Subsequent calls without the plugin fall back to ISO format → may create a second note that day with the ISO path while the custom-format note is orphaned. Documented; not auto-recovered. Recommend re-enabling the plugin to keep continuity. |
 | Template that calls Templater | Daily Notes API uses the configured template engine; if Templater is configured + enabled, it runs. If template references undefined variables, the plugin handles it. Out of our hands. |
 
 ## Tool count after both PRs

--- a/docs/design/2026-05-20-frontmatter-properties-and-periodic-notes.md
+++ b/docs/design/2026-05-20-frontmatter-properties-and-periodic-notes.md
@@ -1,0 +1,273 @@
+# 2026-05-20 — Frontmatter properties (D) + periodic notes (C) — design
+
+Spec for two independent tool families to be shipped as two sequential PRs.
+Decisions in this document were brainstormed in interview form on 2026-05-20.
+No production code is written from this document directly — the implementation
+plan lives in a separate file produced by `superpowers:writing-plans`.
+
+## Goals
+
+Add two tool families that close concrete usability gaps the current 30-tool
+surface leaves open:
+
+1. **D — atomic frontmatter properties.** First-class get/set/delete on a
+   single YAML key, plus vault-wide value enumeration. Today, modifying a
+   single key requires `patch_vault_file targetType:"frontmatter"` which
+   replaces the entire block — clumsy and risk-prone for agents.
+
+2. **C — daily/periodic notes helpers.** Ergonomic creation/append on
+   daily, weekly, monthly, quarterly and yearly notes — the single most
+   common Obsidian workflow, currently reachable only via
+   `execute_template` with path-pattern knowledge.
+
+## Out of scope
+
+- Bulk write (`set_note_properties(path, {...})`) — deferred until soak
+  signals demand. Per-call latency is sub-10 ms in-process; the multi-key
+  case is uncommon enough that YAGNI applies.
+- Append-to-list-idempotent (`append_to_note_property_list`) — same reason.
+- Periodic note rename / delete — out of scope; daily notes are not
+  special once they exist, the existing `rename_vault_file` /
+  `delete_vault_file` already cover the case.
+- Recent-changes feed, Canvas tools, MCP `resources` capability — these
+  were the other candidates considered in the same brainstorm. Not blocked
+  by this spec; can be sequenced after.
+
+## Stack
+
+Same as the rest of the plugin (no new runtime deps for D; C may pull
+`obsidian-daily-notes-interface` if not already transitively present —
+verified during implementation).
+
+- TypeScript 5 strict, `verbatimModuleSyntax: true`
+- ArkType for boundary validation
+- `bun:test` (native)
+- Registered via the shared `ToolRegistry` — no direct SDK calls
+
+## Architecture
+
+Both modules add files under
+`packages/obsidian-plugin/src/features/mcp-tools/tools/`, following the
+established pattern (one file per tool, schema + handler + types,
+unit-tested next to the source). No new feature module under `features/`
+is required.
+
+Tool registration is wired in
+`packages/obsidian-plugin/src/features/mcp-tools/index.ts` — a single
+edit per PR.
+
+```
+mcp-tools/tools/
+├── getNoteProperty.ts          (PR #1 / D)
+├── setNoteProperty.ts          (PR #1 / D)
+├── deleteNoteProperty.ts       (PR #1 / D)
+├── listPropertyValues.ts       (PR #1 / D)
+├── getOrCreateDailyNote.ts     (PR #2 / C)
+├── appendToDailyNote.ts        (PR #2 / C)
+└── getOrCreatePeriodicNote.ts  (PR #2 / C)
+```
+
+## Module D — atomic frontmatter properties
+
+### Tool surface (4 tools, atomic)
+
+Naming uses `note_property` (semantic, concise). Coexists with the
+existing `patch_vault_file targetType:"frontmatter"` — the latter remains
+the path for replacing the entire FM block; the new tools are the path
+for single-key ops.
+
+#### `get_note_property(path, key) → value | null`
+
+- `path: string` — vault-relative
+- `key: string` — top-level YAML key
+- Returns the raw value preserving native type (string, number, boolean,
+  list, or `null` if the key does not exist on this note).
+- File not found → `errorCode: "file_not_found"`.
+- Frontmatter missing on the file → returns `null` (not an error — the
+  key cannot exist if there is no FM, that is the same as "key absent").
+- Frontmatter malformed (YAML invalid in Obsidian's parser) → error
+  identical in shape to `get_vault_file_partial mode:"frontmatter"`.
+
+#### `set_note_property(path, key, value)`
+
+- `value: string | number | boolean | string[] | number[]` — ArkType union.
+  Date values are passed as ISO 8601 strings (Obsidian YAML does not type
+  them natively).
+- File missing FM block → block is auto-initialised at the file head, like
+  `patch_vault_file` already does for missing headings.
+- `value === null` → semantically equivalent to `delete_note_property`
+  (documented in `.describe()`, redirects internally — zero-friction for
+  agents that compute a "clear this field" intent).
+- YAML-illegal key characters (`:`, `\n`, leading `#`, etc) → pre-validated,
+  `errorCode: "invalid_key"`.
+- Atomic on disk via `app.fileManager.processFrontMatter(file, cb)`.
+
+#### `delete_note_property(path, key)`
+
+- Idempotent: key absent → no-op success.
+- File missing → error (`file_not_found`).
+- Same `processFrontMatter` atomic path.
+
+#### `list_property_values(key, folder?, limit?=500) → wrapper`
+
+```
+{
+  values: Array<{ value: <native type>, count: number }>,
+  truncated: boolean,
+  totalDistinct: number,
+}
+```
+
+- Iterates `app.metadataCache` in-memory (no file I/O).
+- `folder?` filters results to files whose path starts with that prefix
+  (slash-normalised, same convention as `list_vault_files`).
+- `limit` defaults to 500 distinct values. If the underlying set is
+  larger, results are truncated to the top-`limit` by count, descending;
+  `truncated: true` and `totalDistinct` lets the agent decide whether
+  to refine.
+- Preserves native types in `value` so number/string distinction is not
+  lost (a frontmatter `priority: 5` returns `value: 5` not `"5"`).
+
+### Edge cases (D)
+
+| Case | Behaviour |
+|---|---|
+| File path traverses out of vault | Rejected by Obsidian's `vault.getAbstractFileByPath` (returns null) → `file_not_found`. |
+| Key is empty string | `invalid_key`. |
+| Set on note containing only `---\n---\n` (empty FM block) | `processFrontMatter` re-emits the block with the new key — supported. |
+| Concurrent edit by user while set runs | `processFrontMatter` re-reads-then-writes inside a single atomic operation per Obsidian; no extra serialisation needed at the tool level. |
+| `list_property_values` with `key="tags"` (special-cased by Obsidian) | Returns the union of frontmatter `tags`/`tag` arrays; inline `#tags` are out of scope here (use `list_tags`). |
+
+## Module C — daily / periodic notes
+
+### Tool surface (3 tools)
+
+#### `get_or_create_daily_note(date?) → { path, content, created }`
+
+- `date?: string` — ISO `YYYY-MM-DD`. Default: today (server-local timezone).
+- Returns the existing note if present, otherwise creates it and returns
+  the new file. `created: boolean` reflects which path was taken.
+
+#### `append_to_daily_note(content, date?, underHeading?) → { path, appended }`
+
+- `content: string` — markdown to append.
+- `date?` as above.
+- `underHeading?: string` — if provided, appends inside that heading's
+  section (reuses the existing `patchActiveFile` heading walker). Default:
+  end-of-file append (like `append_to_vault_file`).
+- If the daily note does not exist, it is auto-created first (same path as
+  `get_or_create_daily_note`).
+
+#### `get_or_create_periodic_note(period, date?) → { path, content, created }`
+
+- `period: "daily" | "weekly" | "monthly" | "quarterly" | "yearly"`.
+- `date?` is ISO 8601 strict, period-specific:
+  - daily → `YYYY-MM-DD`
+  - weekly → `YYYY-Www` (ISO week)
+  - monthly → `YYYY-MM`
+  - quarterly → `YYYY-QN`
+  - yearly → `YYYY`
+- Default: the period instance containing today.
+
+### Plugin handling — graceful
+
+A small detector reads at call time:
+
+- `app.internalPlugins.plugins["daily-notes"]` — built-in Daily Notes
+- `app.plugins.plugins["periodic-notes"]` — community Periodic Notes
+
+| Plugin state | Behaviour |
+|---|---|
+| Daily Notes ON | Folder, date format, template all read from its config. Creation via `createDailyNote(date)` so template + interpolations (`{{date}}`, `{{title}}`, etc) are applied. |
+| Daily Notes OFF, Periodic Notes ON | Periodic Notes covers daily too — same path via its API. |
+| Both OFF | Fallback defaults: folder = vault root, format = ISO 8601 strict, template = none (empty file). Documented in `.describe()`. |
+| Daily ON, Periodic OFF | `period: "weekly"|"monthly"|...` falls back to fallback defaults (root, ISO format, no template). Daily continues to use the Daily Notes plugin. |
+
+The detector is exported as `services/periodicNotesDetector.ts` and
+unit-tested independently.
+
+### Edge cases (C)
+
+| Case | Behaviour |
+|---|---|
+| `date` malformed for the chosen period (e.g. `2026-W99`) | Pre-validated by ArkType regex; `errorCode: "invalid_date_for_period"`. |
+| Daily note exists with custom non-ISO format the plugin generates | Detector reads the plugin's format setting and matches. Without the plugin, only ISO is recognised. |
+| Plugin returns the wrong note (race during user setting change) | Out of scope — single source of truth is the plugin's API; we don't second-guess. |
+| `append_to_daily_note` with `underHeading` that doesn't exist | Error from the heading walker (same as `patch_vault_file` today). |
+| Template that calls Templater | Daily Notes API uses the configured template engine; if Templater is configured + enabled, it runs. If template references undefined variables, the plugin handles it. Out of our hands. |
+
+## Tool count after both PRs
+
+30 (current) + 4 (D) + 3 (C) = **37 tools**. Within comfortable bounds for
+Claude Desktop / Cursor / Cline tool-list rendering. CLAUDE.md tool count
+note bumped in PR #2's CLAUDE.md update.
+
+## Test plan (strict)
+
+Per tool, baseline:
+
+- Unit happy path (1+ test).
+- Edge cases enumerated in this spec — at least 2 per tool, more where the
+  table above lists multiple.
+- Integration test against a tmpdir vault with FM fixtures (per the
+  existing test-setup pattern; see `test-setup.ts`).
+- Manual smoke through Claude Desktop on the vault TEST.
+
+In addition:
+
+- **Soak proattivo**: pre-release BRAT branch posted to folotp +
+  marcoaperez before merge, with a structured ask (chain-discriminator
+  per `Soak preflight` in CLAUDE.md, plus the per-tool happy + edge
+  list). Wait 1–2 days for feedback before merge.
+- **CI green** including the `build-smoke` job that the PR #150 cycle
+  added.
+
+## Shipping plan
+
+**PR #1 — D (`feat/note-properties`)**
+
+- 4 new tool files + tests
+- 1 edit to `mcp-tools/index.ts` (registration)
+- CLAUDE.md tool count update (30 → 34)
+- CHANGELOG `[Unreleased]` entry under `### Added`
+- Soak proattivo, merge after.
+
+**PR #2 — C (`feat/periodic-notes`)**
+
+- 3 new tool files + tests
+- 1 new service (`periodicNotesDetector.ts`) + tests
+- 1 edit to `mcp-tools/index.ts`
+- CLAUDE.md tool count update (34 → 37)
+- CHANGELOG `[Unreleased]` entry under `### Added`
+- Starts after PR #1 soak closes (assimilates any feedback pattern).
+
+Both target `main` directly via PR (per `main-strict` ruleset). No
+intermediate release branch — release cut is a separate, later step that
+will bundle the new code with any other accumulated changes.
+
+## Success criteria
+
+- All 7 tools registered, schema-valid, callable from at least one MCP
+  client (manual smoke).
+- Per-tool tests pass under `bun test` in each package.
+- `bun run check` green across the workspace.
+- Soak round closes with zero unresolved blockers from folotp +
+  marcoaperez.
+- CHANGELOG and CLAUDE.md are in sync with the new tool count and the
+  new entries.
+
+## Open items (resolve during implementation, do not re-design)
+
+1. `set_note_property` with `value: null` redirect to delete — confirmed
+   in this spec; double-check no MCP client serialises `null` differently
+   from "missing arg". Same scrutiny for boolean values vs the
+   ToolRegistry boolean-string coercion (CLAUDE.md gotcha #1) — when the
+   schema is a union with `string` as first alternative, an incoming
+   `"true"` should still be coerced to boolean if the agent's intent was
+   boolean, but ArkType union resolution may match string first; verify
+   and pin behaviour with a unit test.
+2. YAML-illegal key char list — finalise the regex in the implementation
+   based on the exact behaviour of `processFrontMatter`.
+3. Whether `obsidian-daily-notes-interface` is already transitively
+   present in `bun.lock`; if not, add as a `dependencies` entry (small,
+   well-maintained, used by Periodic Notes itself).


### PR DESCRIPTION
## Summary

Pure docs PR — no runtime / shipped-bundle change. Lays out the design for two upcoming feature PRs:

- **Module D** — atomic frontmatter property tools: 4 new MCP tools (`get_note_property`, `set_note_property`, `delete_note_property`, `list_property_values`). Closes the gap where the only FM write path today is `patch_vault_file targetType:"frontmatter"` which replaces the whole block.
- **Module C** — daily / periodic notes helpers: 3 new MCP tools (`get_or_create_daily_note`, `append_to_daily_note`, `get_or_create_periodic_note`) with graceful Daily Notes / Periodic Notes plugin handling.

Tool count goes 30 → 37 across the two future PRs (shipped sequentially: D first, then C).

## Files

- `docs/design/2026-05-20-frontmatter-properties-and-periodic-notes.md` — full SPEC (273+ lines) with goals, scope, per-tool schemas, edge-case tables, plugin matrix, test plan, shipping strategy.
- `docs/architecture/ADR-0001-atomic-frontmatter-property-tools.md` — decision record for D (tool surface shape, ArkType value union, list wrapper return).
- `docs/architecture/ADR-0002-periodic-notes-tools.md` — decision record for C (3-tool split, ISO 8601 strict, plugin delegation with graceful fallback).

The SPEC and ADRs reflect the brainstorming + interview-driver session held 2026-05-20 with the four explicit edge-case decisions pinned (TZ default, underHeading-on-autocreate strict, plugin ON→OFF custom-format divergence, null-as-delete redirect).

## Test plan

- [ ] CI (`check-and-test`) green — pure markdown additions, expected no-op.
- [ ] Both ADRs and the SPEC are readable end-to-end without forward references.