### PR TITLE
refactor(patch): share heading walker; characterize embed/degenerate link rewriting

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/headingRename.test.ts
@@ -377,6 +377,92 @@ describe("headingRename — rewriteBacklinker fenced-code guard (#143 C2)", () =
   });
 });
 
+describe("headingRename — rewriteBacklinker embeds & degenerate links", () => {
+  // Embeds `![[…]]` are wikilinks with a leading `!`. The wikilink regex
+  // matches the `[[…]]` span and leaves the `!` untouched, so an embed of a
+  // renamed heading must follow the rename exactly like a plain wikilink.
+  test("rewrites an embed `![[note#heading]]`, preserving the leading `!`", () => {
+    const r = rewriteBacklinker(
+      "Transclude: ![[source#Old]] below.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Transclude: ![[source#New]] below.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("rewrites a same-file section embed `![[#heading]]`", () => {
+    const r = rewriteBacklinker(
+      "Inline: ![[#Old]] here.",
+      "Old",
+      "New",
+      "source.md",
+      "source.md", // empty notePart resolves to the backlinker (self) itself
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Inline: ![[#New]] here.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("rewrites an embed targeting a subheading-path leaf", () => {
+    const r = rewriteBacklinker(
+      "Transclude: ![[source#Parent > Old]] below.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Transclude: ![[source#Parent > New]] below.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("does NOT rewrite an embed pointing at a different note", () => {
+    const r = rewriteBacklinker(
+      "Transclude: ![[other#Old]] below.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Transclude: ![[other#Old]] below.");
+    expect(r.rewriteCount).toBe(0);
+  });
+
+  // Degenerate alias shapes: per the first-`|` tokenizer (#158), everything
+  // after the first `|` is the alias and is preserved verbatim — including a
+  // leading `|` (double-pipe) or an empty alias (trailing `|`).
+  test("degenerate double-pipe `[[note#A||C]]` — heading=`A`, alias `|C` preserved", () => {
+    const r = rewriteBacklinker(
+      "Look at [[source#A||C]] here.",
+      "A",
+      "Z",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Look at [[source#Z||C]] here.");
+    expect(r.rewriteCount).toBe(1);
+  });
+
+  test("degenerate empty alias `[[note#Old|]]` — trailing pipe preserved", () => {
+    const r = rewriteBacklinker(
+      "Look at [[source#Old|]] here.",
+      "Old",
+      "New",
+      "source.md",
+      "back.md",
+      resolveBasic,
+    );
+    expect(r.newText).toBe("Look at [[source#New|]] here.");
+    expect(r.rewriteCount).toBe(1);
+  });
+});
+
 describe("headingRename — rewriteSourceHeadingLine level fallback (#143 H2)", () => {
   test("H2: regex-miss fallback uses the known level, not hardcoded H1", () => {
     // `##Old` (no space after the hashes) does not match the heading-line

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
@@ -59,6 +59,28 @@ export function resolveHeadingPath(
 }
 
 /**
+ * Find the first line that is a heading (`#`–`######` followed by a space and
+ * text) whose trimmed text equals `leafHeading`. Returns the 0-based line
+ * index and the heading level (count of leading `#`), or `null` if absent.
+ *
+ * Shared by `patch_vault_file` and `append_to_periodic_note` so both locate a
+ * leaf heading identically. The level is the `#{1,6}` capture length, which
+ * for any line that matches equals a separate `/^(#+)/` count.
+ */
+export function findLeafHeadingLine(
+  lines: string[],
+  leafHeading: string,
+): { line: number; level: number } | null {
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(#{1,6})\s+(.+)$/);
+    if (m && m[2].trim() === leafHeading) {
+      return { line: i, level: m[1].length };
+    }
+  }
+  return null;
+}
+
+/**
  * Ensure appended content ends with whitespace so the next section in the
  * document remains visually separated. markdown-patch does not insert any
  * separation on its own, so `**bold**` appended under a heading would
@@ -659,16 +681,9 @@ export async function applyPatch(
     // Find the heading line by comparing the full path.
     const targetParts = resolvedTarget.split(targetDelimiter);
     const leafHeading = targetParts[targetParts.length - 1];
-    let headingLine = -1;
-    for (let i = 0; i < lines.length; i++) {
-      const m = lines[i].match(/^(#{1,6})\s+(.+)$/);
-      if (m && m[2].trim() === leafHeading) {
-        headingLine = i;
-        break;
-      }
-    }
+    const found = findLeafHeadingLine(lines, leafHeading);
 
-    if (headingLine === -1) {
+    if (found === null) {
       // Heading not found — respect createTargetIfMissing.
       if (!createIfMissing) {
         return {
@@ -684,9 +699,10 @@ export async function applyPatch(
       return { content: [{ type: "text", text: "File patched successfully" }] };
     }
 
+    const { line: headingLine, level: headingLevel } = found;
+
     // Find the end of this heading's section: the next heading of same or
     // higher level (lower number means higher in hierarchy), or EOF.
-    const headingLevel = lines[headingLine].match(/^(#+)/)?.[1].length ?? 1;
 
     // 0.3.9 #16 parity: reject root-orphan H2+ when createTargetIfMissing=false
     // (legacy LRA enforced this via markdown-patch's indexer; the 0.4.0

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
@@ -9,6 +9,7 @@ import {
 } from "$/features/mcp-tools/services/periodicNotesDetector";
 import {
   findHeadingSectionEnd,
+  findLeafHeadingLine,
   normalizeAppendBody,
   resolveHeadingPath,
 } from "$/features/mcp-tools/services/patchHelpers";
@@ -100,18 +101,9 @@ export async function appendToPeriodicNoteHandler(
     const targetParts = resolvedTarget.split(HEADING_DELIMITER);
     const leafHeading = targetParts[targetParts.length - 1];
 
-    let headingLine = -1;
-    let headingLevel = 1;
-    for (let i = 0; i < lines.length; i++) {
-      const m = lines[i].match(/^(#{1,6})\s+(.+)$/);
-      if (m && m[2].trim() === leafHeading) {
-        headingLine = i;
-        headingLevel = m[1].length;
-        break;
-      }
-    }
+    const found = findLeafHeadingLine(lines, leafHeading);
 
-    if (headingLine === -1) {
+    if (found === null) {
       // Strict-by-default: do NOT silently fall back to EOF, do NOT
       // rollback an auto-created file (the file's existence is the
       // right end state regardless of this single append — see ADR-0002
@@ -128,6 +120,7 @@ export async function appendToPeriodicNoteHandler(
       );
     }
 
+    const { line: headingLine, level: headingLevel } = found;
     const sectionEnd = findHeadingSectionEnd(lines, headingLine, headingLevel);
     const newLines = [
       ...lines.slice(0, sectionEnd),


### PR DESCRIPTION
## Summary
Low-risk cleanup, two concerns, two commits:

- **`test(rename_heading)`** — adds 6 regression guards for link shapes the rewriter already handles but had no coverage for: embeds (`![[note#heading]]`, same-file `![[#heading]]`, subheading-path embeds) and degenerate aliases (`[[note#A||C]]` double-pipe, `[[note#Old|]]` empty alias). All pass against current code — **no behavior change**, just locks the contract (the `!` is preserved; the first-`|` tokenizer keeps everything after the first pipe verbatim).
- **`refactor(patch)`** — `append_to_periodic_note` and `patch_vault_file` each had their own inline loop matching a leaf heading via `/^(#{1,6})\s+(.+)$/`. Extracted a single `findLeafHeadingLine(lines, leafHeading) -> {line, level} | null` in `patchHelpers` and used it in both. The level equals `patch_vault_file`'s prior separate `/^(#+)/` count for any matching line, so behavior is unchanged.

Context: these were the leftover nits accumulated post-0.6.0. Investigation found the third flagged nit (`getOrCreateDailyNote.ts:89` "redundant if(!file)") was a **false positive** — that check is the TS narrowing for the `as TFile` cast plus a defensive guard — so it's deliberately untouched.

## Test plan
- [x] `bun run check` (workspace typecheck) — 0 errors
- [x] `bun test` in obsidian-plugin — 494 pass, 0 fail (incl. patch_vault_file, appendToPeriodicNote, rename_heading)
- [x] `bun run format:check` — prettier clean
- [x] `bun run build` — build-smoke ok