### PR TITLE
fix(migration): accept absolute npx path as valid 0.4.x Claude config shape

### DIFF
--- a/packages/obsidian-plugin/src/features/migration/services/detect.test.ts
+++ b/packages/obsidian-plugin/src/features/migration/services/detect.test.ts
@@ -208,6 +208,37 @@ describe("detectLegacyInstall", () => {
     expect(state.hasLegacyClaudeConfigEntry).toBe(false);
   });
 
+  test("Claude config has 0.4.0 entry with absolute npx path → hasLegacyClaudeConfigEntry=false", async () => {
+    // Regression: when npx is at an absolute path (e.g. /opt/homebrew/bin/npx)
+    // the entry is still 0.4.0-shape and must NOT be flagged as legacy.
+    const configPath = path.join(tmpRoot, "claude_desktop_config.json");
+    await fsp.writeFile(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          "mcp-tools-istefox": {
+            command: "/opt/homebrew/bin/npx",
+            args: [
+              "-y",
+              "mcp-remote",
+              "http://127.0.0.1:27200/mcp",
+              "--header",
+              "Authorization: Bearer xxx",
+            ],
+          },
+        },
+      }),
+    );
+
+    const state = await detectLegacyInstall({
+      pluginData: {},
+      claudeConfigPath: configPath,
+      binaryInstallDirOverride: path.join(tmpRoot, "nope"),
+    });
+
+    expect(state.hasLegacyClaudeConfigEntry).toBe(false);
+  });
+
   test("Claude config has the entry with command=npx but args missing mcp-remote → still legacy", async () => {
     // Defensive: someone hand-edited the config to use npx but for an
     // entirely different package. We must not silently treat that as

--- a/packages/obsidian-plugin/src/features/migration/services/detect.ts
+++ b/packages/obsidian-plugin/src/features/migration/services/detect.ts
@@ -236,8 +236,9 @@ async function probeLegacyClaudeConfigEntry(
   const command = typeof newEntry.command === "string" ? newEntry.command : "";
   const args = Array.isArray(newEntry.args) ? (newEntry.args as unknown[]) : [];
 
-  // 0.4.0 shape: command="npx", args contains the literal "mcp-remote".
-  const usesNpx = command === "npx";
+  // 0.4.0 shape: command resolves to npx (bare "npx" or any absolute path
+  // to the npx binary), args contains the literal "mcp-remote".
+  const usesNpx = path.basename(command) === "npx";
   const usesMcpRemote = args.some(
     (a) => typeof a === "string" && a === "mcp-remote",
   );

--- a/packages/obsidian-plugin/src/features/migration/services/setup.ts
+++ b/packages/obsidian-plugin/src/features/migration/services/setup.ts
@@ -208,7 +208,7 @@ const LINGERING_NOTICE_MS = 8000;
 function emitLingeringLegacyNotice(state: LegacyInstallState): void {
   const which = lingeringSignalDescription(state);
   new Notice(
-    `MCP Connector: legacy 0.3.x state still detected (${which}). Re-run the migration check from Settings → Migration from 0.3.x.`,
+    `MCP Connector: legacy 0.3.x state still detected (${which}). Disable and re-enable the plugin to run the migration wizard.`,
     LINGERING_NOTICE_MS,
   );
   logger.info("migration: legacy state persists after dismissal", {


### PR DESCRIPTION
## Summary

- **Root cause**: `detect.ts` used `command === "npx"` (strict string equality), so any absolute path to the npx binary (e.g. `/opt/homebrew/bin/npx`) was falsely classified as a legacy 0.3.x config entry. This triggered the lingering-legacy Notice on every plugin load for users who previously set an absolute npx path to work around npm PATH issues.
- **Fix**: changed to `path.basename(command) === "npx"` — accepts bare `"npx"` and any absolute path whose basename is `npx`.
- **Bonus fix**: the Notice text referenced `"Settings → Migration from 0.3.x"` which does not exist (T8.b planned but never implemented). Updated to `"Disable and re-enable the plugin to run the migration wizard."`.
- **Regression test** added for the `/opt/homebrew/bin/npx` case.

## Test plan

- [ ] CI suite green
- [ ] After merge: disable/enable plugin in Obsidian — notice should NOT appear if the only legacy signal was the absolute npx path