### PR TITLE
docs(adr-0003): mark status Accepted after merge of PR #174

### DIFF
--- a/docs/architecture/ADR-0003-execute-dataview-query.md
+++ b/docs/architecture/ADR-0003-execute-dataview-query.md
@@ -1,7 +1,8 @@
 # ADR-0003 — `execute_dataview_query` in-process tool
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-05-24
+- **Accepted**: 2026-05-26 — implemented in PR #173 (marcoaperez), hardened and merged via PR #174 (`860a626`)
 - **Scope**: RFC #166 — 1 new in-process MCP tool. PR authored by an external contributor against the surface this ADR settles.
 
 ## Context


### PR DESCRIPTION
Closes the ADR lifecycle: sets `Status: Proposed → Accepted` and records the merge date and squash SHA (`860a626`) from PR #174.

No code changes — docs only.