### PR TITLE
fix(smart-connections): guard v2 fallback against SC v4 env without search()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-05-27
+
+### Fixed
+
+- **`search_vault_smart` broken with Smart Connections v4.** SC v4 removed `window.SmartSearch`; the v2 fallback in `loadSmartSearchAPI` blindly assigned `plugin.env` (which has no `search()` in SC v4) as the API, causing `installed: true` with an uncallable search function. The stream then closed immediately, permanently blocking access to `smart_sources`. Fixed by guarding the v2 fallback with `typeof candidate.search === "function"` — if `env` has no callable `search()`, polling continues until the v3 path (`smart_sources`) becomes ready. Also tightened the `takeWhile` predicate to `typeof dep.api?.search !== "function"` for defence-in-depth. (#186)
+
 ## [0.8.1] — 2026-05-27
 
 ### Fixed

--- a/packages/obsidian-plugin/src/shared/index.ts
+++ b/packages/obsidian-plugin/src/shared/index.ts
@@ -171,12 +171,17 @@ export const loadSmartSearchAPI = (plugin: McpToolsPlugin) =>
       // Try window.SmartSearch first (works on some platforms for v2.x)
       let legacyApi = window.SmartSearch;
 
-      // Fallback to plugin system (fixes Linux/cross-platform detection issues)
+      // Fallback to plugin system (fixes Linux/cross-platform detection issues).
+      // SC v4 removed window.SmartSearch; plugin.env exists but has no search().
+      // Guard: only accept env if it exposes a callable search() — otherwise keep
+      // legacyApi null so polling continues until the v3 path becomes ready.
       if (!legacyApi && smartConnectionsPlugin?.env) {
-        legacyApi =
+        const candidate =
           smartConnectionsPlugin.env as unknown as SmartConnections.SmartSearch;
-        // Cache it for future use
-        window.SmartSearch = legacyApi;
+        if (typeof candidate.search === "function") {
+          legacyApi = candidate;
+          window.SmartSearch = legacyApi;
+        }
       }
 
       return {
@@ -189,7 +194,7 @@ export const loadSmartSearchAPI = (plugin: McpToolsPlugin) =>
           smartConnectionsPlugin as App["plugins"]["plugins"]["smart-connections"],
       };
     }),
-    takeWhile((dependency) => !dependency.installed, true),
+    takeWhile((dep) => typeof dep.api?.search !== "function", true),
     distinct(({ installed }) => installed),
   );
 


### PR DESCRIPTION
Fixes #186.

## Root cause

SC v4 removed `window.SmartSearch`. The v2 fallback in `loadSmartSearchAPI` (`shared/index.ts`) assigned `plugin.env` directly as the API without checking whether it exposed a callable `search()`. Since SC v4's `env` has no `search()`, the stream returned `installed: true` with an uncallable API, causing `takeWhile` to close the observable immediately — `smart_sources` (the v3 path) would become ready later but no code was watching, leaving `search_vault_smart` broken for the entire session.

## Fix

Two targeted changes to `loadSmartSearchAPI`:

1. **v2 fallback guard** — check `typeof candidate.search === "function"` before accepting `env` as the legacy API. If it lacks `search()`, `legacyApi` stays `null` so polling continues until the v3 `smart_sources` path becomes ready.

2. **`takeWhile` predicate** — changed from `!dependency.installed` to `typeof dep.api?.search !== "function"` for defence-in-depth: the stream only stops when the API is actually callable.

## Testing

Verified no regressions in the existing test suite (829 pass; 16 pre-existing `bindWithFallback` failures unrelated to this change). The fix matches exactly the root cause analysis and code change proposed in #186 by @folotp.