### PR TITLE
chore(format): apply prettier to findBrokenLinks.ts

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.ts
@@ -74,8 +74,7 @@ export async function findBrokenLinksHandler(
       const entry: BrokenLinkEntry = {
         source_path: file.path,
         // frontmatterLinks have no position; use 0 as sentinel.
-        line_number:
-          raw.position != null ? raw.position.start.line + 1 : 0,
+        line_number: raw.position != null ? raw.position.start.line + 1 : 0,
         link_target: raw.link,
         link_type: kind,
         original: raw.original,


### PR DESCRIPTION
Fixes CI prettier failure introduced by #179. One-line formatting diff.