### PR TITLE
chore(main): remove dead 0.3.x HTTP handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ## [Unreleased]
 
+### Removed
+
+- **Dead 0.3.x HTTP handlers in `main.ts`.** `handleTemplateExecution`
+  and `handleSearchRequest` were Express-style request handlers from
+  the pre-0.4.x line; they survived the in-process HTTP-embedded pivot
+  as private methods with no call site (verified: no reference, binding,
+  or reflection dispatch). Removed (~180 LOC) along with the now-orphan
+  imports. No behaviour change — template execution and smart search
+  run through the in-process MCP path (`executeTemplate` /
+  `templatesCompat`, `search_vault_smart`).
+
 ### Continuous integration
 
 - Drop the retired `feat/http-embedded` branch from `ci.yml`

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -1,15 +1,9 @@
 import { type } from "arktype";
-import type { Request, Response } from "express";
 import { Notice, Plugin, TFile } from "obsidian";
-import { shake } from "radash";
 import { lastValueFrom } from "rxjs";
 import {
-  jsonSearchRequest,
   LocalRestAPI,
-  searchParameters,
   Templater,
-  type PromptArgAccessor,
-  type SearchResponse,
   type SmartConnections,
 } from "shared";
 import {
@@ -52,7 +46,6 @@ import type { ExcerptResolver } from "./features/semantic-search/services/native
 import {
   loadLocalRestAPI,
   loadSmartSearchAPI,
-  loadTemplaterAPI,
   type Dependencies,
 } from "./shared";
 import { logger } from "./shared/logger";
@@ -538,189 +531,6 @@ export default class McpToolsPlugin extends Plugin {
       });
 
     logger.info("MCP Tools Plugin loaded");
