### PR TITLE
fix(test): align mock weekly format to ISO; extract describeFormat (#165 follow-up)

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.test.ts
@@ -165,6 +165,24 @@ describe("periodicNotesDetector", () => {
       const r = resolvePeriodicNote(app, "daily", "2026-05-22");
       expect(r.exists).toBe(false);
     });
+
+    test("weekly default format matches the detector at an ISO year boundary", async () => {
+      // `2026-W53` is a real ISO week (its Monday is 2026-12-28), but the
+      // *locale* week-year of that date is 2027-W01. If the mock's default
+      // weekly format were `gggg-[W]ww` (locale) while the detector uses
+      // `GGGG-[W]WW` (ISO), create() would land the file at `2027-W01.md`
+      // while the detector resolves `2026-W53.md` — a silent path mismatch.
+      // Both must use ISO. (Regression guard for the mock format.)
+      setMockPeriodicNotesPlugin("weekly", { loaded: true, folder: "Weekly" });
+      const app = mockApp();
+      const r = resolvePeriodicNote(app, "weekly", "2026-W53");
+      expect(r.path).toBe("Weekly/2026-W53.md");
+      expect(r.exists).toBe(false);
+      await r.create();
+      expect(
+        app.vault.getAbstractFileByPath("Weekly/2026-W53.md"),
+      ).not.toBeNull();
+    });
   });
 
   describe("resolvePeriodicNote — date default = today", () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.ts
@@ -265,3 +265,23 @@ function computePath(
   const filename = `${m.format(format)}.md`;
   return folder ? `${folder}/${filename}` : filename;
 }
+
+/**
+ * Human-readable expected date format for a period, used in the
+ * `invalid_date_for_period` error message. Shared by the periodic-note
+ * tools so the wording stays in one place.
+ */
+export function describeFormat(period: PeriodType): string {
+  switch (period) {
+    case "daily":
+      return "`YYYY-MM-DD`";
+    case "weekly":
+      return "`YYYY-Www` (ISO week, e.g. `2026-W21`)";
+    case "monthly":
+      return "`YYYY-MM`";
+    case "quarterly":
+      return "`YYYY-QN` (N=1-4)";
+    case "yearly":
+      return "`YYYY`";
+  }
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
@@ -2,6 +2,7 @@ import { type } from "arktype";
 import type { App, TFile } from "obsidian";
 import {
   DATE_REGEX_BY_PERIOD,
+  describeFormat,
   isValidPeriodicDate,
   type PeriodType,
   resolvePeriodicNote,
@@ -175,19 +176,4 @@ function errorPayload(
     ],
     isError: true,
   };
-}
-
-function describeFormat(period: PeriodType): string {
-  switch (period) {
-    case "daily":
-      return "`YYYY-MM-DD`";
-    case "weekly":
-      return "`YYYY-Www` (ISO week, e.g. `2026-W21`)";
-    case "monthly":
-      return "`YYYY-MM`";
-    case "quarterly":
-      return "`YYYY-QN` (N=1-4)";
-    case "yearly":
-      return "`YYYY`";
-  }
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
@@ -2,6 +2,7 @@ import { type } from "arktype";
 import type { App, TFile } from "obsidian";
 import {
   DATE_REGEX_BY_PERIOD,
+  describeFormat,
   isValidPeriodicDate,
   type PeriodType,
   resolvePeriodicNote,
@@ -121,19 +122,4 @@ export async function getOrCreatePeriodicNoteHandler(
       },
     ],
   };
-}
-
-function describeFormat(period: PeriodType): string {
-  switch (period) {
-    case "daily":
-      return "`YYYY-MM-DD`";
-    case "weekly":
-      return "`YYYY-Www` (ISO week, e.g. `2026-W21`)";
-    case "monthly":
-      return "`YYYY-MM`";
-    case "quarterly":
-      return "`YYYY-QN` (N=1-4)";
-    case "yearly":
-      return "`YYYY`";
-  }
 }

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -315,7 +315,11 @@ function _defaultFormat(period: MockPeriodType): string {
     case "daily":
       return "YYYY-MM-DD";
     case "weekly":
-      return "gggg-[W]ww";
+      // ISO 8601 week-year (GGGG/WW), matching the detector. The locale
+      // form `gggg-[W]ww` diverges at year boundaries (e.g. 2026-12-28 →
+      // ISO 2026-W53 vs locale 2027-W01); keep the mock aligned so the
+      // plugin-on weekly path is exercised against the real path shape.
+      return "GGGG-[W]WW";
     case "monthly":
       return "YYYY-MM";
     case "quarterly":


### PR DESCRIPTION
## Summary

Follow-up to the #165 (Module C) review — the one MAJOR finding was test-only, so rather than bounce the PR back to @marcoaperez I folded it into this fix-forward on `main`.

- **`test-setup.ts` mock weekly format**: was `gggg-[W]ww` (locale week-year) while the detector computes `GGGG-[W]WW` (ISO). They agree except at a year boundary (`2026-W53`, whose Monday `2026-12-28` has locale week-year `2027-W01`), so the plugin-on weekly path could resolve/create at divergent paths. Mock now uses ISO, matching the detector. The shipped detector was already correct — this is mock hygiene.
- **Regression test**: weekly plugin-on path pinned to the `2026-W53` boundary so the divergence can't go dormant again.
- **`describeFormat()` extracted**: was duplicated verbatim in `getOrCreatePeriodicNote` + `appendToPeriodicNote`; now lives in `periodicNotesDetector` and is exported.

## Test plan

- [x] `bun run check` green; `bun run build` success; `bun run format:check` clean.
- [x] 877 pass (3 known local-only `bindWithFallback` port false-fails, CI-gated).
- [ ] CI `check-and-test` green.