### PR TITLE
docs: post-0.8.0 cleanup — promote [Unreleased] to [0.8.0], update project status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-26
+
 ### Added
 
 - **Vault Intelligence tools (5, Module E).** `find_broken_links`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,9 +328,9 @@ Active traps in the current tree. Historical bugs already fixed are in `git log`
 
 3. **`bun run check` at the repo root** (again) — shared-package changes cascade; both runtime packages must still type-check.
 
-## Project status (2026-05-18)
+## Project status (2026-05-26)
 
-- `main` at **0.5.0** — standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16). Tools: 34. `minAppVersion: 1.7.2`. Distributed via the **Obsidian community store** (accepted & listed, id `mcp-tools-istefox`) **and** BRAT. Tag stack `0.4.0` → `0.5.0`.
+- `main` at **0.8.0** — standalone in-process HTTP MCP server (0.4.x promoted to `main` 2026-05-16). Tools: 43. `minAppVersion: 1.7.2`. Distributed via the **Obsidian community store** (accepted & listed, id `mcp-tools-istefox`) **and** BRAT. Tag stack `0.4.0` → `0.8.0`.
 - `archive/main-0.3.12` — the retired 0.3.x stdio/binary line (20 MCP tools). Preserved for historical reference; HEAD `76fa012` 2026-04-28; tag stack `0.3.0` → `0.3.12`. No active development.
 - **Community store: ACCEPTED & LISTED** (2026-05-16) — id `mcp-tools-istefox` in `obsidianmd/obsidian-releases/community-plugins.json`; installable in-app + via BRAT. Obsidian shows a standard "not manually reviewed by Obsidian staff" disclaimer (automated review path; high-risk `fs`/`child_process` capability disclosures, which are intrinsic and were deliberately NOT removed). The legacy PR-based submission `obsidianmd/obsidian-releases#11919` was closed (process moved to the community.obsidian.md portal). Consult `CHANGELOG.md` for the current `[Unreleased]` state.
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Move Module E (Vault Intelligence, 5 tools) content from `[Unreleased]` to the new `[0.8.0] — 2026-05-26` section in CHANGELOG.md
- Update `CLAUDE.md` Project status: version 0.5.0 → 0.8.0, tools 34 → 43, tag stack `0.4.0 → 0.8.0`, date 2026-05-18 → 2026-05-26

## Test plan

- [ ] Verify `[Unreleased]` is empty in CHANGELOG.md
- [ ] Verify `[0.8.0]` section contains the 5 Module E tools
- [ ] Verify CLAUDE.md Project status shows 0.8.0 / 43 tools
EOF
)