-  }
-
-  private async handleTemplateExecution(req: Request, res: Response) {
-    try {
-      const { api: templater } = await lastValueFrom(loadTemplaterAPI(this));
-      if (!templater) {
-        new Notice(
-          `${this.manifest.name}: Templater plugin is not available. Please install it from the community plugins.`,
-          0,
-        );
-        logger.error("Templater plugin is not available");
-        res.status(503).json({
-          error: "Templater plugin is not available",
-        });
-        return;
-      }
-
-      // Validate request body
-      const params = LocalRestAPI.ApiTemplateExecutionParams(req.body);
-
-      if (params instanceof type.errors) {
-        const response = {
-          error: "Invalid request body",
-          body: req.body,
-          summary: params.summary,
-        };
-        logger.debug("Invalid request body", response);
-        res.status(400).json(response);
-        return;
-      }
-
-      // Get prompt content from vault
-      const templateFile = this.app.vault.getAbstractFileByPath(params.name);
-      if (!(templateFile instanceof TFile)) {
-        logger.debug("Template file not found", {
-          params,
-          templateFile,
-        });
-        res.status(404).json({
-          error: `File not found: ${params.name}`,
-        });
-        return;
-      }
-
-      const config = templater.create_running_config(
-        templateFile,
-        templateFile,
-        Templater.RunMode.CreateNewFromTemplate,
-      );
-
-      const prompt: PromptArgAccessor = (argName: string) => {
-        return params.arguments[argName] ?? "";
-      };
-
-      const oldGenerateObject =
-        templater.functions_generator.generate_object.bind(
-          templater.functions_generator,
-        );
-
-      // Override generate_object to inject arg into user functions
-      templater.functions_generator.generate_object = async function (
-        config,
-        functions_mode,
-      ) {
-        const functions = await oldGenerateObject(config, functions_mode);
-        Object.assign(functions, { mcpTools: { prompt } });
-        return functions;
-      };
-
-      // Process template with variables
-      const processedContent = await templater.read_and_parse_template(config);
-
-      // Restore original functions generator
-      templater.functions_generator.generate_object = oldGenerateObject;
-
-      // Create new file if requested.
-      //
-      // `path` in the response reflects what THIS handler operated on
-      // (`params.targetPath`), not where Templater may have moved the
-      // file via `tp.file.move()` in the template's prelude — that's a
-      // side effect of the rendering pass and produces a separate file
-      // at the move target. `app.vault.create` here is the only
-      // operation that creates the file the caller asked for, so the
-      // returned `path` correctly tracks that operation.
-      //
-      // If a future refactor delegates to
-      // `templater.create_new_note_from_template(...)`, the same field
-      // would naturally carry the post-move destination by reading
-      // `tp.config.target_file.path`. The contract stays "the path
-      // this handler operated on", semantically forward-compatible.
-      //
-      // Design rationale + worked example (folotp's note on the
-      // `tp.file.move()` semantics seam):
-      //   https://github.com/istefox/obsidian-mcp-connector/issues/20#issuecomment-4335497942
-      if (params.createFile && params.targetPath) {
-        await this.app.vault.create(params.targetPath, processedContent);
-        res.json({
-          message: "Prompt executed and file created successfully",
-          content: processedContent,
-          path: params.targetPath,
-        });
-        return;
-      }
-
-      res.json({
-        message: "Prompt executed without creating a file",
-        content: processedContent,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger.error("Prompt execution error:", {
-        error: message,
-        body: req.body,
-      });
-      res.status(503).json({
-        error: "An error occurred while processing the prompt",
-        message,
-      });
-      return;
-    }
-  }
-
-  private async handleSearchRequest(req: Request, res: Response) {
-    try {
-      const dep = await lastValueFrom(loadSmartSearchAPI(this));
-      const smartSearch = dep.api;
-      if (!smartSearch) {
-        new Notice(
-          "Smart Connections plugin is required but not found. Please install it from the community plugins.",
-          0,
-        );
-        res.status(503).json({
-          error: "Smart Connections plugin is not available",
-        });
-        return;
-      }
-
-      // Validate request body
-      const requestBody = jsonSearchRequest
-        .pipe(({ query, filter = {} }) => ({
-          query,
-          filter: shake({
-            key_starts_with_any: filter.folders,
-            exclude_key_starts_with_any: filter.excludeFolders,
-            limit: filter.limit,
-          }),
-        }))
-        .to(searchParameters)(req.body);
-      if (requestBody instanceof type.errors) {
-        res.status(400).json({
-          error: "Invalid request body",
-          summary: requestBody.summary,
-        });
-        return;
-      }
-
-      // Perform search
-      const results = await smartSearch.search(
-        requestBody.query,
-        requestBody.filter,
-      );
-
-      // Format response
-      const response: SearchResponse = {
-        results: await Promise.all(
-          results.map(async (result) => ({
-            path: result.item.path,
-            text: await result.item.read(),
-            score: result.score,
-            breadcrumbs: result.item.breadcrumbs,
-          })),
-        ),
-      };
-
-      res.json(response);
-      return;
-    } catch (error) {
-      logger.error("Smart Search API error:", { error, body: req.body });
-      res.status(503).json({
-        error: "An error occurred while processing the search request",
-      });
-      return;
-    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises


### PR DESCRIPTION
## Summary

Removes two dead Express-style HTTP handlers from `main.ts` — `handleTemplateExecution` and `handleSearchRequest` — leftovers from the pre-0.4.x line that survived the in-process HTTP-embedded pivot as `private` methods with **no call site**.

Verified dead: no reference, no `.bind()`, no reflection/string dispatch anywhere in the codebase. As `private` + uncalled they are structurally unreachable, so removal is a behaviour no-op. The equivalent 0.4.x functionality runs through the in-process MCP path (`executeTemplate` / `templatesCompat` for template execution, `search_vault_smart` for smart search).

Surfaced by a structural refactor audit — these were the only dead-code finding; the rest of the file (and `patchHelpers.ts`, the other large file audited) is cohesive and was left untouched.

## Changes

- Remove `handleTemplateExecution` + `handleSearchRequest` (~180 LOC).
- Remove now-orphan imports: `express` `Request`/`Response`, `radash` `shake`, `shared` `jsonSearchRequest`/`searchParameters`/`PromptArgAccessor`/`SearchResponse`, `loadTemplaterAPI`.
- CHANGELOG `[Unreleased]` → `### Removed`.

Diff is **removal-only** (190 deletions, 0 insertions in `main.ts`). A pre-existing prettier non-conformance elsewhere in the file is deliberately left untouched to keep this single-concern (CI has no prettier gate; can be a separate cleanup).

## Test plan

- [x] `bun run check` green across workspace.
- [x] `bun run build` success.
- [x] `bun test`: 808/808 plugin, 21/21 shared.
- [ ] CI `check-and-test` green.