### PR TITLE
feat: execute_dataview_query — in-process Dataview API tool (ADR-0003, #166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ## [Unreleased]
 
+### Added
+
+- **`execute_dataview_query` — in-process Dataview DQL tool.** New tool that
+  runs a DQL query directly against the Dataview plugin API
+  (`app.plugins.plugins.dataview.api.query(query, sourcePath)`) and returns
+  the native typed result — `{type:"table", headers, values}` /
+  `{type:"list", values}` / `{type:"task", values}` / `{type:"calendar", values}`.
+  In-process: no Local REST API required. Three-state plugin detection
+  surfaces a distinct `errorCode` per cause: `dataview_not_installed`
+  (permanent), `dataview_not_ready` (transient — the plugin is loaded but
+  the index hasn't finished building yet, Dataview fires
+  `dataview:index-ready` when done), and `dataview_query_failed` (the DQL
+  was parsed/evaluated by Dataview and rejected — Dataview's error string
+  surfaces verbatim). DQL validation is delegated to Dataview entirely;
+  ArkType only validates the boundary string shapes. Coexists with
+  `search_vault` (which keeps its LRA-coupled DQL + JsonLogic path
+  unchanged for backward compatibility) — the new tool's `.describe()`
+  guides agents to prefer it for new DQL workflows. Large results are not
+  truncated at the tool level; `.describe()` recommends in-DQL `LIMIT`.
+  Tool count 37 → 38. **The LRA-coupled count stays at 1** —
+  `search_vault` is the only remaining LRA-coupled tool. (ADR-0003, #166)
+
 ## [0.6.0] — 2026-05-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guidance for Claude Code (and similar AI agents) working in this repository.
 
 One shipped component on the 0.4.x line:
 
-1. **Obsidian plugin** — hosts an in-process HTTP MCP server (port 27200 default), writes `claude_desktop_config.json`, exposes all 37 MCP tools and prompts over streamable-HTTP. No separate binary. Semantic search via native Transformers.js (no Smart Connections dependency).
+1. **Obsidian plugin** — hosts an in-process HTTP MCP server (port 27200 default), writes `claude_desktop_config.json`, exposes all 38 MCP tools and prompts over streamable-HTTP. No separate binary. Semantic search via native Transformers.js (no Smart Connections dependency).
 
 Why operations go through Obsidian APIs rather than reading `.md` files directly: it preserves Obsidian's metadata cache, respects file locks on open notes, and lets the plugin invoke other Obsidian plugins (Templater, Dataview) through their APIs.
 
@@ -149,7 +149,7 @@ Rules:
 
 Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are exposed.
 
-### Tools (37 total, 0.4.x)
+### Tools (38 total, 0.4.x)
 
 **Vault file management** — `packages/obsidian-plugin/src/features/mcp-tools/tools/`:
 
@@ -173,7 +173,8 @@ Capabilities declared: **`tools`** and **`prompts`**. No MCP resources are expos
 | `set_note_property` | Set one frontmatter key (atomic via `processFrontMatter`; auto-inits the block; `value:null` deletes). |
 | `delete_note_property` | Remove one frontmatter key (idempotent). |
 | `list_property_values` | Enumerate distinct values of a frontmatter key across the vault, with per-value counts (scale-safe). |
-| `search_vault` | Search via Dataview DQL or JsonLogic query. |
+| `search_vault` | Search via Dataview DQL or JsonLogic query (LRA-coupled — kept for backward compatibility). |
+| `execute_dataview_query` | Run a Dataview DQL query in-process via the plugin API; returns the native typed result (`{type:"table"\|"list"\|"task"\|"calendar", …}`). No LRA required. Three-state detection (`dataview_not_installed` / `dataview_not_ready` / query-failed). Prefer over `search_vault`'s DQL for new workflows. |
 | `search_vault_simple` | Plain text search with context window. |
 
 **Semantic search** — `features/semantic-search/` (native Transformers.js MiniLM embedder, WASM CDN-pinned, in-process — no Smart Connections required):

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -135,6 +135,10 @@ import {
   appendToPeriodicNoteHandler,
   appendToPeriodicNoteSchema,
 } from "./tools/appendToPeriodicNote";
+import {
+  executeDataviewQueryHandler,
+  executeDataviewQuerySchema,
+} from "./tools/executeDataviewQuery";
 
 export type RegisterToolsContext = {
   app: App;
@@ -270,6 +274,9 @@ export async function registerTools(
       app: ctx.app,
       plugin: ctx.plugin,
     }),
+  );
+  registry.register(executeDataviewQuerySchema, async ({ arguments: args }) =>
+    executeDataviewQueryHandler({ arguments: args, app: ctx.app }),
   );
 
   // Commands

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  getMockDataviewCalls,
+  mockApp,
+  resetMockVault,
+  setMockDataviewQueryImpl,
+  setMockDataviewState,
+} from "$/test-setup";
+import { executeDataviewQueryHandler } from "./executeDataviewQuery";
+
+function parse(result: { content: Array<{ type: "text"; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("execute_dataview_query", () => {
+  beforeEach(() => {
+    resetMockVault();
+  });
+
+  describe("three-state plugin detection", () => {
+    test("absent → errorCode dataview_not_installed (permanent)", async () => {
+      // Default state is "absent" — no extra setup.
+      const res = await executeDataviewQueryHandler({
+        arguments: { query: 'TABLE FROM ""' },
+        app: mockApp(),
+      });
+      expect(res.isError).toBe(true);
+      const body = parse(res);
+      expect(body.errorCode).toBe("dataview_not_installed");
+      expect(body.query).toBe('TABLE FROM ""');
+    });
+
+    test("loaded but index not built → errorCode dataview_not_ready (transient)", async () => {
+      setMockDataviewState("not_ready");
+      const res = await executeDataviewQueryHandler({
+        arguments: { query: 'TABLE FROM ""' },
+        app: mockApp(),
+      });
+      expect(res.isError).toBe(true);
+      const body = parse(res);
+      expect(body.errorCode).toBe("dataview_not_ready");
+      // Caller hint references the dataview:index-ready event so the agent
+      // knows to retry rather than treat it as a permanent failure.
+      expect(body.error.toLowerCase()).toContain("index");
+    });
+
+    test("ready + successful query → returns native typed result, no isError", async () => {
+      setMockDataviewState("ready");
+      setMockDataviewQueryImpl(() => ({
+        successful: true,
+        value: {
+          type: "table",
+          headers: ["file", "mtime"],
+          values: [
+            ["Notes/A.md", "2026-05-22"],
+            ["Notes/B.md", "2026-05-20"],
+          ],
+        },
+      }));
+      const res = await executeDataviewQueryHandler({
+        arguments: { query: 'TABLE file.mtime FROM "Notes"' },
+        app: mockApp(),
+      });
+      expect(res.isError).toBeUndefined();
+      const body = parse(res);
+      expect(body.type).toBe("table");
+      expect(body.headers).toEqual(["file", "mtime"]);
+      expect(body.values).toHaveLength(2);
+    });
+  });
+
+  describe("query result envelope unwrap", () => {
+    test.each([
+      [
+        "list",
+        { type: "list", values: ["Notes/A.md", "Notes/B.md"] },
+        ["values"],
+      ],
+      [
+        "task",
+        { type: "task", values: [{ text: "todo", completed: false }] },
+        ["values"],
+      ],
+      [
+        "calendar",
+        { type: "calendar", values: [{ date: "2026-05-22" }] },
+        ["values"],
+      ],
+    ] as const)(
+      "%s query type passes through verbatim",
+      async (_label, value, expectedKeys) => {
+        setMockDataviewState("ready");
+        setMockDataviewQueryImpl(() => ({ successful: true, value }));
+        const res = await executeDataviewQueryHandler({
+          arguments: { query: "..." },
+          app: mockApp(),
+        });
+        expect(res.isError).toBeUndefined();
+        const body = parse(res);
+        expect(body.type).toBe(value.type);
+        for (const k of expectedKeys) expect(body[k]).toBeDefined();
+      },
+    );
+
+    test("extra Dataview fields (idMeaning) pass through unchanged", async () => {
+      setMockDataviewState("ready");
+      setMockDataviewQueryImpl(() => ({
+        successful: true,
+        value: {
+          type: "table",
+          headers: ["file"],
+          values: [],
+          idMeaning: { type: "path" },
+        },
+      }));
+      const res = await executeDataviewQueryHandler({
+        arguments: { query: 'TABLE FROM ""' },
+        app: mockApp(),
+      });
+      const body = parse(res);
+      expect(body.idMeaning).toEqual({ type: "path" });
+    });
+  });
+
+  describe("query failure (Dataview returns successful:false)", () => {
+    test("errorCode dataview_query_failed surfaces Dataview's error verbatim", async () => {
+      setMockDataviewState("ready");
+      setMockDataviewQueryImpl(() => ({
+        successful: false,
+        error: "Failed to parse query: expected FROM after TABLE",
+      }));
+      const res = await executeDataviewQueryHandler({
+        arguments: { query: "TABLE" },
+        app: mockApp(),
+      });
+      expect(res.isError).toBe(true);
+      const body = parse(res);
+      expect(body.errorCode).toBe("dataview_query_failed");
+      expect(body.error).toBe(
+        "Failed to parse query: expected FROM after TABLE",
+      );
+      expect(body.query).toBe("TABLE");
+    });
+  });
+
+  describe("sourcePath flows through to Dataview's originFile", () => {
+    test("when sourcePath provided, originFile arg matches", async () => {
+      setMockDataviewState("ready");
+      const res = await executeDataviewQueryHandler({
+        arguments: {
+          query: "LIST FROM [[#]]",
+          sourcePath: "Projects/Roadmap.md",
+        },
+        app: mockApp(),
+      });
+      expect(res.isError).toBeUndefined();
+      const calls = getMockDataviewCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0].source).toBe("LIST FROM [[#]]");
+      expect(calls[0].originFile).toBe("Projects/Roadmap.md");
+    });
+
+    test("when sourcePath omitted, originFile is undefined (not coerced)", async () => {
+      setMockDataviewState("ready");
+      await executeDataviewQueryHandler({
+        arguments: { query: "LIST" },
+        app: mockApp(),
+      });
+      const calls = getMockDataviewCalls();
+      expect(calls[0].originFile).toBeUndefined();
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.ts
@@ -1,0 +1,139 @@
+import { type } from "arktype";
+import type { App } from "obsidian";
+
+export const executeDataviewQuerySchema = type({
+  name: '"execute_dataview_query"',
+  arguments: {
+    query: type("string>0").describe(
+      'Dataview DQL query. Supports `TABLE`, `LIST`, `TASK`, and `CALENDAR` query types. Examples: `TABLE file.mtime FROM "Projects"`, `LIST FROM #client`, `TASK WHERE !completed`. For large vaults prefer `LIMIT n` in the query itself — the tool returns the full result with no row cap.',
+    ),
+    "sourcePath?": type("string>0").describe(
+      "Optional vault-relative origin file. Establishes relative-link / `this.*` resolution context for the query (maps to Dataview's `originFile` internally).",
+    ),
+  },
+}).describe(
+  'Run a Dataview DQL query against the vault and return the native typed result. In-process via the Dataview plugin API (`app.plugins.plugins.dataview.api.query`) — no Local REST API required. Returns the typed shape per query type: TABLE → `{type:"table", headers, values}`, LIST → `{type:"list", values}`, TASK → `{type:"task", values}`, CALENDAR → `{type:"calendar", values}`. Requires the Dataview community plugin: `errorCode: "dataview_not_installed"` if absent, `dataview_not_ready` if loaded but the index has not finished building (retry shortly — Dataview fires `dataview:index-ready` when done), `dataview_query_failed` if the DQL itself is rejected (the underlying error is surfaced verbatim). Coexists with `search_vault` (which keeps its LRA-coupled DQL + JsonLogic path) — prefer this tool for new DQL workflows.',
+);
+
+export type ExecuteDataviewQueryContext = {
+  arguments: { query: string; sourcePath?: string };
+  app: App;
+};
+
+// ── Dataview runtime shape ─────────────────────────────────────────────────
+//
+// Dataview's plugin API is not in our `.d.ts` (it lives in the user's
+// installed Dataview plugin at runtime). Same pattern as `listTags.ts:30`
+// for `getTags` and the `periodicNotesDetector.ts` cast for the daily-notes
+// interface lib's stale .d.ts: declare the runtime shape locally + cast at
+// the call site, with a safe-fail fallback when the shape changes.
+//
+// `api.query(source, originFile?, settings?)` resolves to a Result envelope:
+//   { successful: true,  value: QueryResult }
+//   { successful: false, error: string }
+// We unwrap the envelope and return the inner `value` (or surface `error`).
+// The success `value` carries extra fields beyond the documented contract
+// (`idMeaning` on table, `primaryMeaning` on list, grouping on task); we
+// pass them through verbatim. The load-bearing contract per ADR-0003 is the
+// `type` discriminator + the typed `headers`/`values` per shape.
+
+interface DataviewResultSuccess<T> {
+  successful: true;
+  value: T;
+}
+interface DataviewResultFailure {
+  successful: false;
+  error: string;
+}
+type DataviewResult<T> = DataviewResultSuccess<T> | DataviewResultFailure;
+
+// We don't constrain QueryResult here — its shape varies per `type`, and the
+// load-bearing field for callers is the `type` discriminator. Treat it as
+// `unknown` and let the JSON serialisation pass the live shape through.
+interface DataviewApi {
+  query: (
+    source: string,
+    originFile?: string,
+    settings?: unknown,
+  ) => Promise<DataviewResult<unknown>>;
+}
+
+interface DataviewPlugin {
+  api?: DataviewApi;
+}
+
+interface AppWithPlugins {
+  plugins?: {
+    plugins?: Record<string, unknown>;
+  };
+}
+
+export async function executeDataviewQueryHandler(
+  ctx: ExecuteDataviewQueryContext,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const { query, sourcePath } = ctx.arguments;
+
+  // Three-state detection per ADR-0003:
+  //   absent              → not installed (permanent until user installs)
+  //   present, no `.api`  → not ready    (transient; index still building,
+  //                                       Dataview fires `dataview:index-ready`)
+  //   `.api` present      → run query
+  const pluginsBag = (ctx.app as unknown as AppWithPlugins).plugins?.plugins;
+  const plugin = pluginsBag?.["dataview"] as DataviewPlugin | undefined;
+
+  if (!plugin) {
+    return errorPayload(
+      "The Dataview community plugin is not installed. Install it from Obsidian's community plugins and enable it, then retry.",
+      "dataview_not_installed",
+      { query },
+    );
+  }
+  if (!plugin.api) {
+    // Plugin loaded but the index has not finished building. Distinct from
+    // "not installed" because the fix is to wait, not to install. Dataview
+    // fires `dataview:index-ready` when the index is ready — the agent
+    // can simply retry shortly.
+    return errorPayload(
+      "Dataview is loaded but its index has not finished building yet. Retry shortly (Dataview fires `dataview:index-ready` when ready).",
+      "dataview_not_ready",
+      { query },
+    );
+  }
+
+  const result = await plugin.api.query(query, sourcePath);
+
+  if (!result.successful) {
+    // DQL parse / evaluation error — surface Dataview's own message verbatim
+    // so the caller sees exactly what Dataview rejected. DQL validation is
+    // Dataview's job, not ours.
+    return errorPayload(result.error, "dataview_query_failed", { query });
+  }
+
+  // Success: serialise the typed result as the standard MCP text payload.
+  // No `isError` on success per the property-tools convention.
+  return {
+    content: [{ type: "text", text: JSON.stringify(result.value, null, 2) }],
+  };
+}
+
+function errorPayload(
+  message: string,
+  errorCode: string,
+  extras: Record<string, unknown>,
+): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -115,6 +115,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "delete_note_property",
         "delete_vault_directory",
         "delete_vault_file",
+        "execute_dataview_query",
         "execute_obsidian_command",
         "execute_template",
         "fetch",
@@ -144,7 +145,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "show_file_in_obsidian",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(37);
+      expect(names).toHaveLength(38);
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -371,6 +371,86 @@ void mock.module("obsidian-daily-notes-interface", () => ({
     _createPeriodicNote("yearly", date),
 }));
 
+// === Mock for the Dataview community plugin (ADR-0003, #166) =============
+//
+// `execute_dataview_query` reads `app.plugins.plugins["dataview"]` directly,
+// not through an npm library, so this mock lives at the app surface — see
+// the `dataview` getter inside `mockApp()` below. The three-state seam is:
+//
+//   "absent"      → app.plugins.plugins["dataview"] returns undefined
+//   "not_ready"   → returns { /* no .api */ } (plugin loaded, index unbuilt)
+//   "ready"       → returns { api: { query: queryImpl } }
+//
+// Tests seed via `setMockDataviewState(...)` and (when "ready") supply a
+// query implementation via `setMockDataviewQueryImpl(fn)`. Default impl is
+// an empty TABLE result so tests that don't care about the payload still
+// get a well-shaped Result envelope back. Mirrors the property-tools
+// `errorCode` failure shape via the `successful: false` branch.
+
+type MockDataviewState = "absent" | "not_ready" | "ready";
+
+interface MockDataviewResultSuccess<T> {
+  successful: true;
+  value: T;
+}
+interface MockDataviewResultFailure {
+  successful: false;
+  error: string;
+}
+type MockDataviewResult<T> =
+  | MockDataviewResultSuccess<T>
+  | MockDataviewResultFailure;
+
+type MockDataviewQueryImpl = (
+  source: string,
+  originFile?: string,
+) => MockDataviewResult<unknown> | Promise<MockDataviewResult<unknown>>;
+
+const _defaultDataviewQueryImpl: MockDataviewQueryImpl = () => ({
+  successful: true,
+  value: { type: "table", headers: [], values: [] },
+});
+
+const _mockDataview = {
+  state: "absent" as MockDataviewState,
+  queryImpl: _defaultDataviewQueryImpl,
+  // Records the (source, originFile) of every query call so tests can assert
+  // that sourcePath flowed through to Dataview's originFile parameter.
+  calls: [] as Array<{ source: string; originFile?: string }>,
+};
+
+/**
+ * Seed the Dataview plugin state. `"absent"` means the plugin isn't
+ * installed (default); `"not_ready"` means it's loaded but the index hasn't
+ * built yet (`.api` undefined); `"ready"` means queries can run.
+ */
+export function setMockDataviewState(state: MockDataviewState): void {
+  _mockDataview.state = state;
+}
+
+/**
+ * Provide the function `api.query` invokes when state is `"ready"`. Receives
+ * the DQL source string + optional `originFile` (Dataview's name for
+ * `sourcePath`); returns a `Result<T, string>` envelope.
+ */
+export function setMockDataviewQueryImpl(impl: MockDataviewQueryImpl): void {
+  _mockDataview.queryImpl = impl;
+}
+
+/** Test-only: the (source, originFile) of every `api.query` call recorded. */
+export function getMockDataviewCalls(): Array<{
+  source: string;
+  originFile?: string;
+}> {
+  return [..._mockDataview.calls];
+}
+
+export function resetMockDataview(): void {
+  _mockDataview.state = "absent";
+  _mockDataview.queryImpl = _defaultDataviewQueryImpl;
+  _mockDataview.calls = [];
+}
+
 // === Phase 2 mock vault state for tool tests ===
 
 type MockVaultState = {
@@ -501,6 +581,7 @@ export function resetMockVault(): void {
   _mockState.modifyFailPaths.clear();
   _mockState.readMutations.clear();
   resetMockPeriodicNotes();
+  resetMockDataview();
 }
 
 /** Make `vault.modify(file)` reject for `path` (rename_heading #143 M2). */
@@ -1055,12 +1136,44 @@ export function mockApp(): App {
     },
   };
 
+  // Community-plugin registry surface (`app.plugins.plugins[id]`). Synthesised
+  // from `_mockDataview.state` at read time so tests can switch state mid-run
+  // without re-creating the App. Only the `dataview` slot is wired today —
+  // additional community plugins can be added the same way (see ADR-0003).
+  const plugins = {
+    plugins: new Proxy({} as Record<string, unknown>, {
+      get: (_target, prop) => {
+        if (prop !== "dataview") return undefined;
+        if (_mockDataview.state === "absent") return undefined;
+        if (_mockDataview.state === "not_ready") {
+          // Plugin object exists, but `.api` is undefined. Same shape Dataview
+          // exposes during the post-load / pre-index-ready window.
+          return {};
+        }
+        // ready
+        return {
+          api: {
+            query: async (
+              source: string,
+              originFile?: string,
+              _settings?: unknown,
+            ) => {
+              _mockDataview.calls.push({ source, originFile });
+              return await _mockDataview.queryImpl(source, originFile);
+            },
+          },
+        };
+      },
+    }),
+  };
+
   return {
     vault,
     workspace,
     metadataCache,
     fileManager,
     commands,
+    plugins,
   } as unknown as App;
 }
 


### PR DESCRIPTION
## Summary

Implements ADR-0003 — `execute_dataview_query(query, sourcePath?)`, a new in-process MCP tool that runs Dataview DQL against `app.plugins.plugins.dataview.api.query(...)` and returns the native typed result. **No Local REST API required**: the LRA-coupled count stays at 1 (`search_vault`'s DQL/JsonLogic path is untouched), while the common DQL workflow gains a zero-LRA path with the typed shape preserved.

### Tool surface

- `query: string>0` — DQL (TABLE / LIST / TASK / CALENDAR).
- `sourcePath?: string>0` — caller-facing name for Dataview's `originFile`; mapped internally.

### Success shape (no `isError`)

JSON-serialised native typed result:

- TABLE → `{type:"table", headers, values, idMeaning?}`
- LIST → `{type:"list", values, primaryMeaning?}`
- TASK → `{type:"task", values}`
- CALENDAR → `{type:"calendar", values}`

Extra Dataview fields (`idMeaning`, `primaryMeaning`, grouping) pass through verbatim. The load-bearing contract per ADR-0003 is the `type` discriminator + the typed `headers`/`values`.

### Failure shape (per Module D convention, `isError: true`)

```json
{ "error": "...", "errorCode": "...", "query": "..." }
```

Three-state plugin detection at call time:

| State | Detection | `errorCode` |
|---|---|---|
| Absent | `app.plugins.plugins["dataview"] === undefined` | `dataview_not_installed` (permanent) |
| Loaded, index not built | plugin object exists, `.api === undefined` | `dataview_not_ready` (transient — Dataview fires `dataview:index-ready`) |
| Ready, DQL rejected | `api.query()` resolves with `{successful: false}` | `dataview_query_failed` (Dataview's error string surfaces verbatim) |

### Decisions inherited from ADR-0003 (no design surprises)

- **Trust Dataview's DQL parser** — ArkType only validates string shapes; DQL grammar is Dataview's job.
- **No tool-level truncation** — recommend in-DQL `LIMIT` via `.describe()`. (Same posture as `search_vault` / `get_vault_file`; a `limit?` wrapper stays a BC follow-up.)
- **Failure envelope follows `getNoteProperty` / `setNoteProperty` convention** (`{error, errorCode, query}` + `isError: true`), explicitly **not** `search_vault`'s plain-text style — ADR-0003 documents the divergence.
- **Coexists with `search_vault`** — the LRA-coupled DQL path stays for backward compatibility; `.describe()` guides agents to prefer the new tool for new DQL workflows.
- **Runtime cast** for the Dataview API shape (not in our `.d.ts`) — same pattern as `listTags.ts:30` for `getTags` and the `obsidian-daily-notes-interface` runtime bag in `periodicNotesDetector.ts`.

## Test plan

- [x] `bun run check` — workspace typecheck clean (shared + test-server + obsidian-plugin)
- [x] `bun run build` — typecheck + bundle ok
- [x] `bun run format:check` — clean (gate #162)
- [x] `bun install --frozen-lockfile` — 0 changes (no dep added)
- [x] **10 new tests** in `executeDataviewQuery.test.ts`:
  - Three-state detection (absent / not_ready / ready + successful)
  - Envelope unwrap for all 4 query types (table / list / task / calendar)
  - Extra-field pass-through (`idMeaning`)
  - `dataview_query_failed` surfaces Dataview's error string verbatim
  - `sourcePath` flows through to Dataview's `originFile` (both supplied and omitted)
- [x] Regression-guard `mcpServer.test.ts`: 38 names alpha-sorted ✓
- [x] Full sweep (`find ! -name port.test.ts ! -name httpServer.test.ts`): **883/883 pass, 2006 expect, 72 files**
- [ ] Manual smoke through a live Obsidian vault with Dataview installed (post-link, ad-hoc — happy to run this if useful)

## Notes for review

- The `app.plugins.plugins` mock surface is new in `test-setup.ts` (extends `mockApp()` with a Proxy that reads `_mockDataview.state` at call time). Same lazy-resolution pattern used by the periodic-notes mock state — consistent.
- I followed the ADR's runtime-shape-verification guidance: the `DataviewApi`/`DataviewResult` interfaces are declared locally in the tool file rather than imported, and the typed `value` is treated as `unknown` so the live Dataview shape passes through unchanged. If a future Dataview release renames `.api` or reshapes `Result`, the `dataview_not_ready` branch absorbs it as a safe-fail rather than throwing.
- ADR-0003 `Status` is still `Proposed` — happy to flip to `Accepted` in this PR or in a follow-up, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)