### PR TITLE
ci(release): mark pre-release tags as prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,13 @@ jobs:
         with:
           generate_release_notes: true
           draft: false
-          prerelease: false
+          # Pre-release tags carry a SemVer suffix with a hyphen
+          # (`0.7.0-beta.1`, `-rc.1`, `-alpha.2`). Mark those prerelease
+          # so GitHub does NOT move `/releases/latest` to them — otherwise
+          # the community store + BRAT-default users would pull an
+          # unfinished beta as "latest". Stable tags (`0.6.0`) have no
+          # hyphen, so prerelease resolves to false.
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

`release.yml` hardcoded `prerelease: false`. Any future `-beta`/`-rc` tag would be published as a **full release**, moving `/releases/latest` to it → community-store + BRAT-default users would pull an unfinished pre-release as "latest". That's the failure mode the soak process exists to prevent.

Fix: `prerelease: ${{ contains(github.ref_name, '-') }}` — a SemVer pre-release suffix (hyphen, e.g. `0.7.0-beta.1`) → `prerelease: true`; a stable tag (`0.6.0`) has no hyphen → `false`.

Surfaced while planning the (abandoned) Module D beta soak; fixing now while at a clean point so the next pre-release is safe.

## Notes
- **No effect on stable releases** — `0.6.0` just shipped correctly under the old line. This only changes behaviour for the next pre-release tag.
- `github.ref_name` here is always a tag (the job is gated by `if: github.ref_type == 'tag'`), and tag names are constrained by the `0.*` tags-protection ruleset — not arbitrary external input, so the expression is injection-safe (it's an action input, not a `run:` shell interpolation).

## Test plan
- [x] `yaml.safe_load` parses clean.
- [ ] CI `check-and-test` green (workflow change — no code impact).
- [ ] Real validation deferred to the next `-beta`/`-rc` tag (can't dry-run a release publish).