### PR TITLE
fix(set-note-property): coerce JSON-encoded string arrays to native lists

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.test.ts
@@ -69,6 +69,46 @@ describe("set_note_property tool", () => {
     expect(readFm("n.md")?.tags).toEqual(["x", "y"]);
   });
 
+  test("JSON-encoded string array is coerced to a native list (LLM client workaround)", async () => {
+    setMockFile("n.md", "");
+    setMockMetadata("n.md", { frontmatter: {} });
+    await setNotePropertyHandler({
+      arguments: { path: "n.md", key: "tags", value: '["a","b","c"]' },
+      app: mockApp(),
+    });
+    expect(readFm("n.md")?.tags).toEqual(["a", "b", "c"]);
+  });
+
+  test("JSON-encoded number array is coerced to a native list", async () => {
+    setMockFile("n.md", "");
+    setMockMetadata("n.md", { frontmatter: {} });
+    await setNotePropertyHandler({
+      arguments: { path: "n.md", key: "scores", value: "[1,2,3]" },
+      app: mockApp(),
+    });
+    expect(readFm("n.md")?.scores).toEqual([1, 2, 3]);
+  });
+
+  test("plain string is not coerced even if it contains brackets", async () => {
+    setMockFile("n.md", "");
+    setMockMetadata("n.md", { frontmatter: {} });
+    await setNotePropertyHandler({
+      arguments: { path: "n.md", key: "note", value: "[see above]" },
+      app: mockApp(),
+    });
+    expect(readFm("n.md")?.note).toBe("[see above]");
+  });
+
+  test("mixed-type JSON array is not coerced (stays as string)", async () => {
+    setMockFile("n.md", "");
+    setMockMetadata("n.md", { frontmatter: {} });
+    await setNotePropertyHandler({
+      arguments: { path: "n.md", key: "mixed", value: '["a",1]' },
+      app: mockApp(),
+    });
+    expect(readFm("n.md")?.mixed).toBe('["a",1]');
+  });
+
   test("auto-initialises a missing frontmatter block", async () => {
     setMockFile("n.md", "just a body, no frontmatter");
     const r = await setNotePropertyHandler({

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.ts
@@ -33,6 +33,32 @@ function isInvalidKey(key: string): boolean {
   return /[:\n\r]/.test(key) || key.trimStart().startsWith("#");
 }
 
+// LLM clients (e.g. Claude) sometimes send arrays as JSON-encoded strings
+// ('["a","b"]') rather than native JSON arrays (["a","b"]) when constructing
+// tool calls. Detect and unwrap: if the value is a string that parses as a
+// homogeneous JSON array of strings or numbers, return the parsed array so
+// processFrontMatter writes a YAML list instead of a quoted string.
+function coerceJsonEncodedArray(
+  value: string | number | boolean | string[] | number[],
+): string | number | boolean | string[] | number[] {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[")) return value;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (!Array.isArray(parsed) || parsed.length === 0) return value;
+    if (parsed.every((item): item is string => typeof item === "string")) {
+      return parsed;
+    }
+    if (parsed.every((item): item is number => typeof item === "number")) {
+      return parsed;
+    }
+  } catch {
+    // not valid JSON — use the string as-is
+  }
+  return value;
+}
+
 export async function setNotePropertyHandler(
   ctx: SetNotePropertyContext,
 ): Promise<{
@@ -98,7 +124,7 @@ export async function setNotePropertyHandler(
     if (value === null) {
       delete fm[key];
     } else {
-      fm[key] = value;
+      fm[key] = coerceJsonEncodedArray(value);
     }
   });
 


### PR DESCRIPTION
## Problem

LLM clients (including Claude) sometimes serialize array values as JSON-encoded strings when constructing tool calls — sending `value: '["a","b","c"]'` (a string) instead of `value: ["a","b","c"]` (a native array). Since `string` is valid in the `value` union type, ArkType accepts it and passes it unchanged to `processFrontMatter`, which then writes the YAML as a quoted string:

```yaml
tags: '["a","b","c"]'   # ← wrong: YAML string
```

instead of the intended YAML list:

```yaml
tags:
  - a
  - b
  - c
```

## Fix

Added `coerceJsonEncodedArray()` in `setNotePropertyHandler`: if `value` is a string whose trimmed form starts with `[` and parses as a valid JSON array of **homogeneous** strings or numbers, it is unwrapped to the native array before being passed to `processFrontMatter`.

Edge cases are deliberately left unchanged:
- **Plain bracket strings** (`"[see above]"`) → kept as string (not valid JSON)
- **Mixed-type arrays** (`'["a",1]'`) → kept as string (not homogeneous — ArkType schema doesn't support `Array<string|number>`)
- **Empty arrays** (`'[]'`) → kept as string (semantically ambiguous)
- **All non-string values** → pass through unchanged

## Tests

4 new regression tests added to `setNoteProperty.test.ts`:

- JSON-encoded string array → coerced to native list ✅
- JSON-encoded number array → coerced to native list ✅
- Plain bracket string (`[see above]`) → preserved as string ✅
- Mixed-type JSON array → preserved as string ✅

## Checklist

- [x] `bun run check` — typecheck clean
- [x] 14/14 `setNoteProperty.test.ts` (10 existing + 4 new)
- [x] All other tool tests unaffected