### PR TITLE
feat: periodic notes tools (Module C, #160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
   `set_note_property` auto-inits a missing block and treats `value:null`
   as delete; `list_property_values` is scale-safe
   (`limit`/`truncated`/`totalDistinct`). Tool count 30 → 34. (ADR-0001)
+- **Periodic notes tools (3).** `get_or_create_daily_note(date?)`,
+  `get_or_create_periodic_note(period, date?)`, and
+  `append_to_periodic_note(period?='daily', content, date?, underHeading?)`
+  give one-call access to daily / weekly / monthly / quarterly / yearly
+  notes without the agent having to know the user's folder layout or
+  date format. When the Daily Notes core plugin or the community
+  Periodic Notes plugin is enabled, creation delegates to the plugin's
+  API (via `obsidian-daily-notes-interface`) so the configured template
+  + `{{date}}` / `{{title}}` interpolations run; otherwise the note is
+  created as an empty file at the ISO path under the vault root.
+  `append_to_periodic_note` reuses the `patch_vault_file` heading walker
+  for `underHeading`, with strict `errorCode: "heading_not_found"` and
+  **no rollback** of an auto-created file (the file's existence is the
+  right end state — add the heading via `patch_vault_file` and retry).
+  Structured writes compose: get the resolved path, then
+  `set_note_property` or `patch_vault_file` — there is no dedicated
+  `patch_periodic_note` (ADR-0002 Alternatives #7–#8, raised in #160).
+  Path / existence / creation centralised in
+  `services/periodicNotesDetector.ts` (`resolvePeriodicNote(app, period,
+  date?) → {path, exists, create()}`) so future periodic-aware tools
+  reuse the same seam. Per-period ISO date validation
+  (`errorCode: "invalid_date_for_period"` on shape or value mismatch).
+  `obsidian-daily-notes-interface` promoted from transitive (via LRA)
+  to direct dependency of `packages/obsidian-plugin`. Tool count
+  34 → 37. (ADR-0002, #160)
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guidance for Claude Code (and similar AI agents) working in this repository.
 
 One shipped component on the 0.4.x line:
 
-1. **Obsidian plugin** — hosts an in-process HTTP MCP server (port 27200 default), writes `claude_desktop_config.json`, exposes all 34 MCP tools and prompts over streamable-HTTP. No separate binary. Semantic search via native Transformers.js (no Smart Connections dependency).
+1. **Obsidian plugin** — hosts an in-process HTTP MCP server (port 27200 default), writes `claude_desktop_config.json`, exposes all 37 MCP tools and prompts over streamable-HTTP. No separate binary. Semantic search via native Transformers.js (no Smart Connections dependency).
 
 Why operations go through Obsidian APIs rather than reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the plugin invoke other Obsidian plugins (Templater, Dataview) through their APIs.
 
@@ -149,7 +149,7 @@ Rules:
 
 Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are exposed.
 
-### Tools (34 total, 0.4.x)
+### Tools (37 total, 0.4.x)
 
 **Vault file management** — `packages/obsidian-plugin/src/features/mcp-tools/tools/`:
 
@@ -187,6 +187,14 @@ Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are expos
 | Tool | Purpose |
 |---|---|
 | `execute_template` | Execute a Templater template with dynamic arguments, optionally creating a new file at `targetPath`. Arguments are validated dynamically from the template's parameter syntax. |
+
+**Periodic notes** — `features/mcp-tools/tools/` + `services/periodicNotesDetector.ts` (Module C, ADR-0002):
+
+| Tool | Purpose |
+|---|---|
+| `get_or_create_daily_note` | Read today's daily note (or one at a passed `YYYY-MM-DD`), creating it if missing. Daily Notes / Periodic Notes plugin API runs the user's template when enabled; ISO+root fallback otherwise. |
+| `get_or_create_periodic_note` | Same shape for `period: "daily"\|"weekly"\|"monthly"\|"quarterly"\|"yearly"`, with period-specific ISO date format. |
+| `append_to_periodic_note` | One-call append (EOF or `underHeading`) on any period, defaulting to daily. Auto-creates the note if missing; reuses the `patch_vault_file` heading walker; strict `heading_not_found` with no rollback. |
 
 **Web fetch** — `features/fetch/index.ts`:
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -16,6 +15,7 @@
         "arktype": "^2.0.0-rc.30",
         "express": "^4.21.2",
         "fs-extra": "^11.2.0",
+        "obsidian-daily-notes-interface": "^0.9.4",
         "obsidian-local-rest-api": "^2.5.4",
         "radash": "^12.1.0",
         "rxjs": "^7.8.1",

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -25,6 +25,7 @@
 		"arktype": "^2.0.0-rc.30",
 		"express": "^4.21.2",
 		"fs-extra": "^11.2.0",
+		"obsidian-daily-notes-interface": "^0.9.4",
 		"obsidian-local-rest-api": "^2.5.4",
 		"radash": "^12.1.0",
 		"rxjs": "^7.8.1",

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -123,6 +123,18 @@ import {
   getOutgoingLinksSchema,
 } from "./tools/getOutgoingLinks";
 import { getBacklinksHandler, getBacklinksSchema } from "./tools/getBacklinks";
+import {
+  getOrCreateDailyNoteHandler,
+  getOrCreateDailyNoteSchema,
+} from "./tools/getOrCreateDailyNote";
+import {
+  getOrCreatePeriodicNoteHandler,
+  getOrCreatePeriodicNoteSchema,
+} from "./tools/getOrCreatePeriodicNote";
+import {
+  appendToPeriodicNoteHandler,
+  appendToPeriodicNoteSchema,
+} from "./tools/appendToPeriodicNote";
 
 export type RegisterToolsContext = {
   app: App;
@@ -270,6 +282,19 @@ export async function registerTools(
       app: ctx.app,
       plugin: ctx.plugin,
     }),
+  );
+
+  // Periodic notes
+  registry.register(getOrCreateDailyNoteSchema, async ({ arguments: args }) =>
+    getOrCreateDailyNoteHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(
+    getOrCreatePeriodicNoteSchema,
+    async ({ arguments: args }) =>
+      getOrCreatePeriodicNoteHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(appendToPeriodicNoteSchema, async ({ arguments: args }) =>
+    appendToPeriodicNoteHandler({ arguments: args, app: ctx.app }),
   );
 
   // Misc

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockFolder,
+  setMockPeriodicNotesPlugin,
+} from "$/test-setup";
+import {
+  DATE_REGEX_BY_PERIOD,
+  isValidPeriodicDate,
+  type PeriodType,
+  resolvePeriodicNote,
+} from "$/features/mcp-tools/services/periodicNotesDetector";
+
+describe("periodicNotesDetector", () => {
+  beforeEach(() => {
+    resetMockVault();
+  });
+
+  describe("DATE_REGEX_BY_PERIOD shape match", () => {
+    test("matches well-shaped ISO strings per period", () => {
+      expect(DATE_REGEX_BY_PERIOD.daily.test("2026-05-22")).toBe(true);
+      expect(DATE_REGEX_BY_PERIOD.weekly.test("2026-W21")).toBe(true);
+      expect(DATE_REGEX_BY_PERIOD.monthly.test("2026-05")).toBe(true);
+      expect(DATE_REGEX_BY_PERIOD.quarterly.test("2026-Q2")).toBe(true);
+      expect(DATE_REGEX_BY_PERIOD.yearly.test("2026")).toBe(true);
+    });
+
+    test("rejects shape mismatches", () => {
+      expect(DATE_REGEX_BY_PERIOD.daily.test("2026/05/22")).toBe(false);
+      expect(DATE_REGEX_BY_PERIOD.weekly.test("2026-21")).toBe(false);
+      expect(DATE_REGEX_BY_PERIOD.quarterly.test("2026-Q5")).toBe(false);
+      expect(DATE_REGEX_BY_PERIOD.yearly.test("26")).toBe(false);
+    });
+  });
+
+  describe("isValidPeriodicDate semantic check", () => {
+    test("accepts real calendar values across all periods", () => {
+      expect(isValidPeriodicDate("daily", "2026-02-28")).toBe(true);
+      expect(isValidPeriodicDate("weekly", "2026-W21")).toBe(true);
+      expect(isValidPeriodicDate("monthly", "2026-12")).toBe(true);
+      expect(isValidPeriodicDate("quarterly", "2026-Q4")).toBe(true);
+      expect(isValidPeriodicDate("yearly", "2026")).toBe(true);
+    });
+
+    test("rejects impossible values that pass the shape regex", () => {
+      // Feb 30 — shape OK, value invalid.
+      expect(isValidPeriodicDate("daily", "2026-02-30")).toBe(false);
+      // Month 13.
+      expect(isValidPeriodicDate("monthly", "2026-13")).toBe(false);
+      // ISO week 54.
+      expect(isValidPeriodicDate("weekly", "2026-W54")).toBe(false);
+    });
+
+    test("rejects shape mismatch too (composes regex check)", () => {
+      expect(isValidPeriodicDate("daily", "garbage")).toBe(false);
+    });
+  });
+
+  describe("resolvePeriodicNote — fallback path (no plugins)", () => {
+    test("daily resolves to root + YYYY-MM-DD path; exists=false when absent", () => {
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "daily", "2026-05-22");
+      expect(r.path).toBe("2026-05-22.md");
+      expect(r.exists).toBe(false);
+    });
+
+    test("daily exists=true when the file is present in the vault", () => {
+      setMockFile("2026-05-22.md", "hello");
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "daily", "2026-05-22");
+      expect(r.exists).toBe(true);
+      expect(r.path).toBe("2026-05-22.md");
+    });
+
+    test("create() falls back to empty file at root", async () => {
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "daily", "2026-05-22");
+      const file = await r.create();
+      // MockTFile exposes .path; assert via the vault read so we go through
+      // the same surface the production tool uses.
+      expect(file).toBeTruthy();
+      const reread = app.vault.getAbstractFileByPath("2026-05-22.md");
+      expect(reread).not.toBeNull();
+    });
+
+    test.each([
+      ["weekly", "2026-W21", "2026-W21.md"],
+      ["monthly", "2026-05", "2026-05.md"],
+      ["quarterly", "2026-Q2", "2026-Q2.md"],
+      ["yearly", "2026", "2026.md"],
+    ] as const)(
+      "%s fallback path is root + ISO + .md",
+      (period, date, expectedPath) => {
+        const app = mockApp();
+        const r = resolvePeriodicNote(app, period as PeriodType, date);
+        expect(r.path).toBe(expectedPath);
+        expect(r.exists).toBe(false);
+      },
+    );
+  });
+
+  describe("resolvePeriodicNote — plugin-on path", () => {
+    test("daily uses plugin folder + format from settings", () => {
+      setMockPeriodicNotesPlugin("daily", {
+        loaded: true,
+        folder: "Daily",
+        format: "YYYY-MM-DD",
+        template: "",
+      });
+      setMockFolder("Daily");
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "daily", "2026-05-22");
+      expect(r.path).toBe("Daily/2026-05-22.md");
+      expect(r.exists).toBe(false);
+    });
+
+    test("custom plugin format (DD-MM-YYYY) is honored", () => {
+      setMockPeriodicNotesPlugin("daily", {
+        loaded: true,
+        folder: "Journal",
+        format: "DD-MM-YYYY",
+      });
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "daily", "2026-05-22");
+      expect(r.path).toBe("Journal/22-05-2026.md");
+    });
+
+    test("create() delegates to plugin API and the file lands at the resolved path", async () => {
+      setMockPeriodicNotesPlugin("daily", {
+        loaded: true,
+        folder: "Daily",
+        format: "YYYY-MM-DD",
+        template: "# Daily\n",
+      });
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "daily", "2026-05-22");
+      expect(r.exists).toBe(false);
+      const file = await r.create();
+      expect(file).toBeTruthy();
+      // The mocked `createDailyNote` writes the template content into the
+      // mock vault at the same path the detector computed — assert both.
+      const at = app.vault.getAbstractFileByPath("Daily/2026-05-22.md");
+      expect(at).not.toBeNull();
+    });
+
+    test("folder setting with leading/trailing slashes is normalized", () => {
+      setMockPeriodicNotesPlugin("monthly", {
+        loaded: true,
+        folder: "/Monthly/",
+        format: "YYYY-MM",
+      });
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "monthly", "2026-05");
+      expect(r.path).toBe("Monthly/2026-05.md");
+    });
+
+    test("folder-vs-file: a folder at the resolved path is NOT counted as exists", () => {
+      // Simulate someone naming a folder identically to where a periodic note
+      // would land. `exists` must be false — otherwise tools would try to
+      // read a folder as a file.
+      setMockFolder("2026-05-22.md");
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "daily", "2026-05-22");
+      expect(r.exists).toBe(false);
+    });
+  });
+
+  describe("resolvePeriodicNote — date default = today", () => {
+    test("daily default produces a YYYY-MM-DD path that matches today's shape", () => {
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "daily");
+      expect(r.path).toMatch(/^\d{4}-\d{2}-\d{2}\.md$/);
+    });
+
+    test("weekly default produces YYYY-Www shape", () => {
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "weekly");
+      expect(r.path).toMatch(/^\d{4}-W\d{2}\.md$/);
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.ts
@@ -1,0 +1,267 @@
+import type { App, TFile } from "obsidian";
+import { moment } from "obsidian";
+import type { Moment } from "moment";
+import * as periodicNotesLib from "obsidian-daily-notes-interface";
+import { ensureParentFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
+
+export type PeriodType =
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "quarterly"
+  | "yearly";
+
+export interface ResolvedPeriodicNote {
+  /** Vault-relative path for the given period + date. */
+  path: string;
+  /** Whether the note already exists. */
+  exists: boolean;
+  /**
+   * Create the note and return it. Delegates to the Daily Notes /
+   * Periodic Notes plugin API when available (so the user's template +
+   * {{date}}/{{title}} interpolations run); falls back to an empty file
+   * at the ISO path under the vault root when neither plugin is on.
+   * Callers check `exists` first and only call `create()` when needed.
+   */
+  create(): Promise<TFile>;
+}
+
+/**
+ * Path / existence / creation seam for a periodic note. The 3 tools compose:
+ *   get_or_create_*       -> resolve -> exists ? read : create()+read
+ *   append_to_periodic_*  -> resolve -> (create() if !exists) -> append
+ *
+ * Plugin detection at call time:
+ *   app.internalPlugins.plugins["daily-notes"]  (core)
+ *   app.plugins.plugins["periodic-notes"]       (community)
+ *
+ * Matrix (ADR-0002): Daily ON -> daily via its API; Periodic ON -> all
+ * periods via its API; both OFF -> vault root + ISO path + empty file.
+ *
+ * `date` is period-specific ISO (YYYY-MM-DD / YYYY-Www / YYYY-MM /
+ * YYYY-QN / YYYY), default = period containing today. Tools validate the
+ * regex before calling; the detector trusts a well-formed value.
+ */
+export function resolvePeriodicNote(
+  app: App,
+  period: PeriodType,
+  date?: string,
+): ResolvedPeriodicNote {
+  const dateStr = date ?? defaultIsoForPeriod(period);
+  const m = parsePeriodicDate(period, dateStr);
+  const pluginOn = pluginLoadedFor(period);
+  const settings = pluginOn ? settingsFor(period) : null;
+  const path = computePath(period, m, settings);
+
+  // Folder-vs-file guard via duck-type per `appendToVaultFile.ts` — and per
+  // Stefano's heads-up on PR #2: `instanceof TFile` is always false under
+  // the test mock (synthetic `TFile` is an empty class), so use null-check
+  // + `children !== undefined` for "is a folder".
+  const existing = app.vault.getAbstractFileByPath(path);
+  const exists =
+    existing != null &&
+    (existing as { children?: unknown }).children === undefined;
+
+  return {
+    path,
+    exists,
+    create: async () => {
+      if (pluginOn) {
+        // Plugin-delegation path: the lib computes its own path from the
+        // same settings + format we read above, applies the configured
+        // template, and runs `{{date}}` / `{{title}}` interpolations.
+        // Returned TFile lives at the same path the tool already exposed.
+        return await createForPeriod(period, m);
+      }
+      // Fallback path: vault root + ISO format + empty file. Parent
+      // folder is the vault root here (empty `settings.folder`), so the
+      // ensure call is a no-op — kept for symmetry in case the fallback
+      // ever evolves to a non-root folder.
+      await ensureParentFolderExists(app, path);
+      return await app.vault.create(path, "");
+    },
+  };
+}
+
+// ── Period <-> lib function dispatch ─────────────────────────────────────
+//
+// The shipped `obsidian-daily-notes-interface@0.9.4` .d.ts only declares
+// the daily surface (`appHasDailyNotesPluginLoaded`, `createDailyNote`,
+// etc.), but the runtime ships the full per-period set
+// (`appHasWeeklyNotesPluginLoaded`, `createWeeklyNote`, …). Cast the
+// import as a typed bag — same pattern CLAUDE.md prescribes for stale /
+// runtime-only Obsidian APIs (`listTags.ts:30` cast for `getTags`).
+
+interface PeriodicNoteSettings {
+  folder?: string;
+  format?: string;
+  template?: string;
+}
+
+interface PeriodicNotesLibRuntime {
+  appHasDailyNotesPluginLoaded: () => boolean;
+  appHasWeeklyNotesPluginLoaded: () => boolean;
+  appHasMonthlyNotesPluginLoaded: () => boolean;
+  appHasQuarterlyNotesPluginLoaded: () => boolean;
+  appHasYearlyNotesPluginLoaded: () => boolean;
+  getDailyNoteSettings: () => PeriodicNoteSettings;
+  getWeeklyNoteSettings: () => PeriodicNoteSettings;
+  getMonthlyNoteSettings: () => PeriodicNoteSettings;
+  getQuarterlyNoteSettings: () => PeriodicNoteSettings;
+  getYearlyNoteSettings: () => PeriodicNoteSettings;
+  createDailyNote: (date: Moment) => Promise<TFile>;
+  createWeeklyNote: (date: Moment) => Promise<TFile>;
+  createMonthlyNote: (date: Moment) => Promise<TFile>;
+  createQuarterlyNote: (date: Moment) => Promise<TFile>;
+  createYearlyNote: (date: Moment) => Promise<TFile>;
+}
+
+const lib = periodicNotesLib as unknown as PeriodicNotesLibRuntime;
+
+function pluginLoadedFor(period: PeriodType): boolean {
+  switch (period) {
+    case "daily":
+      return lib.appHasDailyNotesPluginLoaded();
+    case "weekly":
+      return lib.appHasWeeklyNotesPluginLoaded();
+    case "monthly":
+      return lib.appHasMonthlyNotesPluginLoaded();
+    case "quarterly":
+      return lib.appHasQuarterlyNotesPluginLoaded();
+    case "yearly":
+      return lib.appHasYearlyNotesPluginLoaded();
+  }
+}
+
+function settingsFor(period: PeriodType): PeriodicNoteSettings {
+  switch (period) {
+    case "daily":
+      return lib.getDailyNoteSettings();
+    case "weekly":
+      return lib.getWeeklyNoteSettings();
+    case "monthly":
+      return lib.getMonthlyNoteSettings();
+    case "quarterly":
+      return lib.getQuarterlyNoteSettings();
+    case "yearly":
+      return lib.getYearlyNoteSettings();
+  }
+}
+
+function createForPeriod(period: PeriodType, m: Moment): Promise<TFile> {
+  switch (period) {
+    case "daily":
+      return lib.createDailyNote(m);
+    case "weekly":
+      return lib.createWeeklyNote(m);
+    case "monthly":
+      return lib.createMonthlyNote(m);
+    case "quarterly":
+      return lib.createQuarterlyNote(m);
+    case "yearly":
+      return lib.createYearlyNote(m);
+  }
+}
+
+// ── Date format defaults + parsing ───────────────────────────────────────
+//
+// Period-specific ISO formats. The detector uses these only as the
+// *fallback* format when no plugin is on; if a plugin is enabled, the
+// plugin's configured `format` (e.g. `DD-MM-YYYY` for daily) is used
+// instead, so a vault with a custom format keeps resolving against the
+// same path the Obsidian UI uses.
+
+const DEFAULT_FORMAT_BY_PERIOD: Record<PeriodType, string> = {
+  daily: "YYYY-MM-DD",
+  // ISO 8601 week dates use the `GGGG-[W]WW` moment format (uppercase G/W
+  // for ISO week-year and ISO week-of-year). `YYYY` would round to the
+  // calendar year and break the year-boundary case (e.g. 2026-01-01 is in
+  // ISO week 2025-W53 on some calendars).
+  weekly: "GGGG-[W]WW",
+  monthly: "YYYY-MM",
+  // moment has no native `Q` quarter token in `format()` that matches the
+  // bare digit form we want (`YYYY-Q3`). `[Q]Q` quotes the literal `Q`
+  // then emits the quarter digit (1-4).
+  quarterly: "YYYY-[Q]Q",
+  yearly: "YYYY",
+};
+
+/**
+ * Per-period ISO regex for `date?` arguments. Shape match only — semantic
+ * validity (Feb 30, month 13, ISO-week 99) is rejected by
+ * `isValidPeriodicDate` below via moment's strict-mode parse.
+ */
+export const DATE_REGEX_BY_PERIOD: Record<PeriodType, RegExp> = {
+  daily: /^\d{4}-\d{2}-\d{2}$/,
+  weekly: /^\d{4}-W\d{2}$/,
+  monthly: /^\d{4}-\d{2}$/,
+  quarterly: /^\d{4}-Q[1-4]$/,
+  yearly: /^\d{4}$/,
+};
+
+/**
+ * Semantic validity check on a period-specific date string. Returns false
+ * for shape mismatch OR impossible values (e.g. `2026-02-30` → daily, or
+ * `2026-W99` → weekly). Tools should run `DATE_REGEX_BY_PERIOD` first for
+ * the shape check (clearer error), then this for the value check.
+ */
+export function isValidPeriodicDate(
+  period: PeriodType,
+  dateStr: string,
+): boolean {
+  if (!DATE_REGEX_BY_PERIOD[period].test(dateStr)) return false;
+  return parsePeriodicDate(period, dateStr).isValid();
+}
+
+function parsePeriodicDate(period: PeriodType, dateStr: string): Moment {
+  switch (period) {
+    case "daily":
+      return moment(dateStr, "YYYY-MM-DD", true);
+    case "weekly":
+      return moment(dateStr, "GGGG-[W]WW", true);
+    case "monthly":
+      return moment(dateStr, "YYYY-MM", true);
+    case "quarterly": {
+      // moment cannot parse `YYYY-QN` directly (`Q` is output-only in
+      // older versions); split and seed the moment manually.
+      const m = /^(\d{4})-Q([1-4])$/.exec(dateStr);
+      if (!m) return moment.invalid();
+      return moment()
+        .year(parseInt(m[1], 10))
+        .quarter(parseInt(m[2], 10))
+        .startOf("quarter");
+    }
+    case "yearly":
+      return moment(dateStr, "YYYY", true);
+  }
+}
+
+function defaultIsoForPeriod(period: PeriodType): string {
+  const now = moment();
+  switch (period) {
+    case "daily":
+      return now.format("YYYY-MM-DD");
+    case "weekly":
+      return now.format("GGGG-[W]WW");
+    case "monthly":
+      return now.format("YYYY-MM");
+    case "quarterly":
+      return `${now.format("YYYY")}-Q${now.quarter()}`;
+    case "yearly":
+      return now.format("YYYY");
+  }
+}
+
+function computePath(
+  period: PeriodType,
+  m: Moment,
+  settings: PeriodicNoteSettings | null,
+): string {
+  const format = settings?.format ?? DEFAULT_FORMAT_BY_PERIOD[period];
+  // Trim leading/trailing slashes so a settings folder of `Daily/` or
+  // `/Daily` both resolve to `Daily/<filename>.md` — matches Obsidian UI
+  // tolerance for folder-setting whitespace.
+  const folder = (settings?.folder ?? "").replace(/^\/+|\/+$/g, "").trim();
+  const filename = `${m.format(format)}.md`;
+  return folder ? `${folder}/${filename}` : filename;
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockPeriodicNotesPlugin,
+} from "$/test-setup";
+import { appendToPeriodicNoteHandler } from "./appendToPeriodicNote";
+
+function parse(result: { content: Array<{ type: "text"; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("append_to_periodic_note", () => {
+  beforeEach(() => {
+    resetMockVault();
+  });
+
+  test("EOF append on existing daily note (default period)", async () => {
+    setMockFile("2026-05-22.md", "first line\n");
+    const app = mockApp();
+    const res = await appendToPeriodicNoteHandler({
+      arguments: { content: "- new bullet", date: "2026-05-22" },
+      app,
+    });
+    expect(res.isError).toBeUndefined();
+    const body = parse(res);
+    expect(body.period).toBe("daily");
+    expect(body.path).toBe("2026-05-22.md");
+    expect(body.appended).toBe(true);
+    expect(body.created).toBe(false);
+    const file = app.vault.getAbstractFileByPath("2026-05-22.md");
+    expect(file).not.toBeNull();
+    const text = await app.vault.read(file as import("obsidian").TFile);
+    expect(text).toContain("first line");
+    expect(text).toContain("- new bullet");
+  });
+
+  test("EOF append on auto-created weekly note (fallback, period explicit)", async () => {
+    const app = mockApp();
+    const res = await appendToPeriodicNoteHandler({
+      arguments: {
+        period: "weekly",
+        content: "## Highlights\n- shipped #159\n",
+        date: "2026-W21",
+      },
+      app,
+    });
+    const body = parse(res);
+    expect(body.period).toBe("weekly");
+    expect(body.path).toBe("2026-W21.md");
+    expect(body.created).toBe(true);
+    const file = app.vault.getAbstractFileByPath("2026-W21.md");
+    const text = await app.vault.read(file as import("obsidian").TFile);
+    expect(text).toContain("Highlights");
+  });
+
+  test("monthly append under heading — section walk inserts at section end", async () => {
+    setMockFile(
+      "2026-05.md",
+      "# Monthly\n\n## Highlights\nfirst\n\n## Next month\nplan\n",
+    );
+    const app = mockApp();
+    const res = await appendToPeriodicNoteHandler({
+      arguments: {
+        period: "monthly",
+        content: "second\n",
+        date: "2026-05",
+        underHeading: "Highlights",
+      },
+      app,
+    });
+    expect(res.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("2026-05.md");
+    const text = await app.vault.read(file as import("obsidian").TFile);
+    // Insert lands before the next sibling heading (Next month), after the
+    // existing "first" line — same semantic as patch_vault_file "append".
+    const idxFirst = text.indexOf("first");
+    const idxSecond = text.indexOf("second");
+    const idxNext = text.indexOf("## Next month");
+    expect(idxFirst).toBeGreaterThan(-1);
+    expect(idxSecond).toBeGreaterThan(idxFirst);
+    expect(idxSecond).toBeLessThan(idxNext);
+  });
+
+  test("underHeading not found on auto-created note → heading_not_found, file IS left in place", async () => {
+    const app = mockApp();
+    const res = await appendToPeriodicNoteHandler({
+      arguments: {
+        period: "weekly",
+        content: "would-be",
+        date: "2026-W21",
+        underHeading: "Highlights", // freshly auto-created file is empty — no heading
+      },
+      app,
+    });
+    expect(res.isError).toBe(true);
+    const body = parse(res);
+    expect(body.errorCode).toBe("heading_not_found");
+    expect(body.created).toBe(true);
+    // The file MUST still exist — strict-by-default no-rollback per ADR-0002.
+    expect(app.vault.getAbstractFileByPath("2026-W21.md")).not.toBeNull();
+  });
+
+  test("plugin-on path — append after auto-create via plugin API + template", async () => {
+    setMockPeriodicNotesPlugin("daily", {
+      loaded: true,
+      folder: "Daily",
+      format: "YYYY-MM-DD",
+      template: "## Today\n",
+    });
+    const app = mockApp();
+    const res = await appendToPeriodicNoteHandler({
+      arguments: {
+        period: "daily",
+        content: "- done #159",
+        date: "2026-05-22",
+        underHeading: "Today",
+      },
+      app,
+    });
+    expect(res.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("Daily/2026-05-22.md");
+    const text = await app.vault.read(file as import("obsidian").TFile);
+    expect(text).toContain("## Today");
+    expect(text).toContain("- done #159");
+  });
+
+  test("invalid date → invalid_date_for_period (no file created)", async () => {
+    const app = mockApp();
+    const res = await appendToPeriodicNoteHandler({
+      arguments: { period: "daily", content: "x", date: "bad" },
+      app,
+    });
+    expect(res.isError).toBe(true);
+    const body = parse(res);
+    expect(body.errorCode).toBe("invalid_date_for_period");
+    expect(app.vault.getAbstractFileByPath("bad.md")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
@@ -1,0 +1,202 @@
+import { type } from "arktype";
+import type { App, TFile } from "obsidian";
+import {
+  DATE_REGEX_BY_PERIOD,
+  isValidPeriodicDate,
+  type PeriodType,
+  resolvePeriodicNote,
+} from "$/features/mcp-tools/services/periodicNotesDetector";
+import {
+  findHeadingSectionEnd,
+  normalizeAppendBody,
+  resolveHeadingPath,
+} from "$/features/mcp-tools/services/patchHelpers";
+
+export const appendToPeriodicNoteSchema = type({
+  name: '"append_to_periodic_note"',
+  arguments: {
+    "period?": type('"daily"|"weekly"|"monthly"|"quarterly"|"yearly"').describe(
+      "Period granularity. Defaults to `daily` so the common case is one positional `content` away.",
+    ),
+    content: type("string").describe("Markdown content to append."),
+    "date?": type("string").describe(
+      "Period-specific ISO date. Formats: daily `YYYY-MM-DD`, weekly `YYYY-Www`, monthly `YYYY-MM`, quarterly `YYYY-QN`, yearly `YYYY`. Default: the period instance containing today in the plugin process timezone.",
+    ),
+    "underHeading?": type("string>0").describe(
+      "If provided, appends inside this heading's section (matched by exact leaf name, or by a `Parent::Child` path with `::` as the delimiter). Without it, appends at end-of-file. If the heading is not found, the call fails with `errorCode: \"heading_not_found\"` — and an auto-created note is left in place (the file's existence is the right end state; add the heading via `patch_vault_file` and retry).",
+    ),
+  },
+}).describe(
+  "Appends content to a periodic note (daily by default). Auto-creates the note if it doesn't exist via the same path as `get_or_create_periodic_note` (plugin API when enabled, ISO fallback otherwise). `underHeading` targets a section via the shared heading walker (same fence-aware semantics as `patch_vault_file`); without it, content is appended at EOF.",
+);
+
+export type AppendToPeriodicNoteContext = {
+  arguments: {
+    period?: PeriodType;
+    content: string;
+    date?: string;
+    underHeading?: string;
+  };
+  app: App;
+};
+
+const HEADING_DELIMITER = "::";
+
+export async function appendToPeriodicNoteHandler(
+  ctx: AppendToPeriodicNoteContext,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const {
+    period = "daily",
+    content,
+    date,
+    underHeading,
+  } = ctx.arguments;
+
+  if (date !== undefined) {
+    if (!DATE_REGEX_BY_PERIOD[period].test(date)) {
+      return errorPayload(
+        `Invalid date format for period '${period}' — expected ${describeFormat(period)}.`,
+        "invalid_date_for_period",
+        { period, date },
+      );
+    }
+    if (!isValidPeriodicDate(period, date)) {
+      return errorPayload(
+        "Date is well-shaped but not a real calendar value (e.g. month 13, Feb 30, ISO-week 99).",
+        "invalid_date_for_period",
+        { period, date },
+      );
+    }
+  }
+
+  const resolved = resolvePeriodicNote(ctx.app, period, date);
+  let created = false;
+  let file = ctx.app.vault.getAbstractFileByPath(resolved.path);
+  if (!resolved.exists) {
+    file = await resolved.create();
+    created = true;
+  }
+  if (!file) {
+    return errorPayload(
+      "Internal: periodic note resolved but not retrievable after create.",
+      "internal_error",
+      { period, path: resolved.path },
+    );
+  }
+  const tfile = file as TFile;
+  const normalized = normalizeAppendBody(content, "append");
+
+  if (underHeading !== undefined) {
+    const raw = await ctx.app.vault.read(tfile);
+    const lines = raw.split("\n");
+
+    // Resolve partial leaf name to full hierarchical path (same as
+    // patch_vault_file): so `underHeading: "Highlights"` matches a nested
+    // `## Weekly review > ## Highlights` without the caller knowing the path.
+    let resolvedTarget = underHeading;
+    if (!underHeading.includes(HEADING_DELIMITER)) {
+      const fullPath = resolveHeadingPath(raw, underHeading, HEADING_DELIMITER);
+      if (fullPath) resolvedTarget = fullPath;
+    }
+    const targetParts = resolvedTarget.split(HEADING_DELIMITER);
+    const leafHeading = targetParts[targetParts.length - 1];
+
+    let headingLine = -1;
+    let headingLevel = 1;
+    for (let i = 0; i < lines.length; i++) {
+      const m = lines[i].match(/^(#{1,6})\s+(.+)$/);
+      if (m && m[2].trim() === leafHeading) {
+        headingLine = i;
+        headingLevel = m[1].length;
+        break;
+      }
+    }
+
+    if (headingLine === -1) {
+      // Strict-by-default: do NOT silently fall back to EOF, do NOT
+      // rollback an auto-created file (the file's existence is the
+      // right end state regardless of this single append — see ADR-0002
+      // Negatives + spec). Caller adds the heading and retries.
+      return errorPayload(
+        `Heading not found in periodic note: "${underHeading}".`,
+        "heading_not_found",
+        {
+          period,
+          path: resolved.path,
+          created,
+          underHeading,
+        },
+      );
+    }
+
+    const sectionEnd = findHeadingSectionEnd(lines, headingLine, headingLevel);
+    const newLines = [
+      ...lines.slice(0, sectionEnd),
+      normalized,
+      ...lines.slice(sectionEnd),
+    ];
+    await ctx.app.vault.modify(tfile, newLines.join("\n"));
+  } else {
+    const existing = await ctx.app.vault.read(tfile);
+    await ctx.app.vault.modify(tfile, existing + normalized);
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            period,
+            path: resolved.path,
+            appended: true,
+            created,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+function errorPayload(
+  message: string,
+  errorCode: string,
+  extras: Record<string, unknown>,
+): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          { error: message, errorCode, ...extras },
+          null,
+          2,
+        ),
+      },
+    ],
+    isError: true,
+  };
+}
+
+function describeFormat(period: PeriodType): string {
+  switch (period) {
+    case "daily":
+      return "`YYYY-MM-DD`";
+    case "weekly":
+      return "`YYYY-Www` (ISO week, e.g. `2026-W21`)";
+    case "monthly":
+      return "`YYYY-MM`";
+    case "quarterly":
+      return "`YYYY-QN` (N=1-4)";
+    case "yearly":
+      return "`YYYY`";
+  }
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
@@ -48,12 +48,7 @@ export async function appendToPeriodicNoteHandler(
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
 }> {
-  const {
-    period = "daily",
-    content,
-    date,
-    underHeading,
-  } = ctx.arguments;
+  const { period = "daily", content, date, underHeading } = ctx.arguments;
 
   if (date !== undefined) {
     if (!DATE_REGEX_BY_PERIOD[period].test(date)) {
@@ -175,11 +170,7 @@ function errorPayload(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          { error: message, errorCode, ...extras },
-          null,
-          2,
-        ),
+        text: JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
       },
     ],
     isError: true,

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockPeriodicNotesPlugin,
+} from "$/test-setup";
+import { getOrCreateDailyNoteHandler } from "./getOrCreateDailyNote";
+
+function parse(result: { content: Array<{ type: "text"; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("get_or_create_daily_note", () => {
+  beforeEach(() => {
+    resetMockVault();
+  });
+
+  test("happy path — creates from scratch in fallback mode, returns created=true + empty content", async () => {
+    const app = mockApp();
+    const res = await getOrCreateDailyNoteHandler({
+      arguments: { date: "2026-05-22" },
+      app,
+    });
+    expect(res.isError).toBeUndefined();
+    const body = parse(res);
+    expect(body.path).toBe("2026-05-22.md");
+    expect(body.created).toBe(true);
+    expect(body.content).toBe("");
+    // File must exist in the vault after.
+    expect(app.vault.getAbstractFileByPath("2026-05-22.md")).not.toBeNull();
+  });
+
+  test("happy path — returns existing without re-creating", async () => {
+    setMockFile("2026-05-22.md", "yesterday's notes");
+    const app = mockApp();
+    const res = await getOrCreateDailyNoteHandler({
+      arguments: { date: "2026-05-22" },
+      app,
+    });
+    expect(res.isError).toBeUndefined();
+    const body = parse(res);
+    expect(body.created).toBe(false);
+    expect(body.content).toBe("yesterday's notes");
+  });
+
+  test("plugin-on path — uses plugin folder/format and seeds template content", async () => {
+    setMockPeriodicNotesPlugin("daily", {
+      loaded: true,
+      folder: "Daily",
+      format: "YYYY-MM-DD",
+      template: "## Daily plan\n",
+    });
+    const app = mockApp();
+    const res = await getOrCreateDailyNoteHandler({
+      arguments: { date: "2026-05-22" },
+      app,
+    });
+    const body = parse(res);
+    expect(body.path).toBe("Daily/2026-05-22.md");
+    expect(body.created).toBe(true);
+    expect(body.content).toBe("## Daily plan\n");
+  });
+
+  test("default date — returns today's path even when no `date` is passed", async () => {
+    const app = mockApp();
+    const res = await getOrCreateDailyNoteHandler({ arguments: {}, app });
+    const body = parse(res);
+    expect(body.path).toMatch(/^\d{4}-\d{2}-\d{2}\.md$/);
+    expect(body.created).toBe(true);
+  });
+
+  test("invalid date format → invalid_date_for_period (shape)", async () => {
+    const app = mockApp();
+    const res = await getOrCreateDailyNoteHandler({
+      arguments: { date: "22/05/2026" },
+      app,
+    });
+    expect(res.isError).toBe(true);
+    const body = parse(res);
+    expect(body.errorCode).toBe("invalid_date_for_period");
+    expect(body.period).toBe("daily");
+  });
+
+  test("invalid date value (Feb 30) → invalid_date_for_period (semantic)", async () => {
+    const app = mockApp();
+    const res = await getOrCreateDailyNoteHandler({
+      arguments: { date: "2026-02-30" },
+      app,
+    });
+    expect(res.isError).toBe(true);
+    const body = parse(res);
+    expect(body.errorCode).toBe("invalid_date_for_period");
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.ts
@@ -1,0 +1,126 @@
+import { type } from "arktype";
+import type { App } from "obsidian";
+import {
+  DATE_REGEX_BY_PERIOD,
+  isValidPeriodicDate,
+  resolvePeriodicNote,
+} from "$/features/mcp-tools/services/periodicNotesDetector";
+
+export const getOrCreateDailyNoteSchema = type({
+  name: '"get_or_create_daily_note"',
+  arguments: {
+    "date?": type("string").describe(
+      "ISO date `YYYY-MM-DD`. Default: today in the plugin process timezone (the user's machine TZ in the in-process / desktop deployment, which is the 99% case). For headless or multi-host setups where the MCP server runs on a different host than the Obsidian client, pass an explicit `date` to avoid TZ-driven off-by-one resolution.",
+    ),
+  },
+}).describe(
+  'Reads today\'s daily note (or the one at `date`), creating it if missing. Returns `{path, content, created}`. When the Daily Notes core plugin or the community Periodic Notes plugin is enabled, the note is created via the plugin\'s API so the configured template + `{{date}}`/`{{title}}` interpolations run; otherwise it is created as an empty file at the ISO path under the vault root. For weekly/monthly/quarterly/yearly notes use `get_or_create_periodic_note`.',
+);
+
+export type GetOrCreateDailyNoteContext = {
+  arguments: { date?: string };
+  app: App;
+};
+
+export async function getOrCreateDailyNoteHandler(
+  ctx: GetOrCreateDailyNoteContext,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const { date } = ctx.arguments;
+
+  if (date !== undefined) {
+    if (!DATE_REGEX_BY_PERIOD.daily.test(date)) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                error:
+                  "Invalid date format for period 'daily' — expected `YYYY-MM-DD`.",
+                errorCode: "invalid_date_for_period",
+                period: "daily",
+                date,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+    if (!isValidPeriodicDate("daily", date)) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                error:
+                  "Date is well-shaped but not a real calendar date (e.g. month 13, Feb 30).",
+                errorCode: "invalid_date_for_period",
+                period: "daily",
+                date,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  const resolved = resolvePeriodicNote(ctx.app, "daily", date);
+  let created = false;
+  let file = ctx.app.vault.getAbstractFileByPath(resolved.path);
+  if (!resolved.exists) {
+    file = await resolved.create();
+    created = true;
+  }
+  // Read content from the (now-existing) file. The detector's `create()`
+  // returns a TFile that is also reachable via the vault API; either is
+  // fine — we re-read via `getAbstractFileByPath` so the same path the
+  // tool returns is the path we read, no drift.
+  if (!file) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              error:
+                "Internal: daily note resolved but not retrievable after create.",
+              errorCode: "internal_error",
+              path: resolved.path,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
+  // Null-check + `as TFile` cast per Stefano's heads-up: `instanceof TFile`
+  // is always false under the test mock.
+  const tfile = file as import("obsidian").TFile;
+  const content = await ctx.app.vault.cachedRead(tfile);
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          { path: resolved.path, content, created },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.ts
@@ -14,7 +14,7 @@ export const getOrCreateDailyNoteSchema = type({
     ),
   },
 }).describe(
-  'Reads today\'s daily note (or the one at `date`), creating it if missing. Returns `{path, content, created}`. When the Daily Notes core plugin or the community Periodic Notes plugin is enabled, the note is created via the plugin\'s API so the configured template + `{{date}}`/`{{title}}` interpolations run; otherwise it is created as an empty file at the ISO path under the vault root. For weekly/monthly/quarterly/yearly notes use `get_or_create_periodic_note`.',
+  "Reads today's daily note (or the one at `date`), creating it if missing. Returns `{path, content, created}`. When the Daily Notes core plugin or the community Periodic Notes plugin is enabled, the note is created via the plugin's API so the configured template + `{{date}}`/`{{title}}` interpolations run; otherwise it is created as an empty file at the ISO path under the vault root. For weekly/monthly/quarterly/yearly notes use `get_or_create_periodic_note`.",
 );
 
 export type GetOrCreateDailyNoteContext = {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockPeriodicNotesPlugin,
+} from "$/test-setup";
+import { getOrCreatePeriodicNoteHandler } from "./getOrCreatePeriodicNote";
+
+function parse(result: { content: Array<{ type: "text"; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("get_or_create_periodic_note", () => {
+  beforeEach(() => {
+    resetMockVault();
+  });
+
+  test("weekly fallback — root + YYYY-Www path, created=true", async () => {
+    const app = mockApp();
+    const res = await getOrCreatePeriodicNoteHandler({
+      arguments: { period: "weekly", date: "2026-W21" },
+      app,
+    });
+    const body = parse(res);
+    expect(body.period).toBe("weekly");
+    expect(body.path).toBe("2026-W21.md");
+    expect(body.created).toBe(true);
+  });
+
+  test("monthly fallback — existing file returns created=false + content", async () => {
+    setMockFile("2026-05.md", "## Monthly review\nq2 ok");
+    const app = mockApp();
+    const res = await getOrCreatePeriodicNoteHandler({
+      arguments: { period: "monthly", date: "2026-05" },
+      app,
+    });
+    const body = parse(res);
+    expect(body.created).toBe(false);
+    expect(body.content).toContain("Monthly review");
+  });
+
+  test("quarterly plugin-on — folder + format from settings", async () => {
+    setMockPeriodicNotesPlugin("quarterly", {
+      loaded: true,
+      folder: "Quarterly",
+      format: "YYYY-[Q]Q",
+    });
+    const app = mockApp();
+    const res = await getOrCreatePeriodicNoteHandler({
+      arguments: { period: "quarterly", date: "2026-Q2" },
+      app,
+    });
+    const body = parse(res);
+    expect(body.path).toBe("Quarterly/2026-Q2.md");
+    expect(body.created).toBe(true);
+  });
+
+  test("yearly fallback — root + YYYY.md", async () => {
+    const app = mockApp();
+    const res = await getOrCreatePeriodicNoteHandler({
+      arguments: { period: "yearly", date: "2026" },
+      app,
+    });
+    const body = parse(res);
+    expect(body.path).toBe("2026.md");
+  });
+
+  test("default date — weekly returns today's ISO week shape", async () => {
+    const app = mockApp();
+    const res = await getOrCreatePeriodicNoteHandler({
+      arguments: { period: "weekly" },
+      app,
+    });
+    const body = parse(res);
+    expect(body.path).toMatch(/^\d{4}-W\d{2}\.md$/);
+  });
+
+  test("invalid quarterly value Q5 → invalid_date_for_period (shape)", async () => {
+    const app = mockApp();
+    const res = await getOrCreatePeriodicNoteHandler({
+      arguments: { period: "quarterly", date: "2026-Q5" },
+      app,
+    });
+    expect(res.isError).toBe(true);
+    const body = parse(res);
+    expect(body.errorCode).toBe("invalid_date_for_period");
+    expect(body.period).toBe("quarterly");
+  });
+
+  test("invalid weekly value W99 → invalid_date_for_period (semantic)", async () => {
+    const app = mockApp();
+    const res = await getOrCreatePeriodicNoteHandler({
+      arguments: { period: "weekly", date: "2026-W99" },
+      app,
+    });
+    expect(res.isError).toBe(true);
+    const body = parse(res);
+    expect(body.errorCode).toBe("invalid_date_for_period");
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
@@ -1,0 +1,139 @@
+import { type } from "arktype";
+import type { App, TFile } from "obsidian";
+import {
+  DATE_REGEX_BY_PERIOD,
+  isValidPeriodicDate,
+  type PeriodType,
+  resolvePeriodicNote,
+} from "$/features/mcp-tools/services/periodicNotesDetector";
+
+export const getOrCreatePeriodicNoteSchema = type({
+  name: '"get_or_create_periodic_note"',
+  arguments: {
+    period: type('"daily"|"weekly"|"monthly"|"quarterly"|"yearly"').describe(
+      "Period granularity. `daily` is also reachable via `get_or_create_daily_note` (zero-friction shortcut for the common case).",
+    ),
+    "date?": type("string").describe(
+      "Period-specific ISO date. Formats: daily `YYYY-MM-DD`, weekly `YYYY-Www` (ISO week), monthly `YYYY-MM`, quarterly `YYYY-QN` (N=1-4), yearly `YYYY`. Default: the period instance containing today in the plugin process timezone (the user's machine TZ in the in-process / desktop deployment).",
+    ),
+  },
+}).describe(
+  'Reads the periodic note for the given `period` (and optional `date`), creating it if missing. Returns `{path, content, created}`. When the Daily Notes core plugin or the community Periodic Notes plugin covers the period, the note is created via the plugin\'s API so the configured template + interpolations run; otherwise it is created as an empty file at the ISO path under the vault root. **Structured writes to the resolved note** (set a frontmatter field, replace under a heading, edit a block) compose: get the path, then `set_note_property` (Module D) or `patch_vault_file` — there is no dedicated `patch_periodic_note` (ADR-0002 Alt #7).',
+);
+
+export type GetOrCreatePeriodicNoteContext = {
+  arguments: { period: PeriodType; date?: string };
+  app: App;
+};
+
+export async function getOrCreatePeriodicNoteHandler(
+  ctx: GetOrCreatePeriodicNoteContext,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const { period, date } = ctx.arguments;
+
+  if (date !== undefined) {
+    if (!DATE_REGEX_BY_PERIOD[period].test(date)) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                error: `Invalid date format for period '${period}' — expected ${describeFormat(period)}.`,
+                errorCode: "invalid_date_for_period",
+                period,
+                date,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+    if (!isValidPeriodicDate(period, date)) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                error:
+                  "Date is well-shaped but not a real calendar value (e.g. month 13, Feb 30, ISO-week 99).",
+                errorCode: "invalid_date_for_period",
+                period,
+                date,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  const resolved = resolvePeriodicNote(ctx.app, period, date);
+  let created = false;
+  let file = ctx.app.vault.getAbstractFileByPath(resolved.path);
+  if (!resolved.exists) {
+    file = await resolved.create();
+    created = true;
+  }
+  if (!file) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              error:
+                "Internal: periodic note resolved but not retrievable after create.",
+              errorCode: "internal_error",
+              period,
+              path: resolved.path,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
+  const tfile = file as TFile;
+  const content = await ctx.app.vault.cachedRead(tfile);
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          { period, path: resolved.path, content, created },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+function describeFormat(period: PeriodType): string {
+  switch (period) {
+    case "daily":
+      return "`YYYY-MM-DD`";
+    case "weekly":
+      return "`YYYY-Www` (ISO week, e.g. `2026-W21`)";
+    case "monthly":
+      return "`YYYY-MM`";
+    case "quarterly":
+      return "`YYYY-QN` (N=1-4)";
+    case "yearly":
+      return "`YYYY`";
+  }
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
@@ -18,7 +18,7 @@ export const getOrCreatePeriodicNoteSchema = type({
     ),
   },
 }).describe(
-  'Reads the periodic note for the given `period` (and optional `date`), creating it if missing. Returns `{path, content, created}`. When the Daily Notes core plugin or the community Periodic Notes plugin covers the period, the note is created via the plugin\'s API so the configured template + interpolations run; otherwise it is created as an empty file at the ISO path under the vault root. **Structured writes to the resolved note** (set a frontmatter field, replace under a heading, edit a block) compose: get the path, then `set_note_property` (Module D) or `patch_vault_file` — there is no dedicated `patch_periodic_note` (ADR-0002 Alt #7).',
+  "Reads the periodic note for the given `period` (and optional `date`), creating it if missing. Returns `{path, content, created}`. When the Daily Notes core plugin or the community Periodic Notes plugin covers the period, the note is created via the plugin's API so the configured template + interpolations run; otherwise it is created as an empty file at the ISO path under the vault root. **Structured writes to the resolved note** (set a frontmatter field, replace under a heading, edit a block) compose: get the path, then `set_note_property` (Module D) or `patch_vault_file` — there is no dedicated `patch_periodic_note` (ADR-0002 Alt #7).",
 );
 
 export type GetOrCreatePeriodicNoteContext = {

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -107,6 +107,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         .sort();
       expect(names).toEqual([
         "append_to_active_file",
+        "append_to_periodic_note",
         "append_to_vault_file",
         "create_vault_directory",
         "create_vault_file",
@@ -121,6 +122,8 @@ describe("end-to-end: HTTP → McpServer", () => {
         "get_backlinks",
         "get_files_by_tag",
         "get_note_property",
+        "get_or_create_daily_note",
+        "get_or_create_periodic_note",
         "get_outgoing_links",
         "get_recent_files",
         "get_server_info",
@@ -141,7 +144,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "show_file_in_obsidian",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(34);
+      expect(names).toHaveLength(37);
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -280,14 +280,16 @@ export interface MockPeriodicNoteSettings {
   template?: string;
 }
 
-const _mockPeriodicNotesState: Record<MockPeriodType, MockPeriodicNoteSettings> =
-  {
-    daily: { loaded: false },
-    weekly: { loaded: false },
-    monthly: { loaded: false },
-    quarterly: { loaded: false },
-    yearly: { loaded: false },
-  };
+const _mockPeriodicNotesState: Record<
+  MockPeriodType,
+  MockPeriodicNoteSettings
+> = {
+  daily: { loaded: false },
+  weekly: { loaded: false },
+  monthly: { loaded: false },
+  quarterly: { loaded: false },
+  yearly: { loaded: false },
+};
 
 /**
  * Seed plugin state for a single period. Pass `{ loaded: true, folder,
@@ -355,12 +357,14 @@ void mock.module("obsidian-daily-notes-interface", () => ({
   getQuarterlyNoteSettings: () => ({ ..._mockPeriodicNotesState.quarterly }),
   getYearlyNoteSettings: () => ({ ..._mockPeriodicNotesState.yearly }),
   createDailyNote: async (date: unknown) => _createPeriodicNote("daily", date),
-  createWeeklyNote: async (date: unknown) => _createPeriodicNote("weekly", date),
+  createWeeklyNote: async (date: unknown) =>
+    _createPeriodicNote("weekly", date),
   createMonthlyNote: async (date: unknown) =>
     _createPeriodicNote("monthly", date),
   createQuarterlyNote: async (date: unknown) =>
     _createPeriodicNote("quarterly", date),
-  createYearlyNote: async (date: unknown) => _createPeriodicNote("yearly", date),
+  createYearlyNote: async (date: unknown) =>
+    _createPeriodicNote("yearly", date),
 }));
 
 // === Phase 2 mock vault state for tool tests ===

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -20,6 +20,7 @@
  */
 
 import { mock } from "bun:test";
+import moment from "moment";
 
 // Obsidian injects `activeWindow` as a global (points to the focused Window
 // in popout-window scenarios). Tests run outside Obsidian, so we stub it to
@@ -176,6 +177,13 @@ void mock.module("obsidian", () => {
     Modal,
     Platform,
     getAllTags,
+    // Obsidian re-exports the `moment` library at runtime; pin to the real
+    // npm package in tests so code that does `import { moment } from "obsidian"`
+    // (e.g. the periodic-notes detector) resolves without crashing at module
+    // load. Production paths that actually invoke moment (plugin-delegation
+    // branches) are exercised in tests by seeding the periodicNotes mock
+    // state below.
+    moment,
     requestUrl: async (req: { url: string } | string) => {
       const url = typeof req === "string" ? req : req.url;
       const r = _mockState.requestUrlResponses.get(url);
@@ -238,6 +246,121 @@ void mock.module("svelte", () => ({
   unmount: (ref: unknown) => {
     svelteMockCalls.unmount.push(ref);
   },
+}));
+
+// === Mock for obsidian-daily-notes-interface (Module C / PR #2) ============
+//
+// The real library reads `window.app` + the Daily Notes / Periodic Notes
+// plugin settings to decide where to put periodic notes and how to render
+// the template. Tests don't have those plugins — so we mock the whole
+// module and let each test seed the plugin-on flags and settings per
+// period via `setMockPeriodicNotesPlugin(...)`. Defaults: all 5 periods
+// OFF (so the detector falls back to vault root + ISO format + empty file,
+// which is the expected behaviour when neither plugin is installed).
+//
+// The `createXNote(date)` stubs mirror the real library's effect: they
+// compute the path from the mocked settings using the same `date.format()`
+// the real lib uses, then commit the file via the existing mock vault
+// (`_mockState.files`) so the tool under test can observe it. This keeps
+// the seam at the lib boundary — the detector still does its own path
+// computation for `exists`, and the same path is reproduced by the mock
+// create stub, so the tool sees a coherent "resolved + created" state.
+
+export type MockPeriodType =
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "quarterly"
+  | "yearly";
+
+export interface MockPeriodicNoteSettings {
+  loaded: boolean;
+  folder?: string;
+  format?: string;
+  template?: string;
+}
+
+const _mockPeriodicNotesState: Record<MockPeriodType, MockPeriodicNoteSettings> =
+  {
+    daily: { loaded: false },
+    weekly: { loaded: false },
+    monthly: { loaded: false },
+    quarterly: { loaded: false },
+    yearly: { loaded: false },
+  };
+
+/**
+ * Seed plugin state for a single period. Pass `{ loaded: true, folder,
+ * format, template? }` to simulate Daily Notes (or the daily slot of
+ * Periodic Notes) being enabled with those settings. Use the default
+ * "all off" state for fallback-path tests.
+ */
+export function setMockPeriodicNotesPlugin(
+  period: MockPeriodType,
+  settings: MockPeriodicNoteSettings,
+): void {
+  _mockPeriodicNotesState[period] = { ...settings };
+}
+
+export function resetMockPeriodicNotes(): void {
+  for (const k of Object.keys(_mockPeriodicNotesState) as MockPeriodType[]) {
+    _mockPeriodicNotesState[k] = { loaded: false };
+  }
+}
+
+function _defaultFormat(period: MockPeriodType): string {
+  switch (period) {
+    case "daily":
+      return "YYYY-MM-DD";
+    case "weekly":
+      return "gggg-[W]ww";
+    case "monthly":
+      return "YYYY-MM";
+    case "quarterly":
+      return "YYYY-[Q]Q";
+    case "yearly":
+      return "YYYY";
+  }
+}
+
+function _createPeriodicNote(period: MockPeriodType, date: unknown): unknown {
+  const s = _mockPeriodicNotesState[period];
+  const fmt = s.format ?? _defaultFormat(period);
+  // `date` is a Moment instance; use real `.format()` via duck-type.
+  const formatted = (date as { format: (fmt: string) => string }).format(fmt);
+  const filename = `${formatted}.md`;
+  const folder = s.folder ?? "";
+  const path = folder ? `${folder}/${filename}` : filename;
+  if (folder && !_mockState.folders.has(folder)) {
+    _mockState.folders.add(folder);
+  }
+  _mockState.files.set(path, s.template ?? "");
+  return fileFromPath(path);
+}
+
+void mock.module("obsidian-daily-notes-interface", () => ({
+  appHasDailyNotesPluginLoaded: (): boolean =>
+    _mockPeriodicNotesState.daily.loaded,
+  appHasWeeklyNotesPluginLoaded: (): boolean =>
+    _mockPeriodicNotesState.weekly.loaded,
+  appHasMonthlyNotesPluginLoaded: (): boolean =>
+    _mockPeriodicNotesState.monthly.loaded,
+  appHasQuarterlyNotesPluginLoaded: (): boolean =>
+    _mockPeriodicNotesState.quarterly.loaded,
+  appHasYearlyNotesPluginLoaded: (): boolean =>
+    _mockPeriodicNotesState.yearly.loaded,
+  getDailyNoteSettings: () => ({ ..._mockPeriodicNotesState.daily }),
+  getWeeklyNoteSettings: () => ({ ..._mockPeriodicNotesState.weekly }),
+  getMonthlyNoteSettings: () => ({ ..._mockPeriodicNotesState.monthly }),
+  getQuarterlyNoteSettings: () => ({ ..._mockPeriodicNotesState.quarterly }),
+  getYearlyNoteSettings: () => ({ ..._mockPeriodicNotesState.yearly }),
+  createDailyNote: async (date: unknown) => _createPeriodicNote("daily", date),
+  createWeeklyNote: async (date: unknown) => _createPeriodicNote("weekly", date),
+  createMonthlyNote: async (date: unknown) =>
+    _createPeriodicNote("monthly", date),
+  createQuarterlyNote: async (date: unknown) =>
+    _createPeriodicNote("quarterly", date),
+  createYearlyNote: async (date: unknown) => _createPeriodicNote("yearly", date),
 }));
 
 // === Phase 2 mock vault state for tool tests ===
@@ -369,6 +492,7 @@ export function resetMockVault(): void {
   _mockState.deletedPaths = [];
   _mockState.modifyFailPaths.clear();
   _mockState.readMutations.clear();
+  resetMockPeriodicNotes();
 }
 
 /** Make `vault.modify(file)` reject for `path` (rename_heading #143 M2). */


### PR DESCRIPTION
## Summary

Module C — three new MCP tools for daily / weekly / monthly / quarterly / yearly notes, implementing the (revised) ADR-0002 from #164 after the #160 feedback round:

- **`get_or_create_daily_note(date?)`** → `{path, content, created}`
- **`get_or_create_periodic_note(period, date?)`** → `{path, content, created}`
- **`append_to_periodic_note(period?='daily', content, date?, underHeading?)`** → `{path, appended, created}`

All three compose on a single seam — `services/periodicNotesDetector.ts` (skeleton seeded by @istefox in [#160](https://github.com/istefox/obsidian-mcp-connector/issues/160#issuecomment-4521…)) exposing:

```ts
resolvePeriodicNote(app, period, date?) → { path, exists, create(): Promise<TFile> }
```

`create()` delegates to the Daily Notes / Periodic Notes plugin API via `obsidian-daily-notes-interface` when enabled (so the user's template + `{{date}}` / `{{title}}` interpolations run); falls back to vault root + ISO format + empty file when neither plugin is on. `underHeading` reuses the existing `patchHelpers` heading walker; strict `errorCode: "heading_not_found"` with **no rollback** of an auto-created file per ADR. Structured writes to periodic notes compose `get_or_create_periodic_note` + `set_note_property` / `patch_vault_file` (no dedicated `patch_periodic_note` — ADR-0002 Alt #7-#8).

**Tool count 34 → 37** (regression-guard `toHaveLength(37)` + alpha-sorted names + CLAUDE.md updated).

### Dependency

`obsidian-daily-notes-interface ^0.9.4` promoted from transitive (it was already pulled in via `obsidian-local-rest-api`) to a direct dependency of `packages/obsidian-plugin`. Mocked in `test-setup.ts` with per-period state setters (`setMockPeriodicNotesPlugin(period, settings)`). `moment` added to the obsidian mock (re-exports the real npm package — already in the lockfile transitively) so detector code paths that go through `moment.format(...)` resolve under test.

### Decisions applied during implementation

- **Per-period ISO validation**: shape via `DATE_REGEX_BY_PERIOD`, value via moment strict mode (`isValidPeriodicDate`). Both checks surface `errorCode: \"invalid_date_for_period\"` distinctly.
- **Weekly default format**: `GGGG-[W]WW` (ISO 8601 week-year), not `YYYY-Www` — so the year-boundary case (`2026-01-01` lives in ISO week `2025-W53`) doesn't slip.
- **Folder normalization**: `/Daily/` ≡ `Daily` ≡ `  Daily  ` — all resolve to `Daily/<file>.md`.
- **Heading walker reuse**: full reuse of `resolveHeadingPath` + `findHeadingSectionEnd` from `patchHelpers` (fence-aware section walker), same `::` delimiter as `patch_vault_file`. No `createIfMissing` / `allowRootHeadings` exposed — strict by default per ADR.
- **Gotcha @istefox flagged on PR #2**: null-check + `as TFile` cast everywhere (not `instanceof TFile`); folder-vs-file via duck-type `children !== undefined`. Applied in detector + all three tools.
- **Stale `.d.ts` of the dep**: ships only daily exports though the runtime has the full 5-period surface. Cast pattern `lib as unknown as PeriodicNotesLibRuntime` documented inline — same shape as the `listTags.ts:30` cast for `getTags`.

## Test plan

- [x] `bun run check` — workspace typecheck clean (shared + test-server + obsidian-plugin)
- [x] `bun run build` — typecheck + bundle ok
- [x] `bun install --frozen-lockfile` — 0 changes (lockfile commit-discipline applied)
- [x] Detector unit tests: **19/19 pass** (shape regex, semantic validity, fallback path, plugin-on path, custom format, folder normalization, folder-vs-file guard, default-today)
- [x] Tool unit tests: **19/19 pass** (6 daily + 7 periodic + 6 append)
  - Happy paths (fallback + plugin-on for each tool)
  - EOF append on existing + auto-created
  - `underHeading` section walk on monthly retro fixture
  - `underHeading` not found on auto-created → `heading_not_found` + file left in place
  - Invalid date format / value per period → `invalid_date_for_period`
- [x] Regression-guard `mcpServer.test.ts`: tools/list returns 37 names alpha-sorted
- [x] Full sweep (`find ! -name port.test.ts ! -name httpServer.test.ts`): **866/866 pass, 1962 expect, 71 files**
- [ ] Manual smoke through the TEST vault (post-link, ad-hoc)
- [ ] BRAT pre-release soak round (folotp + marcoaperez per spec)

## Notes for review

- Fixtures @istefox offered (Daily ON custom folder/format; Periodic ON weekly/monthly) are **not** in this PR — happy to drop them in as a follow-up commit on this branch when they're ready. The mock harness already covers both shapes via `setMockPeriodicNotesPlugin`.
- ADR-0002 \"Alternatives #7-#8\" framing kept verbatim in `get_or_create_periodic_note`'s `.describe()` so agents see the compose path (`set_note_property` / `patch_vault_file` on the resolved path) instead of asking for a `patch_periodic_note` that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)