### PR TITLE
docs(adr-0002): generalize periodic append; decline patch/json-get (#160)

### DIFF
--- a/docs/architecture/ADR-0002-periodic-notes-tools.md
+++ b/docs/architecture/ADR-0002-periodic-notes-tools.md
@@ -17,11 +17,13 @@ Constraints (`CLAUDE.md`): never touch the vault filesystem directly from a hand
 
 ## Decision
 
-### Tool surface — 3 tools, daily-dedicated split
+### Tool surface — 3 tools
 
-- `get_or_create_daily_note(date?) → { path, content, created }` — `date?` is ISO `YYYY-MM-DD`, default today (server-local timezone).
-- `append_to_daily_note(content, date?, underHeading?) → { path, appended }` — auto-creates the daily note if missing; `underHeading?` reuses the existing heading-walker from `patch_vault_file`; default is end-of-file append.
+- `get_or_create_daily_note(date?) → { path, content, created }` — `date?` is ISO `YYYY-MM-DD`, default today (server-local timezone). Daily is ~90% of the read/create workflow, so it keeps a dedicated shortcut.
+- `append_to_periodic_note(period?, content, date?, underHeading?) → { path, appended }` — `period?` defaults to `"daily"`; auto-creates the note if missing; `underHeading?` reuses the existing heading-walker from `patch_vault_file`; default is end-of-file append. **Revised post-#160** (was `append_to_daily_note`): generalised to all periods so weekly/monthly/quarterly/yearly notes get a one-call append too, while the `period="daily"` default keeps the common case ergonomic.
 - `get_or_create_periodic_note(period, date?) → { path, content, created }` — `period: "daily" | "weekly" | "monthly" | "quarterly" | "yearly"`.
+
+The minor asymmetry (two get/create tools — daily-dedicated + generic — but one generalised append) is deliberate: daily get/create is the dominant case and earns its shortcut, while a single `append_to_periodic_note` with a `daily` default covers the common append without a second tool.
 
 ### Date format — ISO 8601 strict, period-specific
 
@@ -66,6 +68,12 @@ We do **not** second-guess the plugin's API — if it returns the wrong note dur
 5. **Read plugin config but reimplement creation in-house** (avoid the dependency on the plugin's API surface). **Rejected**: misses template interpolation (Daily Notes runs the configured template engine, including Templater hooks if present); reimplementing template execution would duplicate logic the plugin already owns and inevitably drift. The plugin's API is the source of truth; we call it.
 
 6. **Add Periodic Notes plugin as a hard dependency** (require it installed). **Rejected**: violates the feature-setup contract — features must degrade gracefully; forcing a community plugin install on users who only want daily-note ergonomics is unacceptable; the fallback (ISO + root + no template) is a coherent vanilla baseline.
+
+7. **A dedicated `patch_periodic_note`** (heading/block/frontmatter replace/prepend/append), surfaced from a prior production implementation in #160. **Rejected**: the cited workflows compose with tools that now exist on `main` — *set a monthly-note frontmatter field* (`status: reviewed`) → `get_or_create_periodic_note` then **`set_note_property`** (single-key atomic, ADR-0001 / Module D); *replace under a weekly `## Highlights`* → `patch_vault_file(targetType:"heading", operation:"replace")`; *block edits* → `patch_vault_file(targetType:"block")`. A `patch_periodic_note` would duplicate `patch_vault_file` + `set_note_property` and add only inline path-resolution. Note the timing: when this ADR was first written the only frontmatter write path was whole-block `patch_vault_file`; Module D's `set_note_property` landed in between and is what makes the compose path clean. The two-call cost (resolve path, then patch) is sub-10 ms in-process. Documented as the prescribed pattern in `get_or_create_periodic_note`'s `.describe()`.
+
+8. **A `format: "json"` option on the periodic get** (parsed frontmatter + tags + stat in one call), also from #160. **Rejected**: `get_vault_file(path, format:"json")` already returns exactly that shape; `get_or_create_periodic_note` → `get_vault_file(format:"json")` composes it without duplicating the structured-read logic.
+
+The underlying asymmetry #160 raises — daily had an append shortcut while the other periods and all structured writes had none — is resolved by (a) generalising append to all periods (see Decision) and (b) routing structured writes through `set_note_property` / `patch_vault_file` on the resolved path, not by adding period-specific patch/read variants.
 
 ## Consequences
 

--- a/docs/design/2026-05-20-frontmatter-properties-and-periodic-notes.md
+++ b/docs/design/2026-05-20-frontmatter-properties-and-periodic-notes.md
@@ -154,24 +154,37 @@ for single-key ops.
 - Returns the existing note if present, otherwise creates it and returns
   the new file. `created: boolean` reflects which path was taken.
 
-#### `append_to_daily_note(content, date?, underHeading?) → { path, appended }`
+#### `append_to_periodic_note(period?, content, date?, underHeading?) → { path, appended }`
 
+> **Revised post-#160**: generalised from `append_to_daily_note` to all
+> periods, so weekly/monthly/quarterly/yearly notes get a one-call append
+> too. `period` defaults to `"daily"` to keep the common case ergonomic.
+
+- `period?: "daily" | "weekly" | "monthly" | "quarterly" | "yearly"` —
+  default `"daily"`.
 - `content: string` — markdown to append.
-- `date?` as above.
+- `date?` — ISO 8601, period-specific (same forms as
+  `get_or_create_periodic_note`).
 - `underHeading?: string` — if provided, appends inside that heading's
   section (reuses the existing `patchActiveFile` heading walker). Default:
   end-of-file append (like `append_to_vault_file`).
-- If the daily note does not exist, it is auto-created first (same path as
-  `get_or_create_daily_note`).
-- **`underHeading` resolution on an auto-created daily**: if the freshly
+- If the target periodic note does not exist, it is auto-created first
+  (same path as `get_or_create_periodic_note`).
+- **`underHeading` resolution on an auto-created note**: if the freshly
   created file (empty or rendered from template) does not contain the
   requested heading, the tool returns `errorCode: "heading_not_found"`.
   The auto-created file is **left in place** (no rollback) — its
   existence is the right end state regardless of whether this single
   append landed. The model can then add the heading (`patch_vault_file`
-  or a subsequent `append_to_daily_note` without `underHeading`) and
+  or a subsequent `append_to_periodic_note` without `underHeading`) and
   retry. Strict-by-default, no silent end-of-file fallback (consistent
   with `patch_vault_file targetType:"heading"`).
+
+Structured writes to periodic notes (set a frontmatter field, replace
+under a heading, edit a block) are **not** a dedicated tool — compose
+`get_or_create_periodic_note` with `set_note_property` (Module D) or
+`patch_vault_file` on the resolved path. Rationale in ADR-0002
+Alternatives #7–#8 (raised in #160).
 
 #### `get_or_create_periodic_note(period, date?) → { path, content, created }`
 
@@ -208,8 +221,8 @@ unit-tested independently.
 | `date` malformed for the chosen period (e.g. `2026-W99`) | Pre-validated by ArkType regex; `errorCode: "invalid_date_for_period"`. |
 | Daily note exists with custom non-ISO format the plugin generates | Detector reads the plugin's format setting and matches. Without the plugin, only ISO is recognised. |
 | Plugin returns the wrong note (race during user setting change) | Out of scope — single source of truth is the plugin's API; we don't second-guess. |
-| `append_to_daily_note` with `underHeading` that doesn't exist (existing daily) | Error from the heading walker (same as `patch_vault_file` today). |
-| `append_to_daily_note` with `underHeading` that doesn't exist (auto-created daily, this call) | `errorCode: "heading_not_found"`; auto-created file is **not** rolled back. Model adds heading + retries. |
+| `append_to_periodic_note` with `underHeading` that doesn't exist (existing note) | Error from the heading walker (same as `patch_vault_file` today). |
+| `append_to_periodic_note` with `underHeading` that doesn't exist (auto-created note, this call) | `errorCode: "heading_not_found"`; auto-created file is **not** rolled back. Model adds heading + retries. |
 | User disables the Daily Notes plugin **after** notes have been created with its custom format | Subsequent calls without the plugin fall back to ISO format → may create a second note that day with the ISO path while the custom-format note is orphaned. Documented; not auto-recovered. Recommend re-enabling the plugin to keep continuity. |
 | Template that calls Templater | Daily Notes API uses the configured template engine; if Templater is configured + enabled, it runs. If template references undefined variables, the plugin handles it. Out of our hands. |
 


### PR DESCRIPTION
## Summary

Revises ADR-0002 (Module C — periodic notes, still `Proposed`) + the spec, per production feedback from @marcoaperez in #160 (before PR #2 / `feat/periodic-notes` starts).

- **Accepted**: `append_to_daily_note` → `append_to_periodic_note(period?='daily', content, date?, underHeading?)` — one-call append for all periods, daily default keeps the common case ergonomic.
- **Declined `patch_periodic_note`** (ADR Alternative #7): cited cases compose via `set_note_property` (Module D, #163) + `patch_vault_file` on the resolved path. Module D's single-key atomic write landed *after* the ADR was first written — that's what makes the compose path clean now.
- **Declined `get(format:json)`** (Alternative #8): `get_vault_file(format:json)` already returns frontmatter+tags+stat.

Module C tool count stays 3. Docs-only PR; no code.

## Test plan

- [ ] Docs-only — CI `check-and-test` should be a no-op pass.
- [ ] ADR-0002 + spec read coherently with the revised append surface.