### PR TITLE
feat(semantic-search): multilingual embedding providers with DLC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ handoff*.md
 .remember/
 CLAUDE.md.bak-*
 docs/superpowers/plans/
+packages/obsidian-plugin/.claude/.triage-fix-last-main.json

--- a/BRAINSTORM.md
+++ b/BRAINSTORM.md
@@ -1,0 +1,94 @@
+# BRAINSTORM — Multilingual embedding providers for search_vault_smart
+
+**Data:** 2026-05-27
+**Fonte requisiti:** SPEC.md at `/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/SPEC.md`
+**Tecniche applicate:** first-principles decomposition, assumption-busting, analogie cross-dominio (DLC/videogioco), inversione/pre-mortem
+
+---
+
+## Problema riformulato (first-principles)
+
+Il risultato irriducibile è **trovare note pertinenti in qualsiasi lingua, senza dipendenze cloud, con continuità operativa durante l'aggiornamento del modello**. Il vettore denso è uno strumento, non il fine; il modello locale è un vincolo fisso (dato non lascia il dispositivo). La dimensionalità e il provider specifico sono dettagli tecnici subordinati a questo obiettivo.
+
+---
+
+## Assunzioni sfidate
+
+- **768 dimensioni fisse** — esito: **aperta** — Matryoshka permette di servire 256/384/512/768d dallo stesso modello; il trade-off qualità/storage/latenza va esplorato nell'ADR. Non è un requisito fisico, è una scelta conservativa.
+- **Re-index totale al cambio provider** — esito: **confermata** — spazi vettoriali di provider diversi sono incompatibili; non ha senso mixarli. Il DLC pattern non evita il rebuild, ma può renderlo non-bloccante (native rimane attivo durante la build).
+- **Selezione provider sempre esplicita** — esito: **sfidabile** — l'utente vuole un `auto`-mode esteso che rilevi la lingua dominante della vault e scelga il provider ottimale senza richiedere selezione manuale.
+
+---
+
+## Alternative di approccio
+
+### Alternativa A — SPEC fedele + DLC UX
+
+- **Idea:** Implementa la SPEC esattamente (EmbeddingProvider interface, native refactored, EmbeddingGemma + e5-base, chunker upgrade, migration path) ma adotta il pattern DLC per l'UX: la ricerca native rimane attiva durante il download del modello e la build dell'indice. Il nuovo provider si attiva solo quando il suo indice è pronto. Nessun blackout.
+- **Asse di differenza:** dati + UX (store per-providerKey, nessun momento in cui la ricerca è completamente disabilitata)
+- **Pro:** scope preciso, nessuna deviazione dalla SPEC concordata; DLC UX riduce la friction senza aumentare la complessità architetturale
+- **Contro:** bundle largo (EmbeddingGemma 190 MB + e5-base ~100 MB); tre provider da mantenere; PR potenzialmente grande
+- **Costo/tempo indicativo:** alto
+
+### Alternativa B — e5-base MVP multilingue
+
+- **Idea:** Implementa l'EmbeddingProvider interface e aggiunge solo `multilingual-e5-base` come provider multilingue (MIT, ~100 MB, 512 context). EmbeddingGemma deferred. Chunker upgrade incluso.
+- **Asse di differenza:** deployment (meno download, meno complessità ONNX, feature parziale ma funzionante prima)
+- **Pro:** download dimezzato (~100 MB vs 190 MB); meno surface ONNX da gestire; rilascio più rapido; e5-base è già ben supportato da transformers.js
+- **Contro:** nessuna vault a 2K context; qualità inferiore su query lunghe; EmbeddingGemma richiede un secondo ciclo
+- **Costo/tempo indicativo:** medio
+
+### Alternativa C — Interface-first, models deferred
+
+- **Idea:** PR 1: EmbeddingProvider interface + migration path (flat → per-providerKey) + chunker upgrade. PR 2 (follow-up): aggiunta dei due provider multilingue. La suite test coprì l'esistente prima di toccare la logica di embedding.
+- **Asse di differenza:** temporalità (disaccoppia refactor strutturale dall'aggiunta di nuove dipendenze pesanti)
+- **Pro:** massimizza la copertura test sul path native prima del rischio di regressione; ogni PR è più piccola e reviewable; il refactor strutturale è prezioso anche senza i nuovi modelli
+- **Contro:** due cicli separati; la feature "multilingue" non è utilizzabile fino alla PR 2; richiede disciplina per non riaprire la PR 1
+- **Costo/tempo indicativo:** medio (ma distribuito)
+
+### Alternativa D — Auto-detect esteso + DLC (ibrido A + auto)
+
+- **Idea:** Come A, ma il provider `"auto"` viene esteso con language detection sulla vault (campionamento di note, rilevamento lingua dominante). Se il vault è prevalentemente non-inglese e EmbeddingGemma è disponibile, auto seleziona il provider ottimale con un banner di suggerimento. La selezione esplicita resta sempre possibile.
+- **Asse di differenza:** confini di responsabilità (il sistema assume decisione di selezione, non l'utente)
+- **Pro:** UX zero-config per la maggior parte degli utenti multilingue; coerente con la logica già presente in `"auto"` per SC vs native
+- **Contro:** language detection aggiunge complessità e un possibile punto di errore; "auto che scarica 190 MB silenziosamente" è un rischio UX se non comunicato chiaramente
+- **Costo/tempo indicativo:** alto
+
+---
+
+## Rischi emersi (inversione / pre-mortem)
+
+- **Setup friction** (modello troppo pesante) → l'utente avvia il download di 190 MB, aspetta 30 minuti, e abbandona il setup. Mitigazione: DLC pattern (native resta attivo), stima visibile di dimensione e tempo prima del click, possibilità di usare e5-base come alternativa più leggera.
+- **Regressioni sul path native** → il refactor del chunker o della store introduce un bug silenzioso nella ricerca inglese per chi non cambia mai provider. Mitigazione: test suite completa sul path native prima di toccare qualsiasi shared code; chunker upgrade come step separato e verificato indipendentemente.
+- **Complessità di manutenzione esplosa** → tre provider, due index path, migration code, chunker nuovo: ogni PR tocca tutto e i test non coprono l'integrazione. Mitigazione: `TransformersProvider` base class condivisa; indici per-providerKey isolati (un bug in Gemma non corrompe native); integration test per il migration path.
+
+---
+
+## Idee adiacenti emerse
+
+- **Ricerca ibrida vettori + BM25** — batterebbe il puro vettoriale su query corte; architetturalmente richiederebbe un layer di fusion score non previsto. [future]
+- **Matryoshka dim configurabile** (slider 256/512/768d in settings per EmbeddingGemma) — il modello lo supporta nativamente; dimensioni ridotte = indice ~2x più piccolo + ricerca più veloce, con leggera perdita di qualità. [future — da annotare come opzione nell'ADR senza implementare]
+- **Bundle e5-base nel plugin** (nessun download, +~100 MB sul plugin scaricato) — non praticabile: l'Obsidian store ha limiti di dimensione del plugin e i 100 MB a freddo penalizzano tutti gli utenti anche quelli che non usano la feature. [esplicitamente esclusa]
+
+---
+
+## Raccomandazione preliminare
+
+**Alternativa A** (SPEC fedele) è la scelta più solida, con due integrazioni dal brainstorm che non aumentano il costo ma riducono i rischi:
+
+1. **DLC UX**: la ricerca native rimane attiva durante il download e il rebuild — nessun blackout. Questo elimina il rischio setup friction senza aggiungere complessità architetturale.
+2. **Auto-mode esteso** (Alternativa D semplificata): `"auto"` suggerisce EmbeddingGemma via banner se rileva contenuto non-inglese, ma non scarica nulla senza consenso esplicito. Language detection superficiale (campione di note, heuristica su caratteri non-ASCII).
+
+Se il team vuole ridurre il rischio di regressione e il tempo al primo rilascio, **Alternativa C** (interface-first) è la seconda scelta: il refactor strutturale è prezioso da solo e permette di verificare l'esistente prima di aggiungere i nuovi modelli pesanti.
+
+**Dichiarata come raccomandazione preliminare**: da validare dall'architect.
+
+---
+
+## Note per l'architect
+
+- **Matryoshka dim**: valutare se esporre dim come parametro dell'`EmbeddingProvider` interface (es. `readonly dimensions: number`) in modo che un futuro provider possa dichiarare dimensioni variabili, senza implementare il configuratore ora. Annotare come `future` nell'ADR.
+- **DLC UX e stato store**: il provider attivo nelle settings può divergere dall'indice disponibile. L'architect deve chiarire quale è la source of truth durante il rebuild e come gestire query concorrenti al vecchio indice mentre il nuovo si costruisce.
+- **Language detection per auto-mode**: la detection può essere lazy (sul primo accesso alle note) o eager (al caricamento del plugin). L'eager detection può rallentare il plugin load su vault grandi. Valutare soglia o campionamento.
+- **Migration path testing**: il migration test (flat `embeddings/` → `embeddings/native-minilm-l6-v2/`) va coperto con un integration test che usa un filesystem reale (non mock) — la logica coinvolge path-join e rename, difficile da testare in isolamento.
+- **Requisiti nuovi da riportare in SPEC**: l'auto-mode esteso con language detection non è esplicitamente in SPEC; se si adotta, aggiungere un paragrafo al comportamento di `"auto"`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,3 +447,18 @@ Five new tools registered under a `// Vault intelligence` block in `mcp-tools/in
 - **`list_bookmarks` uses `app.internalPlugins`**, not `app.plugins.plugins`. Bookmarks is a core plugin. Community plugin path returns `undefined` for it. Access pattern: `(app.internalPlugins as unknown as { plugins: { bookmarks?: … } }).plugins.bookmarks` — same `unknown` cast pattern as `listTags` / `getRecentFiles`.
 - **`find_broken_links` uses per-file cache**, not `unresolvedLinks` map — required for line numbers and link-type context. `frontmatterLinks` have no position field; emit `line_number: 0` as sentinel (documented in `.describe()`).
 - **`mockApp()` in `test-setup.ts` needs an `internalPlugins` slot** — additive extension, no existing test affected. See ADR-0004 for the mock shape.
+
+## Decisioni dal chain Multilingual Embedding Providers
+
+ADR: `docs/architecture/ADR-0005-multilingual-embedding-providers.md`
+
+**Key decisions to carry forward:**
+
+- **`EmbeddingProvider` ≠ `SemanticSearchProvider`** — two distinct interfaces. `EmbeddingProvider` (embedding layer, `types.ts`) is the dependency of `indexer.ts`; `SemanticSearchProvider` (search-side, unchanged) is the dependency of `searchVaultSmartHandler`. Do not merge them.
+- **DLC concurrency via per-providerKey store directories** — `EmbeddingStoreRegistry` holds both the active store and the building store; they are physically isolated paths. No locking needed. `state.provider` swaps only after `rebuildAll()` completes. A partially-built store triggers the re-index banner on next load (flat-sentinel mechanism handles mid-flush crashes).
+- **`TransformersProvider` base class** parameterized by model ID + `TaskPromptFn` — both `EmbeddingGemmaProvider` (768d, 2K ctx, `"task: search result | query: "`) and `MultilingualE5Provider` (768d, 512 ctx, `"query: "` / `"passage: "`) extend it. `configureEnv()` lives in a shared `onnxEnv.ts` to avoid double-initialization.
+- **`@xenova/transformers` v2.17.2 is pinned** — v4 breaks under Obsidian's plugin loader (`import.meta.url`). Any new ONNX provider must be smoke-tested against v2.17.2 in Electron/WASM before merge. `device: 'wasm'` must be set explicitly.
+- **Store migration (v1 flat → per-providerKey)** — `migrateV1FlatStore` renames the flat pair to `embeddings/native-minilm-l6-v2/` on first load. Must be wrapped in try/catch; NFS/permission failures leave the flat store in place and surface the re-index banner rather than crashing.
+- **Chunker: 1-sentence overlap applied at embed time, not stored** — `wrapChunkerWithOverlap` is applied in `processOnePath`, not in `chunk()`. Stored `Chunk.text` is overlap-free; hash comparisons and delta detection remain stable. `#frontmatter` chunks receive no overlap from a non-existent prior chunk.
+- **`"auto"` provider language detection** — 50-note sample, non-ASCII character ratio. If >30%, surfaces a settings banner suggesting EmbeddingGemma. No auto-download; no provider switch without explicit user action.
+- **`FORMAT_VERSION` 1 → 2** is a path change only; the binary format is unchanged. The integration test for migration must use a real `FileSystemAdapter` tmpdir (not a mock) — path-rename logic is not safely testable in isolation.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,184 @@
+# SPEC: Multilingual embedding providers for search_vault_smart
+
+## Objective
+
+Replace the single hardcoded `all-MiniLM-L6-v2` backend with a pluggable
+`EmbeddingProvider` interface and add two multilingual local providers:
+**EmbeddingGemma 300M** (Apache 2.0, 768d, Matryoshka, 2K context) and
+**multilingual-e5-base** (MIT, 768d, 512 context). Bundle a markdown-aware
+chunker upgrade that benefits all providers including the existing native one.
+
+## Scope
+
+**In scope — this cycle:**
+- `EmbeddingProvider` interface and refactor of existing backends behind it
+- EmbeddingGemma 300M ONNX provider (task-prompt aware: `"task: search result | query: {text}"` / `"title: none | text: {text}"`)
+- multilingual-e5-base provider (`"query: "` / `"passage: "` prefixes)
+- Store path keyed on `providerKey` (`embeddings/<providerKey>/`)
+- Provider-change banner + explicit re-index button in settings
+- Model files cached to `.obsidian/plugins/mcp-connector/models/<modelId>/`
+- Markdown-aware chunker: frontmatter chunk, H2 split, code fence atomic, 1-sentence overlap
+- Progress UI for model download (reuse existing `ModelDownloadProgress.svelte` pattern)
+- Settings UI: radio group extended with new provider entries
+
+**Out of scope — deferred:**
+- Gemini cloud provider (Option B) — separate chain
+- Matryoshka dimension selection (fixed at 768 for EmbeddingGemma and e5-base)
+- HNSW approximate-nearest-neighbour index (flat scan retained, per existing design)
+- Cross-vault or cross-device index sharing
+
+## Stack
+
+- **Runtime:** `@huggingface/transformers` (already in tree) with `device: 'wasm'` explicit (Electron compatibility)
+- **Settings UI:** Svelte (existing `SemanticSettingsSection.svelte`)
+- **Store format:** existing `embeddings.bin` + `embeddings.index.json` (one pair per provider under `embeddings/<providerKey>/`)
+- **Test harness:** bun test (existing)
+
+## Architecture
+
+### EmbeddingProvider interface
+
+New in `features/semantic-search/types.ts`:
+
+```
+interface EmbeddingProvider {
+  readonly providerKey: string      // stable id: "native-minilm-l6-v2" | "embedding-gemma-300m" | "multilingual-e5-base"
+  readonly dimensions: number       // 384 or 768
+  readonly maxInputTokens: number   // 512 or 2048
+  embed(texts: string[], role: "document" | "query"): Promise<Float32Array[]>
+  isAvailable(): Promise<boolean>
+  getModelSizeBytes(): number       // approximate; drives UI estimate
+}
+```
+
+### Provider implementations
+
+| File | Model | Key | Dims | Context | License |
+|---|---|---|---|---|---|
+| `nativeProvider.ts` (refactored) | all-MiniLM-L6-v2 | `native-minilm-l6-v2` | 384 | 512 | Apache 2.0 |
+| `embeddingGemmaProvider.ts` (new) | onnx-community/embeddinggemma-300m-ONNX | `embedding-gemma-300m` | 768 | 2048 | Apache 2.0 |
+| `multilingualE5Provider.ts` (new) | Xenova/multilingual-e5-base | `multilingual-e5-base` | 768 | 512 | MIT |
+
+`embeddingGemmaProvider` and `multilingualE5Provider` share a generic
+`TransformersProvider` base (parameterized by model id, dims, task-prompt fn).
+
+### Store path strategy
+
+```
+.obsidian/plugins/mcp-connector/
+  models/
+    embedding-gemma-300m-ONNX/     ← downloaded ONNX files
+    multilingual-e5-base/
+  embeddings/
+    native-minilm-l6-v2/           ← existing index (migrated from flat embeddings/)
+      embeddings.bin
+      embeddings.index.json
+    embedding-gemma-300m/
+      embeddings.bin
+      embeddings.index.json
+    multilingual-e5-base/
+      embeddings.bin
+      embeddings.index.json
+```
+
+Existing users: on first load with the new code, the flat `embeddings/` dir is
+migrated to `embeddings/native-minilm-l6-v2/` transparently.
+
+### Indexer — provider change detection
+
+`indexer.ts` reads the active provider's `providerKey` from settings on each
+init. If the `embeddings/<providerKey>/` dir does not exist, emit a
+`providerIndexMissing` event. The settings component listens to this event
+and shows the re-index banner.
+
+### Chunker upgrade
+
+All changes are backward-compatible (no API surface change, just richer output):
+
+1. **Frontmatter chunk:** YAML frontmatter block extracted as a separate
+   chunk, always prepended before body chunks. Chunk id suffix: `#frontmatter`.
+2. **H2-bounded body split:** split on `## Heading` boundaries. If a section
+   exceeds `maxInputTokens`, split further on `### Heading`. Never split
+   inside a section that fits.
+3. **Code fences and tables atomic:** if a code fence or table exceeds
+   `maxInputTokens`, keep it as a single oversized chunk (truncation is
+   better than mid-fence split). Log a debug warning.
+4. **1-sentence overlap:** prepend the last sentence of the previous chunk
+   to the next chunk's text before embedding (not stored, applied at embed time).
+
+### Settings schema (additive)
+
+```ts
+type SemanticSearchSettings = {
+  provider: "native" | "smart-connections" | "auto" | "embedding-gemma" | "multilingual-e5-base"
+  indexingMode: "live" | "low-power"
+  unloadModelWhenIdle: boolean
+}
+```
+
+`"embedding-gemma"` maps to `EmbeddingGemmaProvider` (768d).
+`"multilingual-e5-base"` maps to `MultilingualE5Provider` (768d).
+Existing values `"native"`, `"smart-connections"`, `"auto"` are unchanged.
+
+## Data model
+
+### Model download record (in-memory, not persisted)
+
+```
+{ modelId: string, status: "idle" | "downloading" | "ready" | "error", progressBytes: number, totalBytes: number }
+```
+
+### Index store (unchanged format, new path)
+
+`FORMAT_VERSION` bumped from 1 → 2. v1 stores found at the flat path are
+migrated to `embeddings/native-minilm-l6-v2/` on init; format version stays
+1 in the migrated files (content is identical, only the path changes).
+
+## UI flows
+
+### 1. User selects EmbeddingGemma in settings
+
+1. Settings saves new provider value.
+2. If `embeddings/embedding-gemma-300m/` does not exist: yellow banner appears below the radio group:
+   > "EmbeddingGemma requires a one-time index rebuild (~190 MB model download + re-embedding). Estimated time: 20–40 min depending on vault size. **[Rebuild now]**"
+3. User clicks **Rebuild now**:
+   - Button changes to a spinner + "Downloading model… 47 MB / 190 MB"
+   - On download complete: "Indexing… 234 / 1,204 notes"
+   - On completion: banner disappears, search is active.
+4. If user closes settings before rebuild: banner re-appears next time settings opens (or on plugin load) until the index exists.
+
+### 2. User switches back to native
+
+Instant — `embeddings/native-minilm-l6-v2/` already exists (migrated on first load).
+No banner, no rebuild.
+
+### 3. First load with new plugin version (existing users)
+
+`embeddings/` (flat) detected → silent migration to `embeddings/native-minilm-l6-v2/`.
+No UX change. Search works immediately.
+
+## Edge cases
+
+| Scenario | Behaviour |
+|---|---|
+| Download interrupted mid-file | Partial model file detected (size mismatch); re-download on next "Rebuild now" |
+| Re-index triggered while another is running | Queue; second trigger is a no-op, not a parallel run |
+| EmbeddingGemma selected but model not yet downloaded | `search_vault_smart` returns `errorCode: "provider_not_ready"` with hint to open settings |
+| Vault with 0 markdown notes | Empty index; no crash; `search_vault_smart` returns empty results |
+| Frontmatter chunk > maxInputTokens | Kept as single chunk (oversized) and truncated at tokenizer level |
+| Code fence > maxInputTokens | Kept atomic, oversized chunk, debug log |
+| `device: 'wasm'` unavailable in Electron | Fall back to `device: 'cpu'`; log info; inference works, slower |
+| Old index FORMAT_VERSION=1 at flat path | Migrated to providerKey path; version stays 1; normal load |
+
+## Success criteria
+
+- `search_vault_smart` with EmbeddingGemma returns relevant results for French/Italian queries against a multilingual vault
+- Selecting EmbeddingGemma shows the re-index banner; clicking "Rebuild now" downloads model, indexes vault, and makes search active
+- Selecting native provider after EmbeddingGemma is instant (no re-index)
+- Existing users upgrade silently (flat index migrated, search uninterrupted)
+- e5-base and EmbeddingGemma appear in the settings provider radio group
+- Chunker produces a separate frontmatter chunk and H2-bounded body chunks
+- Code fences are never split mid-fence
+- All existing semantic search tests pass; new tests cover providers, chunker upgrades, and migration path
+- Model files land in `.obsidian/plugins/mcp-connector/models/`
+- Gemini option is absent (deferred)

--- a/docs/architecture/ADR-0005-multilingual-embedding-providers.md
+++ b/docs/architecture/ADR-0005-multilingual-embedding-providers.md
@@ -1,0 +1,214 @@
+# ADR-0005: Multilingual embedding providers for `search_vault_smart`
+
+**Status:** Accepted  
+**Date:** 2026-05-27
+
+---
+
+## Context
+
+`search_vault_smart` currently uses a single hardcoded `all-MiniLM-L6-v2`
+backend (384d, English-dominant). Users with multilingual vaults (French,
+Italian, mixed) report poor recall. Two additional local models address this
+without cloud dependency:
+
+- **EmbeddingGemma 300M** (`onnx-community/embeddinggemma-300m-ONNX`): 768d,
+  2048-token context, Apache 2.0. Task-prompt format: query prefix
+  `"task: search result | query: {text}"`, document prefix
+  `"title: none | text: {text}"`. Approximate download size ~190 MB.
+- **multilingual-e5-base** (`Xenova/multilingual-e5-base`): 768d, 512-token
+  context, MIT. Prefix format: `"query: "` / `"passage: "`. Approximate
+  download size ~100 MB.
+
+The existing embedding layer (`embedder.ts`, `nativeProvider.ts`,
+`providerFactory.ts`) has no provider abstraction. The store writes to a flat
+`embeddings/` path keyed to a single 384d vector space. The chunker does not
+distinguish frontmatter from body, does not respect H2 section boundaries, and
+does not treat code fences as atomic units.
+
+Constraints that shaped the decision:
+
+- `@xenova/transformers` v2.17.2 is pinned (v4 breaks under Obsidian's plugin
+  loader; see CLAUDE.md Gotchas). All new providers must work with this version.
+- Electron/WASM constraint: `device: 'wasm'`, single-threaded (no
+  SharedArrayBuffer). CDN-pinned WASM paths required.
+- `FORMAT_VERSION = 1` must not corrupt existing user indices.
+- The native MiniLM provider must continue to work without any user action
+  (existing users upgrade silently).
+- Gemini cloud provider deferred. Matryoshka dimension selection deferred.
+
+---
+
+## Decision
+
+**Adopt Alternative A (SPEC-faithful) with the two BRAINSTORM integrations:
+DLC UX and a non-downloading auto-detect banner.**
+
+The full feature set shipped in one PR:
+
+1. `EmbeddingProvider` interface added to `types.ts`.
+2. `nativeProvider.ts` refactored behind the interface; unmodified at the
+   `SemanticSearchProvider` (search-side) level.
+3. A shared `TransformersProvider` base class parameterized by model ID and
+   task-prompt function; both `EmbeddingGemmaProvider` and
+   `MultilingualE5Provider` extend it.
+4. Store paths keyed on `providerKey` (`embeddings/<providerKey>/`).
+   `FORMAT_VERSION` bumped to 2; v1 at the flat path silently migrated to
+   `embeddings/native-minilm-l6-v2/` on first load.
+5. A multi-store registry (`EmbeddingStoreRegistry`) wires one
+   `EmbeddingStore` instance per provider key.
+6. `indexer.ts` made provider-agnostic: accepts `EmbeddingProvider` and
+   `EmbeddingStore` as injected dependencies; the store key is now determined
+   by the chosen provider's `providerKey`, not by a hardcoded path.
+7. DLC UX: during a new provider's download + index build, the native
+   provider's store stays active and continues serving queries. The active
+   search provider swaps only when the new index is fully built.
+8. `"auto"` mode extended: on first activation, sample ~50 notes and compute
+   the non-ASCII character ratio. If >30% non-ASCII, surface a settings banner
+   suggesting EmbeddingGemma; no download triggered automatically.
+9. Settings schema extended: `provider` union gains `"embedding-gemma"` and
+   `"multilingual-e5-base"`.
+10. Chunker upgraded: frontmatter as a separate chunk (`#frontmatter` suffix),
+    H2-bounded body split with H3 sub-split, code fences and tables kept
+    atomic, 1-sentence overlap prepended at embed time.
+
+### Why Alternative A over the other candidates
+
+**Alternative B (e5-base MVP only):** Would ship the interface refactor and one
+multilingual model faster, but EmbeddingGemma's 2048-token context window and
+Matryoshka architecture are qualitatively different from e5-base and require a
+second PR. Two PRs means two migrations, two migration tests, and two UI
+additions. The single-PR cost of shipping both simultaneously is lower than the
+coordination overhead of sequencing them.
+
+**Alternative C (interface-first, models deferred):** The structural refactor
+is valuable on its own, but splitting it from the models defers the user-facing
+feature and creates an intermediate state where the interface exists but no new
+provider can be selected. The risk of regressions on the native path is
+mitigated by the existing test suite and by the DLC design (new providers build
+into separate store directories, so a bug there cannot corrupt the native
+index).
+
+**Alternative D (full auto-detect):** Ruled out in its full form: auto-download
+of ~190 MB without explicit user consent is a hard UX anti-pattern. Retained as
+a soft suggestion (banner, no download). Language detection is cheap enough
+(50-note sample, character ratio) to not affect plugin load time.
+
+### DLC concurrency model
+
+During a provider rebuild:
+
+- `EmbeddingStoreRegistry` holds both the old (active) store and the
+  new (building) store.
+- `searchVaultSmartHandler` routes queries to `state.provider`, which still
+  points at the old `NativeProvider` backed by the old store.
+- The indexer rebuild writes exclusively into the new provider's store
+  directory. No lock is needed against the old store because they are
+  physically separate paths.
+- When `rebuildAll()` completes without error, the registry emits a
+  `providerReady` event; `index.ts` swaps `state.provider` to the new
+  provider, closes the old store, and persists the new provider key.
+- If the rebuild errors mid-way, the new store is left in a partially-built
+  state. On next load, the missing/incomplete index for the selected provider
+  triggers the re-index banner again; the flat-sentinel mechanism
+  (`embeddings.index.json.writing`) already handles mid-flush crashes.
+
+### Chunker upgrade
+
+The existing `chunk()` function is augmented (not replaced):
+
+- Frontmatter is now emitted as a distinct first chunk with id suffix
+  `#frontmatter` rather than prepended to the first body chunk. This
+  preserves the existing `minTokens` guard.
+- Body sections split on H2 boundaries (existing H1 split retained); if a
+  section exceeds `maxInputTokens`, split further on H3.
+- Code fences (`\`\`\`...`) and pipe-delimited tables detected by a
+  simple regex pass; if oversized, kept as a single chunk and logged at
+  `debug`. Never split mid-fence.
+- 1-sentence overlap: before calling `embed()`, the last sentence of the
+  previous chunk is prepended. Not stored in the chunk record; applied
+  in a new thin wrapper `wrapWithOverlap(chunker, embed)` inside the indexer.
+  The `Chunk` schema is unchanged.
+
+### Matryoshka / variable dimensions
+
+`EmbeddingProvider.dimensions` is typed as `readonly number` so a future
+provider can declare variable dimensionality without changing the interface.
+The current two new providers fix dimensions at 768. A dimension-selection
+slider is explicitly deferred and not wired in this cycle.
+
+---
+
+## Alternatives considered
+
+### Alternative A — SPEC-faithful + DLC UX (adopted)
+
+See Decision above.
+
+### Alternative B — e5-base MVP only
+
+Single multilingual provider (MIT, ~100 MB), EmbeddingGemma deferred.
+
+**Rejected:** Two-phase delivery doubles migration surface and delays the
+qualitatively differentiated model (2K context, Matryoshka).
+
+### Alternative C — Interface-first, models in a follow-up PR
+
+Structural refactor in PR 1; both providers in PR 2.
+
+**Rejected:** Produces an intermediate repo state with an unused interface.
+The DLC design isolates provider stores, removing the primary regression risk
+that motivated this split.
+
+### Alternative D — Full auto-mode with provider auto-selection
+
+`"auto"` detects dominant vault language and selects provider without user
+confirmation.
+
+**Rejected in full form:** Silent ~190 MB download violates consent. Retained
+as a non-downloading suggestion banner only.
+
+### Rejected idea: bundle e5-base in the plugin binary
+
+~100 MB added to every user's plugin download regardless of language needs.
+The Obsidian community store has size constraints; this would likely block
+listing. Rejected unconditionally.
+
+---
+
+## Consequences
+
+**Positive:**
+- Multilingual vaults (French, Italian, mixed) get meaningfully better recall.
+- Zero search blackout during provider switch (DLC UX).
+- Existing users upgrade silently; native MiniLM remains default.
+- `TransformersProvider` base class means a third provider requires no
+  new plumbing, only a `modelId` + task-prompt function.
+- Chunker upgrade benefits all three providers uniformly.
+
+**Negative:**
+- First-time EmbeddingGemma users face a 190 MB download and 20–40 min
+  index build (clearly communicated in the banner; native stays active).
+- Three providers to maintain; two index directories per user who has switched.
+- `FORMAT_VERSION` migration adds a one-time path rename on upgrade; must
+  be covered by an integration test using a real filesystem.
+- `main.ts` production wiring grows in complexity (registry, per-provider
+  store construction, DLC swap logic).
+
+**Neutral:**
+- `EmbeddingStore` interface is unchanged; the registry wraps it.
+- `Embedder` interface is unchanged; each provider constructs its own.
+- `SemanticSearchProvider` (search-side interface) is unchanged.
+- `searchVaultSmartHandler` is unchanged; it addresses `state.provider`.
+
+---
+
+## References
+
+- SPEC.md: `/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/SPEC.md`
+- BRAINSTORM.md: `/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/BRAINSTORM.md`
+- `@xenova/transformers` v2.17.2 pin rationale: `embedder.ts` file header
+- WASM CDN pin: `embedder.ts` `ORT_WASM_PATHS` constant (onnxruntime-web@1.14.0)
+- DLC concurrency: see `EmbeddingStoreRegistry` design in the implementation plan
+- Matryoshka future option: `EmbeddingProvider.dimensions` is typed `readonly number`
+  precisely to accommodate variable-dim providers without interface churn

--- a/docs/manifests/2026-05-27-multilingual-embedding-providers.manifest.yml
+++ b/docs/manifests/2026-05-27-multilingual-embedding-providers.manifest.yml
@@ -1,0 +1,64 @@
+manifest_schema_version: "1.1"
+topic: "multilingual-embedding-providers"
+topic_full_title: "Multilingual embedding providers for search_vault_smart"
+project_root: "/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools"
+mode: "greenfield"
+anonymize: true
+created_at: "2026-05-27T09:21:27+00:00"
+last_updated_at: "2026-05-27T11:04:18+00:00"
+current_step: "step_6_review"
+status: "in_progress"
+
+# Gate 0 triage result
+gate0:
+  decision: null
+  criteria_spec_adr_exist: false
+  decided_at: null
+
+# Artifacts (absolute paths, populated as steps complete)
+artifacts:
+  spec: "/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/SPEC.md"
+  brainstorm: "/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/BRAINSTORM.md"
+  adr: "/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/docs/architecture/ADR-0005-multilingual-embedding-providers.md"
+  arch: null
+  plan: "/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/docs/superpowers/plans/2026-05-27-multilingual-embedding-providers.md"
+  project_claude_md: "/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/CLAUDE.md"
+
+# HITL gates audit trail
+hitl_gates:
+  - gate: 1
+    label: "spec_review"
+    status: "pending"
+    approved_at: null
+    notes: null
+  - gate: 2
+    label: "architecture_review"
+    status: "approved"
+    approved_at: "2026-05-27T09:55:19+00:00"
+    notes: "Architecture approved; test-cmd approved (brownfield)"
+  - gate: 3
+    label: "project_memory_review"
+    status: "approved"
+    approved_at: "2026-05-27T10:06:08+00:00"
+    notes: "CLAUDE.md updated with ADR-0005 decisions"
+  - gate: 5
+    label: "review_cycle_decision"
+    status: "pending"
+    approved_at: null
+    notes: null
+
+# Session boundary tracking
+session_boundary:
+  pre_step_4_session_id: null
+  fresh_session_started_at: null
+  resumed_at: null
+
+# Failure tracking (populated only on status=failed)
+failure:
+  failed_at: null
+  failed_step: null
+  failure_reason: null
+  partial_artifacts: []
+
+# Hint for next action (UX)
+next_action: "Run /skill concept-to-code multilingual-embedding-providers to start Step 1 interview"

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
@@ -102,6 +102,11 @@ export async function searchVaultSmartHandler(
 
   const provider = state.provider;
   if (!provider.isReady()) {
+    if (state.pendingProvider) {
+      return errorResult(
+        `Semantic search is not ready: the "${state.pendingProvider}" index is still being built. Open Settings → MCP Connector → Semantic Search and click "Rebuild now" if the build has not started yet.`,
+      );
+    }
     return errorResult(
       usingSmartConnections
         ? "Semantic search is not ready: the Smart Connections plugin is not loaded or has not finished indexing this vault. Wait for Smart Connections to finish loading, or open Settings → MCP Connector → Semantic Search to switch providers."

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/port.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/port.test.ts
@@ -9,27 +9,23 @@ afterEach(async () => {
     await new Promise<void>((r) => s.close(() => r()));
 });
 
-/** Acquire n OS-assigned free ports via bind-and-release (port 0). */
-async function freePorts(n: number): Promise<number[]> {
-  const ports: number[] = [];
-  for (let i = 0; i < n; i++) {
-    ports.push(
-      await new Promise<number>((resolve, reject) => {
-        const s = createServer();
-        s.listen(0, "127.0.0.1", () => {
-          const { port } = s.address() as { port: number };
-          s.close(() => resolve(port));
-        });
-        s.on("error", reject);
-      }),
-    );
-  }
-  return ports;
+// Bind to port 0 to let the OS assign a free ephemeral port, keep the
+// server listening so the port remains occupied for the caller.
+async function occupyFreePort(): Promise<{ port: number; server: Server }> {
+  const server = createServer();
+  openServers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const port = (server.address() as { port: number }).port;
+  return { port, server };
 }
 
 describe("bindWithFallback", () => {
   test("binds to the first port in the range when free", async () => {
-    const [port] = await freePorts(1);
+    // Occupy a port, release it, then immediately use it as the range.
+    // Small TOCTOU window but acceptable for a unit test.
+    const { port, server: blocker } = await occupyFreePort();
+    await new Promise<void>((r) => blocker.close(() => r()));
+
     const server = createServer();
     openServers.push(server);
     const bound = await bindWithFallback(server, [port]);
@@ -37,34 +33,23 @@ describe("bindWithFallback", () => {
   });
 
   test("falls back to the next port when the first is taken", async () => {
-    const [port1, port2] = await freePorts(2);
-
-    const blocker = createServer();
-    openServers.push(blocker);
-    await new Promise<void>((r) =>
-      blocker.listen(port1, "127.0.0.1", () => r()),
-    );
+    const { port: p0 } = await occupyFreePort(); // p0 stays occupied
+    const { port: p1, server: blocker1 } = await occupyFreePort(); // grab p1
+    await new Promise<void>((r) => blocker1.close(() => r())); // free p1
 
     const server = createServer();
     openServers.push(server);
-    const bound = await bindWithFallback(server, [port1, port2]);
-    expect(bound).toBe(port2);
+    const bound = await bindWithFallback(server, [p0, p1]);
+    expect(bound).toBe(p1);
   });
 
   test("throws when all ports in range are taken", async () => {
-    const ports = await freePorts(3);
-    const blockers = ports.map(() => createServer());
-    openServers.push(...blockers);
-    await Promise.all(
-      blockers.map(
-        (s, i) =>
-          new Promise<void>((r) => s.listen(ports[i], "127.0.0.1", () => r())),
-      ),
-    );
+    const { port: p0 } = await occupyFreePort();
+    const { port: p1 } = await occupyFreePort();
 
     const server = createServer();
     openServers.push(server);
-    await expect(bindWithFallback(server, ports)).rejects.toThrow(
+    await expect(bindWithFallback(server, [p0, p1])).rejects.toThrow(
       /no free port/i,
     );
   });

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/port.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/port.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { createServer, type Server } from "node:http";
 import { bindWithFallback } from "./port";
-import { PORT_RANGE } from "../constants";
 
 const openServers: Server[] = [];
 
@@ -10,42 +9,62 @@ afterEach(async () => {
     await new Promise<void>((r) => s.close(() => r()));
 });
 
+/** Acquire n OS-assigned free ports via bind-and-release (port 0). */
+async function freePorts(n: number): Promise<number[]> {
+  const ports: number[] = [];
+  for (let i = 0; i < n; i++) {
+    ports.push(
+      await new Promise<number>((resolve, reject) => {
+        const s = createServer();
+        s.listen(0, "127.0.0.1", () => {
+          const { port } = s.address() as { port: number };
+          s.close(() => resolve(port));
+        });
+        s.on("error", reject);
+      }),
+    );
+  }
+  return ports;
+}
+
 describe("bindWithFallback", () => {
   test("binds to the first port in the range when free", async () => {
+    const [port] = await freePorts(1);
     const server = createServer();
     openServers.push(server);
-    const port = await bindWithFallback(server, [...PORT_RANGE]);
-    expect(port).toBe(PORT_RANGE[0]);
+    const bound = await bindWithFallback(server, [port]);
+    expect(bound).toBe(port);
   });
 
   test("falls back to the next port when the first is taken", async () => {
+    const [port1, port2] = await freePorts(2);
+
     const blocker = createServer();
     openServers.push(blocker);
     await new Promise<void>((r) =>
-      blocker.listen(PORT_RANGE[0], "127.0.0.1", () => r()),
+      blocker.listen(port1, "127.0.0.1", () => r()),
     );
 
     const server = createServer();
     openServers.push(server);
-    const port = await bindWithFallback(server, [...PORT_RANGE]);
-    expect(port).toBe(PORT_RANGE[1]);
+    const bound = await bindWithFallback(server, [port1, port2]);
+    expect(bound).toBe(port2);
   });
 
   test("throws when all ports in range are taken", async () => {
-    const blockers = PORT_RANGE.map(() => createServer());
+    const ports = await freePorts(3);
+    const blockers = ports.map(() => createServer());
     openServers.push(...blockers);
     await Promise.all(
       blockers.map(
         (s, i) =>
-          new Promise<void>((r) =>
-            s.listen(PORT_RANGE[i], "127.0.0.1", () => r()),
-          ),
+          new Promise<void>((r) => s.listen(ports[i], "127.0.0.1", () => r())),
       ),
     );
 
     const server = createServer();
     openServers.push(server);
-    await expect(bindWithFallback(server, [...PORT_RANGE])).rejects.toThrow(
+    await expect(bindWithFallback(server, ports)).rejects.toThrow(
       /no free port/i,
     );
   });

--- a/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
+++ b/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
@@ -16,26 +16,45 @@
   let rebuilding = false;
   let storeSize = 0;
   let lastError: string | null = null;
+  let pendingProvider: string | null = null;
+  let autoSuggestProvider: string | null = null;
+
+  const PROVIDER_META: Record<
+    string,
+    { label: string; size: string; seconds: string }
+  > = {
+    "embedding-gemma-300m": {
+      label: "EmbeddingGemma 300M",
+      size: "~190 MB",
+      seconds: "5–10 min",
+    },
+    "multilingual-e5-base": {
+      label: "Multilingual E5 base",
+      size: "~100 MB",
+      seconds: "3–5 min",
+    },
+  };
 
   onMount(() => {
     const state = plugin.semanticSearchState;
     if (state) {
       settings = { ...state.settings };
+      pendingProvider = state.pendingProvider ?? null;
+      autoSuggestProvider = state.autoSuggestProvider ?? null;
     }
     refreshStatus();
   });
 
   function refreshStatus() {
-    // The store size is only available once the production wiring
-    // (T15) constructs the store and exposes it on state.store. For
-    // now we read it via an `any`-typed probe so the UI is forward-
-    // compatible without forcing a type widening of state today.
     const state = plugin.semanticSearchState as
       | (typeof plugin.semanticSearchState & {
           store?: { size?: () => number };
         })
       | undefined;
     storeSize = state?.store?.size?.() ?? 0;
+    pendingProvider = plugin.semanticSearchState?.pendingProvider ?? null;
+    autoSuggestProvider =
+      plugin.semanticSearchState?.autoSuggestProvider ?? null;
   }
 
   async function persist(next: SemanticSearchSettings) {
@@ -49,6 +68,7 @@
     try {
       await applySettings(plugin, state, next);
       settings = next;
+      pendingProvider = state.pendingProvider ?? null;
     } catch (e) {
       lastError = e instanceof Error ? e.message : String(e);
     } finally {
@@ -68,15 +88,20 @@
     await persist({ ...settings, unloadModelWhenIdle: value });
   }
 
+  async function onRebuildNow() {
+    const state = plugin.semanticSearchState;
+    if (!state || !pendingProvider) return;
+    if (state.startRebuildFor) {
+      state.startRebuildFor(pendingProvider);
+    } else {
+      new Notice("Rebuild not available yet — reload Obsidian.");
+    }
+  }
+
   async function onRebuild() {
-    const state = plugin.semanticSearchState as
-      | (typeof plugin.semanticSearchState & {
-          indexer?: { rebuildAll?: () => Promise<void> };
-        })
-      | undefined;
-    const indexer = state?.indexer;
-    if (!indexer?.rebuildAll) {
-      new Notice("Indexer not available yet — wait for Phase 3 wiring.");
+    const indexer = plugin.semanticSearchState?.indexer;
+    if (!indexer) {
+      new Notice("Semantic index not available yet — reload Obsidian.");
       return;
     }
     rebuilding = true;
@@ -99,6 +124,37 @@
     Search notes by meaning, not just by keyword. Pick the embedding
     backend that matches your setup.
   </p>
+
+  {#if autoSuggestProvider}
+    {@const meta = PROVIDER_META[autoSuggestProvider]}
+    <div class="banner info">
+      Your vault appears to contain non-English content.
+      {meta?.label ?? autoSuggestProvider} may improve search quality.
+      <button
+        type="button"
+        class="banner-action"
+        on:click={() =>
+          onProviderChange(
+            autoSuggestProvider === "embedding-gemma-300m"
+              ? "embedding-gemma"
+              : "multilingual-e5-base",
+          )}
+      >
+        Switch
+      </button>
+    </div>
+  {/if}
+
+  {#if pendingProvider}
+    {@const meta = PROVIDER_META[pendingProvider]}
+    <div class="banner warn">
+      {meta?.label ?? pendingProvider} index is being built ({meta?.size ?? ""}
+      download, ~{meta?.seconds ?? ""}).
+      <button type="button" class="banner-action" on:click={onRebuildNow}>
+        Rebuild now
+      </button>
+    </div>
+  {/if}
 
   <fieldset disabled={saving}>
     <legend>Provider</legend>
@@ -138,6 +194,31 @@
       />
       Smart Connections plugin
       <span class="hint">requires the Smart Connections community plugin</span>
+    </label>
+    <label>
+      <input
+        type="radio"
+        name="ss-provider"
+        value="embedding-gemma"
+        checked={settings.provider === "embedding-gemma"}
+        on:change={() => onProviderChange("embedding-gemma")}
+      />
+      EmbeddingGemma 300M
+      <span class="hint">multilingual, 768d, 2K context (~190 MB download)</span
+      >
+    </label>
+    <label>
+      <input
+        type="radio"
+        name="ss-provider"
+        value="multilingual-e5-base"
+        checked={settings.provider === "multilingual-e5-base"}
+        on:change={() => onProviderChange("multilingual-e5-base")}
+      />
+      Multilingual E5 base
+      <span class="hint"
+        >multilingual, 768d, 512 context (~100 MB download)</span
+      >
     </label>
   </fieldset>
 
@@ -236,6 +317,27 @@
     color: var(--text-muted);
     font-size: 0.85em;
     margin-left: 0.4em;
+  }
+
+  .banner {
+    border-radius: 4px;
+    font-size: 0.9em;
+    margin-bottom: 0.75em;
+    padding: 0.5em 0.75em;
+  }
+
+  .banner.info {
+    background: var(--background-modifier-info);
+    color: var(--text-normal);
+  }
+
+  .banner.warn {
+    background: var(--background-modifier-error);
+    color: var(--text-normal);
+  }
+
+  .banner-action {
+    margin-left: 0.5em;
   }
 
   .status {

--- a/packages/obsidian-plugin/src/features/semantic-search/index.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/index.test.ts
@@ -186,6 +186,7 @@ describe("semantic-search setup — provider factory integration (T8)", () => {
         memFiles.delete(p);
         memBins.delete(p);
       },
+      async mkdir() {},
     };
     const store = createEmbeddingStore({
       adapter,
@@ -240,6 +241,7 @@ describe("semantic-search setup — provider factory integration (T8)", () => {
       async remove() {
         return undefined;
       },
+      async mkdir() {},
     };
     const store = createEmbeddingStore({
       adapter,
@@ -312,6 +314,7 @@ describe("applySettings — UI swap path (T12)", () => {
       async remove() {
         return;
       },
+      async mkdir() {},
     };
     const store = createEmbeddingStore({
       adapter,
@@ -357,5 +360,141 @@ describe("applySettings — UI swap path (T12)", () => {
     expect((getStorage().semanticSearch as { provider: string }).provider).toBe(
       "native",
     );
+  });
+
+  test("DLC: embedding-gemma with store not ready sets pendingProvider and keeps old provider", async () => {
+    const { plugin } = makePluginStub();
+    const { createEmbeddingStore } = await import("./services/store");
+    const { createEmbeddingStoreRegistry } = await import(
+      "./services/storeRegistry"
+    );
+    const adapter = {
+      async exists() {
+        return false;
+      },
+      async read(): Promise<string> {
+        throw new Error("nope");
+      },
+      async write() {
+        return;
+      },
+      async readBinary(): Promise<ArrayBuffer> {
+        throw new Error("nope");
+      },
+      async writeBinary() {
+        return;
+      },
+      async remove() {
+        return;
+      },
+      async mkdir() {},
+    };
+    const store = createEmbeddingStore({
+      adapter,
+      binPath: "/p/embeddings.bin",
+      indexPath: "/p/embeddings.index.json",
+      vectorDim: 4,
+    });
+    await store.init();
+    const embedder = {
+      embed: async () => new Float32Array(4),
+      embedBatch: async (ts: string[]) => ts.map(() => new Float32Array(4)),
+      unload: async () => undefined,
+      isLoaded: () => true,
+    };
+    const registry = createEmbeddingStoreRegistry(adapter, "/p/embeddings");
+
+    const result = await setup(plugin, {
+      factoryDeps: { plugin, embedder, store, registry },
+    });
+    if (!result.success) throw new Error(result.error);
+    result.state.registry = registry;
+    const initialProvider = result.state.provider;
+
+    await applySettings(plugin, result.state, {
+      ...result.state.settings,
+      provider: "embedding-gemma",
+    });
+
+    // Store not marked ready → pendingProvider set, live provider unchanged.
+    expect(result.state.pendingProvider).toBe("embedding-gemma-300m");
+    expect(result.state.provider).toBe(initialProvider);
+  });
+
+  test("DLC: embedding-gemma with store ready swaps provider and clears pendingProvider", async () => {
+    const { plugin } = makePluginStub();
+    const { createEmbeddingStore } = await import("./services/store");
+    const { createEmbeddingStoreRegistry } = await import(
+      "./services/storeRegistry"
+    );
+    const adapter = {
+      async exists() {
+        return false;
+      },
+      async read(): Promise<string> {
+        throw new Error("nope");
+      },
+      async write() {
+        return;
+      },
+      async readBinary(): Promise<ArrayBuffer> {
+        throw new Error("nope");
+      },
+      async writeBinary() {
+        return;
+      },
+      async remove() {
+        return;
+      },
+      async mkdir() {},
+    };
+    const store = createEmbeddingStore({
+      adapter,
+      binPath: "/p/embeddings.bin",
+      indexPath: "/p/embeddings.index.json",
+      vectorDim: 4,
+    });
+    await store.init();
+    const embedder = {
+      embed: async () => new Float32Array(4),
+      embedBatch: async (ts: string[]) => ts.map(() => new Float32Array(4)),
+      unload: async () => undefined,
+      isLoaded: () => true,
+    };
+    const registry = createEmbeddingStoreRegistry(adapter, "/p/embeddings");
+    registry.markReady("embedding-gemma-300m");
+    // Seed the gemma store so the chooser can build the NativeProvider.
+    const gemmaStore = registry.storeFor("embedding-gemma-300m", 768);
+    await gemmaStore.init();
+
+    const fakeGemmaEp = {
+      providerKey: "embedding-gemma-300m" as const,
+      dimensions: 768,
+      maxInputTokens: 2048,
+      embed: async (texts: string[]) => texts.map(() => new Float32Array(768)),
+      isAvailable: async () => true,
+      getModelSizeBytes: () => 0,
+    };
+
+    const result = await setup(plugin, {
+      factoryDeps: {
+        plugin,
+        embedder,
+        store,
+        registry,
+        embeddingProviders: { "embedding-gemma-300m": fakeGemmaEp },
+      },
+    });
+    if (!result.success) throw new Error(result.error);
+    result.state.registry = registry;
+    const initialProvider = result.state.provider;
+
+    await applySettings(plugin, result.state, {
+      ...result.state.settings,
+      provider: "embedding-gemma",
+    });
+
+    expect(result.state.pendingProvider).toBeNull();
+    expect(result.state.provider).not.toBe(initialProvider);
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/index.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/index.ts
@@ -18,6 +18,7 @@ import {
 import type { ModelDownloader } from "./services/modelDownloader";
 import type { SemanticIndexer } from "./services/indexer";
 import type { EmbeddingStore } from "./services/store";
+import type { EmbeddingStoreRegistry } from "./services/storeRegistry";
 
 export { default as FeatureSettings } from "./components/SemanticSettingsSection.svelte";
 export {
@@ -89,6 +90,25 @@ export type SemanticSearchState = {
    */
   store?: EmbeddingStore | null;
   /**
+   * Store registry for the DLC provider-swap pattern. When present,
+   * `applySettings` checks whether the new provider's store is ready
+   * before swapping the live provider.
+   */
+  registry?: EmbeddingStoreRegistry | null;
+  /**
+   * providerKey of the provider currently being built (download +
+   * index). Set when the user switches to a provider whose store is
+   * not yet ready. Cleared once `onProviderReady` fires.
+   */
+  pendingProvider?: string | null;
+  /**
+   * providerKey suggested by the auto language-detect heuristic.
+   * Non-null when the vault non-ASCII ratio exceeds the threshold and
+   * the user has not yet chosen a multilingual provider. The settings
+   * UI uses this to surface the suggestion banner.
+   */
+  autoSuggestProvider?: string | null;
+  /**
    * Lazy indexer-start hook. First call starts the indexer in
    * background (fire-and-forget); subsequent calls are no-ops. The
    * search tool handler invokes this so vault events are subscribed
@@ -96,6 +116,12 @@ export type SemanticSearchState = {
    * request on a multi-minute first build.
    */
   startIndexerIfNeeded?: () => void;
+  /**
+   * Trigger a download + full index build for a specific providerKey.
+   * Wired by production setup (Task 8); absent in tests and early lifecycle.
+   * The settings UI calls this from the rebuild banner's "Rebuild now" button.
+   */
+  startRebuildFor?: ((providerKey: string) => void) | null;
   teardown: () => Promise<void>;
 };
 
@@ -211,6 +237,9 @@ export async function setup(
       downloader: null,
       indexer: null,
       store: opts.factoryDeps?.store ?? null,
+      registry: null,
+      pendingProvider: null,
+      autoSuggestProvider: null,
       startIndexerIfNeeded: undefined, // production wiring overrides this
       teardown: async () => {
         // production wiring overrides this to flush+close the
@@ -229,12 +258,27 @@ export async function teardown(state: SemanticSearchState): Promise<void> {
 }
 
 /**
+ * Maps provider setting values that require a store build to their
+ * providerKey. Values absent from this map (native, smart-connections,
+ * auto) are always immediately swappable.
+ */
+const DOWNLOADABLE_PROVIDER_KEYS: Partial<Record<string, string>> = {
+  "embedding-gemma": "embedding-gemma-300m",
+  "multilingual-e5-base": "multilingual-e5-base",
+};
+
+/**
  * Persist a new SemanticSearchSettings value and swap the live
  * provider via the chooser closure when one is available.
  *
- * Used by the settings UI (T12) on tri-state / mode / unload-toggle
- * change. Held under the feature mutex so a rapid double-toggle
- * cannot land out-of-order writes against `data.json`.
+ * For providers that require a store build (embedding-gemma,
+ * multilingual-e5-base), if the store is not yet marked ready in the
+ * registry, the live provider is NOT swapped — the old results stay
+ * available while the index builds — and `state.pendingProvider` is
+ * set so the UI can show the rebuild banner.
+ *
+ * Held under the feature mutex so a rapid double-toggle cannot land
+ * out-of-order writes against `data.json`.
  */
 export async function applySettings(
   plugin: McpToolsPlugin,
@@ -247,6 +291,15 @@ export async function applySettings(
     await plugin.saveData(data);
   });
   state.settings = next;
+
+  const pendingKey = DOWNLOADABLE_PROVIDER_KEYS[next.provider];
+  if (pendingKey && state.registry && !state.registry.isReady(pendingKey)) {
+    // Store not yet built — surface the rebuild banner, keep old provider.
+    state.pendingProvider = pendingKey;
+    return;
+  }
+
+  state.pendingProvider = null;
   if (state.chooser) {
     state.provider = state.chooser(next);
   }

--- a/packages/obsidian-plugin/src/features/semantic-search/integration.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/integration.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./services/indexer";
 import { createNativeProvider } from "./services/nativeProvider";
 import type { Embedder } from "./services/embedder";
+import { createNativeEmbeddingProvider } from "./services/nativeEmbeddingProvider";
 
 const VOCAB = [
   "apple",
@@ -105,6 +106,7 @@ function memVaultAdapter(): VaultAdapter {
       f.delete(p);
       b.delete(p);
     },
+    async mkdir() {},
   };
 }
 
@@ -174,7 +176,7 @@ describe("Phase 3 end-to-end integration", () => {
     const indexer = createLiveIndexer({
       vault,
       chunker: integrationChunker,
-      embedder,
+      embedder: createNativeEmbeddingProvider(embedder),
       store,
       debounceMs: 30,
     });
@@ -215,7 +217,7 @@ describe("Phase 3 end-to-end integration", () => {
     const indexer = createLiveIndexer({
       vault,
       chunker: integrationChunker,
-      embedder,
+      embedder: createNativeEmbeddingProvider(embedder),
       store,
       debounceMs: 30,
     });
@@ -265,7 +267,7 @@ describe("Phase 3 end-to-end integration", () => {
     const indexer = createLiveIndexer({
       vault,
       chunker: integrationChunker,
-      embedder,
+      embedder: createNativeEmbeddingProvider(embedder),
       store,
       debounceMs: 30,
     });
@@ -305,7 +307,7 @@ describe("Phase 3 end-to-end integration", () => {
     const indexer1 = createLiveIndexer({
       vault,
       chunker: integrationChunker,
-      embedder,
+      embedder: createNativeEmbeddingProvider(embedder),
       store: store1,
       debounceMs: 30,
     });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/chunker.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/chunker.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { chunk, countTokens, hashChunk } from "./chunker";
+import {
+  chunk,
+  countTokens,
+  hashChunk,
+  wrapChunkerWithOverlap,
+} from "./chunker";
 
 const lorem = (words: number): string => {
   const base = "lorem ipsum dolor sit amet consectetur adipiscing elit ";
@@ -22,7 +27,7 @@ describe("chunker", () => {
     expect(chunks[0]?.contentHash).toMatch(/^[0-9a-f]{16}$/);
   });
 
-  test("H1 + multiple H2 → one chunk per section, frontmatter merged with first", async () => {
+  test("H1 + multiple H2 → one chunk per section, small frontmatter dropped", async () => {
     const content = [
       "---",
       "tags: [research, ai]",
@@ -43,18 +48,18 @@ describe("chunker", () => {
 
     const chunks = await chunk(content);
 
+    // Frontmatter has ~5 tokens (below minTokens=20) → dropped, not merged.
     expect(chunks).toHaveLength(3);
     expect(chunks[0]?.heading).toBe("Top");
     expect(chunks[1]?.heading).toBe("Section A");
     expect(chunks[2]?.heading).toBe("Section B");
 
-    // Frontmatter merged into the first chunk only.
-    expect(chunks[0]?.text).toContain("tags: [research, ai]");
-    expect(chunks[0]?.text).toContain("title: Notes");
+    // No body chunk carries frontmatter.
+    expect(chunks[0]?.text).not.toContain("tags:");
     expect(chunks[1]?.text).not.toContain("tags:");
     expect(chunks[2]?.text).not.toContain("tags:");
 
-    // IDs ordinal across the file.
+    // IDs ordinal across body chunks.
     expect(chunks.map((c) => c.id)).toEqual(["0", "1", "2"]);
   });
 
@@ -135,11 +140,12 @@ describe("chunker", () => {
     expect(chunks).toHaveLength(0);
   });
 
-  test("frontmatter-only large enough → single chunk when no body", async () => {
+  test("frontmatter-only large enough → single #frontmatter chunk when no body", async () => {
     const fm = lorem(40);
     const content = `---\nnotes: |\n  ${fm}\n---\n`;
     const chunks = await chunk(content);
     expect(chunks.length).toBeGreaterThanOrEqual(1);
+    expect(chunks[0]?.id).toBe("#frontmatter");
     expect(chunks[0]?.text).toContain("notes:");
   });
 
@@ -162,5 +168,121 @@ describe("chunker", () => {
     expect(chunks).toHaveLength(2);
     expect(chunks[0]?.offset).toBe(0);
     expect(chunks[1]?.offset).toBeGreaterThan(0);
+  });
+
+  // New: frontmatter large enough to meet minTokens
+  test("frontmatter large enough emitted as #frontmatter chunk before body", async () => {
+    const fm = lorem(30);
+    const content = [
+      "---",
+      `notes: ${fm}`,
+      "---",
+      "# Body",
+      "",
+      lorem(30),
+    ].join("\n");
+
+    const chunks = await chunk(content);
+
+    expect(chunks[0]?.id).toBe("#frontmatter");
+    expect(chunks[0]?.heading).toBeNull();
+    expect(chunks[0]?.text).toContain("notes:");
+
+    // Body chunk does not carry frontmatter.
+    expect(chunks[1]?.id).toBe("0");
+    expect(chunks[1]?.text).not.toContain("notes:");
+
+    expect(chunks.map((c) => c.id)).toEqual(["#frontmatter", "0"]);
+  });
+
+  // New: H3 sub-split
+  test("H3 sub-split fires when H2 section exceeds maxTokens", async () => {
+    const content = [
+      "## Parent",
+      "",
+      lorem(30),
+      "",
+      "### Sub A",
+      "",
+      lorem(300),
+      "",
+      "### Sub B",
+      "",
+      lorem(300),
+    ].join("\n");
+
+    // Section ≈ 630 tokens (30 + 300 + 300 + headings) > 512 default maxTokens.
+    const chunks = await chunk(content);
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks.map((c) => c.heading)).toEqual(["Parent", "Sub A", "Sub B"]);
+    // Each chunk is within the token limit.
+    for (const c of chunks) {
+      expect(countTokens(c.text)).toBeLessThanOrEqual(514);
+    }
+  });
+
+  // New: code fence atomic
+  test("oversized code fence kept as single chunk", async () => {
+    // 150 lines × ~4 tokens each ≈ 600 tokens > default maxTokens 512.
+    const codeLines = Array.from(
+      { length: 150 },
+      (_, i) => `const x${i} = ${i};`,
+    ).join("\n");
+    const content = `## Section\n\n\`\`\`typescript\n${codeLines}\n\`\`\``;
+
+    const chunks = await chunk(content, { maxTokens: 512 });
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.text).toContain("```typescript");
+    expect(chunks[0]?.heading).toBe("Section");
+  });
+
+  // New: overlap wrapper
+  test("wrapChunkerWithOverlap prepends last sentence of previous chunk", async () => {
+    // Section body must exceed minTokens (20); lorem(20) + 2 sentences = ~29 tokens.
+    const content = [
+      "# First",
+      "",
+      lorem(20) + " Opening sentence. This is the final sentence.",
+      "",
+      "# Second",
+      "",
+      lorem(30),
+    ].join("\n");
+
+    const wrapped = wrapChunkerWithOverlap(chunk);
+    const chunks = await wrapped(content);
+
+    // No frontmatter — two body chunks.
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]?.id).toBe("0");
+    expect(chunks[1]?.id).toBe("1");
+    // Second chunk starts with the last sentence of the first.
+    expect(chunks[1]?.text.startsWith("This is the final sentence.")).toBe(
+      true,
+    );
+    // First chunk is unchanged.
+    expect(chunks[0]?.text.startsWith("# First")).toBe(true);
+  });
+
+  test("wrapChunkerWithOverlap: #frontmatter chunk not used as overlap source", async () => {
+    const fm = lorem(30);
+    const content = [
+      "---",
+      `notes: ${fm}`,
+      "---",
+      "# Body",
+      "",
+      lorem(30),
+    ].join("\n");
+
+    const wrapped = wrapChunkerWithOverlap(chunk);
+    const chunks = await wrapped(content);
+
+    // #frontmatter is chunks[0]; body chunk is chunks[1].
+    expect(chunks[0]?.id).toBe("#frontmatter");
+    // Body chunk should NOT have frontmatter overlap prepended.
+    expect(chunks[1]?.text.startsWith("# Body")).toBe(true);
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/chunker.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/chunker.ts
@@ -1,19 +1,17 @@
 /**
  * Heading-section chunker for vault markdown.
  *
- * Splits content on H1/H2 boundaries (H3+ stay inside their parent
- * section). Sections that exceed `maxTokens` (default 512) are split
- * further with a token-based sliding window using `overlapTokens`
- * (default 64). Sections shorter than `minTokens` (default 20) are
- * skipped — too little signal to embed usefully and too easy to
- * dominate cosine similarity with shared boilerplate.
+ * Splits content on H1/H2 boundaries. H3+ stay inside their parent
+ * section unless the section exceeds `maxTokens`, in which case H3
+ * sub-sections are split before falling back to a sliding window.
  *
- * Frontmatter (`---` block at the very top of the file) is concatenated
- * to the first non-skipped chunk, so file-level metadata stays
- * searchable even when it lives outside the body prose.
+ * Frontmatter is emitted as a dedicated chunk with id `"#frontmatter"`
+ * so file-level metadata is searchable independently of body prose.
+ * Small frontmatter (below `minTokens`) is silently dropped.
  *
- * Inline tags (`#foo`), wikilinks (`[[link]]`), and code fences are
- * preserved verbatim — they are signal for embedding.
+ * Code fences are atomic: if a section contains a code fence whose
+ * token count exceeds `maxTokens`, the entire section is kept as a
+ * single chunk rather than split mid-fence.
  *
  * Token counting is approximate: `text.split(/\s+/)`. The exact MiniLM
  * BPE tokenizer would be more precise but requires loading the model
@@ -21,6 +19,8 @@
  * magnitude. For the 512/64 window choices the approximation is well
  * within tolerance.
  */
+
+import { logger } from "$/shared/logger";
 
 export type ChunkOpts = {
   maxTokens?: number;
@@ -35,6 +35,9 @@ export type Chunk = {
   offset: number;
   contentHash: string;
 };
+
+/** Signature of the chunk() function, used by the indexer and overlap wrapper. */
+export type ChunkerFn = (content: string) => Promise<Chunk[]>;
 
 const DEFAULT_MAX_TOKENS = 512;
 const DEFAULT_OVERLAP_TOKENS = 64;
@@ -105,19 +108,15 @@ function splitByHeadings(body: string, baseOffset: number): Section[] {
   for (let i = 0; i < lines.length; i += 2) {
     const line = lines[i] ?? "";
     const sep = lines[i + 1] ?? "";
+    const trimmedLine = line.trimEnd();
 
-    const h1 = /^(# )(.+)$/.exec(line);
-    const h2 = /^(## )(.+)$/.exec(line);
-    const heading = h1?.[2] ?? h2?.[2] ?? null;
+    const h1 = trimmedLine.match(/^# (.+)$/);
+    const h2 = trimmedLine.match(/^## (.+)$/);
+    const heading = h1?.[1] ?? h2?.[1] ?? null;
 
     if (heading !== null) {
-      // Close current section and open a new one.
       if (current.text.length > 0) sections.push(current);
-      current = {
-        heading,
-        text: line + sep,
-        offset: cursor,
-      };
+      current = { heading, text: line + sep, offset: cursor };
     } else {
       current.text += line + sep;
     }
@@ -126,6 +125,66 @@ function splitByHeadings(body: string, baseOffset: number): Section[] {
 
   if (current.text.length > 0) sections.push(current);
   return sections;
+}
+
+/**
+ * Split a section further on `### ` boundaries. Returns the original
+ * section unchanged (as a single-element array) when no H3 headings
+ * are found, so the caller can distinguish "no split" from "split".
+ */
+function splitSectionByH3(section: Section): Section[] {
+  const lines = section.text.split(/(\r?\n)/);
+  const sub: Section[] = [];
+  let current: Section = {
+    heading: section.heading,
+    text: "",
+    offset: section.offset,
+  };
+  let cursor = section.offset;
+
+  for (let i = 0; i < lines.length; i += 2) {
+    const line = lines[i] ?? "";
+    const sep = lines[i + 1] ?? "";
+    const trimmedLine = line.trimEnd();
+
+    const h3 = trimmedLine.match(/^### (.+)$/);
+    if (h3 !== null) {
+      if (current.text.length > 0) sub.push(current);
+      current = { heading: h3[1] ?? null, text: line + sep, offset: cursor };
+    } else {
+      current.text += line + sep;
+    }
+    cursor += line.length + sep.length;
+  }
+
+  if (current.text.length > 0) sub.push(current);
+  return sub.length > 1 ? sub : [section];
+}
+
+/**
+ * Returns true if the text contains a code fence whose own token count
+ * exceeds `maxTokens` — signals that the section should be kept atomic
+ * rather than split mid-fence.
+ */
+function hasOversizedCodeFence(text: string, maxTokens: number): boolean {
+  const lines = text.split("\n");
+  let inFence = false;
+  let fenceStart = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.startsWith("```")) {
+      if (!inFence) {
+        inFence = true;
+        fenceStart = i;
+      } else {
+        const fenceText = lines.slice(fenceStart, i + 1).join("\n");
+        if (countTokens(fenceText) > maxTokens) return true;
+        inFence = false;
+      }
+    }
+  }
+  return false;
 }
 
 /**
@@ -180,10 +239,143 @@ function slidingWindows(
 }
 
 /**
+ * Emit chunks for one section into `out`. Tries H3 sub-split first
+ * for oversized sections; falls back to sliding windows. Code fences
+ * that alone exceed `maxTokens` are kept atomic.
+ */
+async function emitSectionChunks(
+  section: Section,
+  maxTokens: number,
+  overlapTokens: number,
+  minTokens: number,
+  out: Chunk[],
+): Promise<void> {
+  const text = section.text.trimEnd();
+  const tokenCount = countTokens(text);
+  if (tokenCount < minTokens) return;
+
+  if (tokenCount <= maxTokens) {
+    out.push({
+      id: String(out.length),
+      text,
+      heading: section.heading,
+      offset: section.offset,
+      contentHash: await hashChunk(text),
+    });
+    return;
+  }
+
+  // Oversized: check for atomic code fence before splitting.
+  if (hasOversizedCodeFence(text, maxTokens)) {
+    logger.debug("embedding chunker: oversized code fence kept atomic", {
+      heading: section.heading,
+      tokens: tokenCount,
+    });
+    out.push({
+      id: String(out.length),
+      text,
+      heading: section.heading,
+      offset: section.offset,
+      contentHash: await hashChunk(text),
+    });
+    return;
+  }
+
+  // Try H3 sub-split before sliding window.
+  const subSections = splitSectionByH3(section);
+  if (subSections.length > 1) {
+    for (const sub of subSections) {
+      const subText = sub.text.trimEnd();
+      const subTokens = countTokens(subText);
+      if (subTokens < minTokens) continue;
+      if (subTokens <= maxTokens) {
+        out.push({
+          id: String(out.length),
+          text: subText,
+          heading: sub.heading,
+          offset: sub.offset,
+          contentHash: await hashChunk(subText),
+        });
+      } else {
+        const windows = slidingWindows(
+          subText,
+          sub.heading,
+          maxTokens,
+          overlapTokens,
+        );
+        for (const w of windows) {
+          out.push({
+            id: String(out.length),
+            text: w,
+            heading: sub.heading,
+            offset: sub.offset,
+            contentHash: await hashChunk(w),
+          });
+        }
+      }
+    }
+    return;
+  }
+
+  // No H3 sub-sections — sliding window.
+  const windows = slidingWindows(
+    text,
+    section.heading,
+    maxTokens,
+    overlapTokens,
+  );
+  for (const w of windows) {
+    out.push({
+      id: String(out.length),
+      text: w,
+      heading: section.heading,
+      offset: section.offset,
+      contentHash: await hashChunk(w),
+    });
+  }
+}
+
+/**
+ * Extracts the last sentence from text using punctuation-based split.
+ * Returns the entire trimmed text when no sentence boundary is found; returns `""` for empty input.
+ */
+function extractLastSentence(text: string): string {
+  const trimmed = text.trimEnd();
+  const parts = trimmed.split(/(?<=[.!?])\s+/);
+  return parts[parts.length - 1]?.trim() ?? "";
+}
+
+/**
+ * Wraps a chunker to prepend the last sentence of the previous chunk's
+ * text to each subsequent chunk before it reaches the embedder. The
+ * stored `Chunk.text` and `contentHash` are unchanged — only the text
+ * passed to `embed()` is enriched with one sentence of overlap.
+ *
+ * `#frontmatter` chunks are skipped as overlap sources since metadata
+ * context does not carry meaningfully into body prose.
+ */
+export function wrapChunkerWithOverlap(chunker: ChunkerFn): ChunkerFn {
+  return async (content: string): Promise<Chunk[]> => {
+    const chunks = await chunker(content);
+    return chunks.map((c, i) => {
+      if (i === 0) return c;
+      const prev = chunks[i - 1]!;
+      if (prev.id === "#frontmatter") return c;
+      const overlap = extractLastSentence(prev.text);
+      if (!overlap) return c;
+      return { ...c, text: overlap + "\n" + c.text };
+    });
+  };
+}
+
+/**
  * Main chunker. Accepts the full markdown content of a file and
  * returns the chunks ready for embedding. Pure function: no I/O, no
- * Obsidian API access, no globals. The caller (T9 indexer) supplies
+ * Obsidian API access, no globals. The caller (indexer) supplies
  * the file path and composes the persistent chunkId.
+ *
+ * Frontmatter (if large enough) is emitted first as a `#frontmatter`
+ * chunk. Body chunks are numbered ordinally starting from `"0"`.
  */
 export async function chunk(
   content: string,
@@ -194,62 +386,33 @@ export async function chunk(
   const minTokens = opts.minTokens ?? DEFAULT_MIN_TOKENS;
 
   const { frontmatter, body, bodyOffset } = extractFrontmatter(content);
-  const sections = splitByHeadings(body, bodyOffset);
 
-  const chunks: Chunk[] = [];
-  let mergedFrontmatter = frontmatter !== null;
-
-  for (const section of sections) {
-    let text = section.text.trimEnd();
-    if (mergedFrontmatter && frontmatter !== null) {
-      text = frontmatter.trim() + "\n\n" + text;
-      mergedFrontmatter = false;
-    }
-    const tokenCount = countTokens(text);
-    if (tokenCount < minTokens) continue;
-
-    if (tokenCount <= maxTokens) {
-      chunks.push({
-        id: String(chunks.length),
-        text,
-        heading: section.heading,
-        offset: section.offset,
-        contentHash: await hashChunk(text),
-      });
-    } else {
-      const windows = slidingWindows(
-        text,
-        section.heading,
-        maxTokens,
-        overlapTokens,
-      );
-      for (const w of windows) {
-        chunks.push({
-          id: String(chunks.length),
-          text: w,
-          heading: section.heading,
-          offset: section.offset,
-          contentHash: await hashChunk(w),
-        });
-      }
-    }
-  }
-
-  // If frontmatter never landed (every section was below minTokens),
-  // emit it as a standalone chunk if the frontmatter itself meets the
-  // size threshold. Otherwise the file is effectively skipped.
-  if (mergedFrontmatter && frontmatter !== null) {
+  let fmChunk: Chunk | null = null;
+  if (frontmatter !== null) {
     const fmText = frontmatter.trim();
     if (countTokens(fmText) >= minTokens) {
-      chunks.push({
-        id: String(chunks.length),
+      fmChunk = {
+        id: "#frontmatter",
         text: fmText,
         heading: null,
         offset: 0,
         contentHash: await hashChunk(fmText),
-      });
+      };
     }
   }
 
-  return chunks;
+  const sections = splitByHeadings(body, bodyOffset);
+  const bodyChunks: Chunk[] = [];
+
+  for (const section of sections) {
+    await emitSectionChunks(
+      section,
+      maxTokens,
+      overlapTokens,
+      minTokens,
+      bodyChunks,
+    );
+  }
+
+  return fmChunk ? [fmChunk, ...bodyChunks] : bodyChunks;
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
@@ -185,10 +185,9 @@ export function createEmbedder(opts: EmbedderOpts): Embedder {
  * Transformers.js's image pipelines pull in) is never touched in the
  * text-only path we actually use.
  */
-// Static import: bundles Transformers.js into main.js. Static beats
-// dynamic in Obsidian/Electron because the plugin runtime does not
-// resolve node_modules — a bundled require() works, a runtime
-// `import(...)` would 404.
+// Static import required: Obsidian's eval-based plugin loader cannot
+// resolve node_modules at runtime; a bundled require() works, a
+// dynamic `import(...)` would 404.
 //
 // `sharp` is stubbed at bundle time (image pipelines are unreachable in
 // our text-only path). `onnxruntime-node` is REDIRECTED to
@@ -201,55 +200,8 @@ export function createEmbedder(opts: EmbedderOpts): Embedder {
 // @huggingface/transformers v4 was tested 2026-04-26 in a spike; it
 // uses `import.meta.url` at runtime which Obsidian's eval-based plugin
 // loader cannot parse. Reverting to v2 keeps the plugin loadable.
-import {
-  pipeline as _xenovaPipeline,
-  env as _xenovaEnv,
-} from "@xenova/transformers";
-
-// One-shot ONNX runtime configuration applied the first time
-// realPipelineFactory is called. Reasons for each setting:
-//
-// * `env.backends.onnx.wasm.wasmPaths`: onnxruntime-web's default
-//   wasm-blob loader resolves siblings via `fetch(new URL(...,
-//   import.meta.url))`. Bun's CJS bundle does not preserve
-//   `import.meta.url` meaningfully, so the loader 404s. Pointing at
-//   the matching CDN sidesteps the whole `import.meta.url` dance.
-//   Pinned to 1.14.0 to match @xenova/transformers@2.17.2's bundled
-//   onnxruntime-web; updating the lib also requires updating this URL
-//   or the WASM ABI may not match the JS glue.
-// * `env.backends.onnx.wasm.numThreads = 1`: Electron's renderer does
-//   not have COOP/COEP cross-origin isolation headers, so
-//   SharedArrayBuffer is restricted. Single-threaded WASM avoids the
-//   worker spin-up path entirely.
-// * `env.allowLocalModels = false`: always use the remote (Hugging
-//   Face Hub), so the lazy first-call download flow drives the
-//   ModelDownloader UI.
-// * `env.useBrowserCache = true`: persist the downloaded model to the
-//   Cache API so subsequent loads are fast.
-const ORT_WASM_PATHS =
-  "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.14.0/dist/";
-
-let _envConfigured = false;
-function configureEnv(): void {
-  if (_envConfigured) return;
-  _envConfigured = true;
-  const e = _xenovaEnv as unknown as {
-    backends?: {
-      onnx?: {
-        wasm?: { numThreads?: number; simd?: boolean; wasmPaths?: string };
-      };
-    };
-    allowLocalModels?: boolean;
-    useBrowserCache?: boolean;
-  };
-  if (e.backends?.onnx?.wasm) {
-    e.backends.onnx.wasm.wasmPaths = ORT_WASM_PATHS;
-    e.backends.onnx.wasm.numThreads = 1;
-    e.backends.onnx.wasm.simd = true;
-  }
-  e.allowLocalModels = false;
-  e.useBrowserCache = true;
-}
+import { pipeline as _xenovaPipeline } from "@xenova/transformers";
+import { configureEnv } from "./onnxEnv";
 
 export async function realPipelineFactory(
   model: string,

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
@@ -1,0 +1,20 @@
+import type { EmbeddingProvider } from "../types";
+import type { PipelineFactory } from "./embedder";
+import { createTransformersProvider } from "./transformersProvider";
+
+export function createEmbeddingGemmaProvider(
+  pipelineFactory: PipelineFactory,
+): EmbeddingProvider {
+  return createTransformersProvider({
+    modelId: "onnx-community/embeddinggemma-300m-ONNX",
+    providerKey: "embedding-gemma-300m",
+    dimensions: 768,
+    maxInputTokens: 2048,
+    modelSizeBytes: 190_000_000,
+    taskPrompt: (text, role) =>
+      role === "query"
+        ? "task: search result | query: " + text
+        : "title: none | text: " + text,
+    pipelineFactory,
+  });
+}

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
@@ -5,7 +5,7 @@ import {
   type VaultEvent,
   type VaultLike,
 } from "./indexer";
-import type { Embedder } from "./embedder";
+import type { EmbeddingProvider } from "../types";
 import {
   createEmbeddingStore,
   type EmbeddingRecord,
@@ -74,6 +74,7 @@ function memAdapter(): VaultAdapter {
       f.delete(p);
       b.delete(p);
     },
+    async mkdir() {},
   };
 }
 
@@ -109,25 +110,25 @@ async function fakeChunker(content: string): Promise<Chunk[]> {
   }));
 }
 
-function fakeEmbedder(): {
-  embedder: Embedder;
+function fakeEmbeddingProvider(): {
+  embedder: EmbeddingProvider;
   embeds: () => string[];
 } {
   const calls: string[] = [];
-  const embedder: Embedder = {
-    embed: async (text) => {
-      calls.push(text);
-      const v = new Float32Array(DIM);
-      v[0] = text.length;
-      return v;
+  const embedder: EmbeddingProvider = {
+    providerKey: "test-provider",
+    dimensions: DIM,
+    maxInputTokens: 512,
+    embed: async (texts, _role) => {
+      for (const text of texts) calls.push(text);
+      return texts.map((text) => {
+        const v = new Float32Array(DIM);
+        v[0] = text.length;
+        return v;
+      });
     },
-    embedBatch: async (texts) => {
-      const out: Float32Array[] = [];
-      for (const t of texts) out.push(await embedder.embed(t));
-      return out;
-    },
-    unload: async () => undefined,
-    isLoaded: () => true,
+    isAvailable: async () => true,
+    getModelSizeBytes: () => 0,
   };
   return { embedder, embeds: () => [...calls] };
 }
@@ -152,7 +153,7 @@ describe("live indexer", () => {
       "a.md": "alpha",
       "b.md": "bravo---CHUNK---bravo two",
     });
-    const { embedder, embeds } = fakeEmbedder();
+    const { embedder, embeds } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -165,7 +166,7 @@ describe("live indexer", () => {
 
     expect(store.size()).toBe(3); // 1 + 2
     expect(embeds()).toEqual(
-      expect.arrayContaining(["alpha", "bravo", "bravo two"]),
+      expect.arrayContaining(["alpha", "bravo", "bravo\nbravo two"]),
     );
     const recs = await collect(store);
     expect(new Set(recs.map((r) => r.filePath))).toEqual(
@@ -177,7 +178,7 @@ describe("live indexer", () => {
     const { vault, files, emit } = makeVault({
       "f.md": "one---CHUNK---two---CHUNK---three",
     });
-    const { embedder, embeds } = fakeEmbedder();
+    const { embedder, embeds } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -187,7 +188,7 @@ describe("live indexer", () => {
     });
     await indexer.start();
 
-    expect(embeds()).toEqual(["one", "two", "three"]);
+    expect(embeds()).toEqual(["one", "one\ntwo", "two\nthree"]);
 
     // Edit: replace chunk 2 only.
     files.set("f.md", "one---CHUNK---TWO!---CHUNK---three");
@@ -195,8 +196,9 @@ describe("live indexer", () => {
     await indexer.flush();
 
     // Only "TWO!" is new — "one" and "three" reuse their existing
-    // vectors via contentHash match.
-    expect(embeds()).toEqual(["one", "two", "three", "TWO!"]);
+    // vectors via contentHash match. Overlap prepends the last sentence
+    // of the previous chunk's original text.
+    expect(embeds()).toEqual(["one", "one\ntwo", "two\nthree", "one\nTWO!"]);
     expect(store.size()).toBe(3);
 
     await indexer.stop();
@@ -204,7 +206,7 @@ describe("live indexer", () => {
 
   test("create event embeds new chunks", async () => {
     const { vault, files, emit } = makeVault({});
-    const { embedder, embeds } = fakeEmbedder();
+    const { embedder, embeds } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -231,7 +233,7 @@ describe("live indexer", () => {
       "doomed.md": "a---CHUNK---b---CHUNK---c",
       "kept.md": "x",
     });
-    const { embedder } = fakeEmbedder();
+    const { embedder } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -258,7 +260,7 @@ describe("live indexer", () => {
     const { vault, files, emit } = makeVault({
       "f.md": "v1",
     });
-    const { embedder, embeds } = fakeEmbedder();
+    const { embedder, embeds } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -292,7 +294,7 @@ describe("live indexer", () => {
 
   test("stop unsubscribes from vault events (no further processing)", async () => {
     const { vault, files, emit } = makeVault({});
-    const { embedder, embeds } = fakeEmbedder();
+    const { embedder, embeds } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -317,7 +319,7 @@ describe("live indexer", () => {
       "a.md": "one",
       "b.md": "two",
     });
-    const { embedder, embeds } = fakeEmbedder();
+    const { embedder, embeds } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -344,7 +346,7 @@ describe("live indexer", () => {
     const { vault, files, emit } = makeVault({
       "f.md": "content",
     });
-    const { embedder } = fakeEmbedder();
+    const { embedder } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -367,7 +369,7 @@ describe("live indexer", () => {
     const { vault, files, emit } = makeVault({
       "f.md": "one---CHUNK---two",
     });
-    const { embedder } = fakeEmbedder();
+    const { embedder } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -401,11 +403,59 @@ describe("live indexer", () => {
     await indexer.stop();
   });
 
+  test("rebuildAll skips processing when isAvailable returns false", async () => {
+    const { vault } = makeVault({ "a.md": "content" });
+    const embeds: string[] = [];
+    const unavailableProvider: EmbeddingProvider = {
+      providerKey: "unavailable",
+      dimensions: DIM,
+      maxInputTokens: 512,
+      embed: async (texts, _role) => {
+        for (const t of texts) embeds.push(t);
+        return texts.map(() => new Float32Array(DIM));
+      },
+      isAvailable: async () => false,
+      getModelSizeBytes: () => 0,
+    };
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder: unavailableProvider,
+      store,
+      debounceMs: 30,
+    });
+    await indexer.start();
+    await indexer.stop();
+
+    expect(embeds).toEqual([]);
+    expect(store.size()).toBe(0);
+  });
+
+  test("overlap context is prepended to consecutive chunk embed inputs", async () => {
+    const { vault } = makeVault({
+      "f.md": "first---CHUNK---second---CHUNK---third",
+    });
+    const { embedder, embeds } = fakeEmbeddingProvider();
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 30,
+    });
+    await indexer.start();
+    await indexer.stop();
+
+    // No punctuation → extractLastSentence returns the full previous text.
+    // chunk[1] gets "first\nsecond"; chunk[2] gets "second\nthird".
+    expect(embeds()).toEqual(["first", "first\nsecond", "second\nthird"]);
+  });
+
   test("read error while path is absent from getMarkdownFiles: genuine deletion", async () => {
     const { vault, files, emit } = makeVault({
       "f.md": "one---CHUNK---two",
     });
-    const { embedder } = fakeEmbedder();
+    const { embedder } = fakeEmbeddingProvider();
     const indexer = createLiveIndexer({
       vault,
       chunker: fakeChunker,
@@ -482,6 +532,7 @@ function countingAdapter(): {
       f.delete(p);
       b.delete(p);
     },
+    async mkdir() {},
   };
   return { adapter, writeBinaryCount: () => writeBinary };
 }
@@ -493,7 +544,7 @@ describe("low-power indexer", () => {
       "a.md": { content: "alpha", mtime: 100 },
       "b.md": { content: "bravo", mtime: 200 },
     });
-    const { embedder, embeds } = fakeEmbedder();
+    const { embedder, embeds } = fakeEmbeddingProvider();
     const indexer = createLowPowerIndexer({
       vault,
       chunker: fakeChunker,
@@ -512,7 +563,7 @@ describe("low-power indexer", () => {
     const { vault, files } = makeMtimeVault({
       "a.md": { content: "alpha", mtime: 100 },
     });
-    const { embedder, embeds } = fakeEmbedder();
+    const { embedder, embeds } = fakeEmbeddingProvider();
     const indexer = createLowPowerIndexer({
       vault,
       chunker: fakeChunker,
@@ -541,7 +592,7 @@ describe("low-power indexer", () => {
       "doomed.md": { content: "go away", mtime: 100 },
       "kept.md": { content: "stays", mtime: 100 },
     });
-    const { embedder } = fakeEmbedder();
+    const { embedder } = fakeEmbeddingProvider();
     const indexer = createLowPowerIndexer({
       vault,
       chunker: fakeChunker,
@@ -577,7 +628,7 @@ describe("low-power indexer", () => {
       "b.md": { content: "bravo", mtime: 100 },
       "c.md": { content: "charlie", mtime: 100 },
     });
-    const { embedder } = fakeEmbedder();
+    const { embedder } = fakeEmbeddingProvider();
     const indexer = createLowPowerIndexer({
       vault,
       chunker: fakeChunker,
@@ -598,7 +649,7 @@ describe("low-power indexer", () => {
     const { vault } = makeMtimeVault({
       "a.md": { content: "alpha", mtime: 100 },
     });
-    const { embedder, embeds } = fakeEmbedder();
+    const { embedder, embeds } = fakeEmbeddingProvider();
     const indexer = createLowPowerIndexer({
       vault,
       chunker: fakeChunker,
@@ -623,7 +674,7 @@ describe("low-power indexer", () => {
     const { vault } = makeMtimeVault({
       "a.md": { content: "alpha", mtime: 100 },
     });
-    const { embedder } = fakeEmbedder();
+    const { embedder } = fakeEmbeddingProvider();
     const indexer = createLowPowerIndexer({
       vault,
       chunker: fakeChunker,

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -22,11 +22,12 @@
  */
 
 import { logger } from "$/shared/logger";
-import type { Chunk } from "./chunker";
-import type { Embedder } from "./embedder";
+import type { Chunk, ChunkerFn } from "./chunker";
+import { wrapChunkerWithOverlap } from "./chunker";
 import type { EmbeddingRecord, EmbeddingStore } from "./store";
+import type { EmbeddingProvider } from "../types";
 
-export type ChunkerFn = (content: string) => Promise<Chunk[]>;
+export type { ChunkerFn };
 
 export type VaultEvent = "modify" | "create" | "delete";
 
@@ -48,7 +49,7 @@ export interface VaultLike {
 export type LiveIndexerOpts = {
   vault: VaultLike;
   chunker: ChunkerFn;
-  embedder: Embedder;
+  embedder: EmbeddingProvider;
   store: EmbeddingStore;
   /** Per-file inactivity window before re-processing. Default 2000ms. */
   debounceMs?: number;
@@ -77,9 +78,11 @@ class LiveIndexerImpl implements SemanticIndexer {
   private unsubs: Array<() => void> = [];
   private running = false;
   private readonly debounceMs: number;
+  private readonly opts: LiveIndexerOpts;
 
-  constructor(private opts: LiveIndexerOpts) {
+  constructor(opts: LiveIndexerOpts) {
     this.debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.opts = { ...opts, chunker: wrapChunkerWithOverlap(opts.chunker) };
   }
 
   async start(): Promise<void> {
@@ -107,6 +110,12 @@ class LiveIndexerImpl implements SemanticIndexer {
   }
 
   async rebuildAll(): Promise<void> {
+    if (!(await this.opts.embedder.isAvailable())) {
+      logger.warn(
+        "live indexer: embedding provider not available, skipping rebuild",
+      );
+      return;
+    }
     const files = this.opts.vault.getMarkdownFiles();
     for (const f of files) {
       await this.processFile(f.path);
@@ -152,7 +161,7 @@ class LiveIndexerImpl implements SemanticIndexer {
     // race the in-flight processor for the prior modify event.
     const prior = this.inFlight.get(path);
     const next = (async () => {
-      if (prior) await prior;
+      if (prior) await prior.catch(() => {});
       await this.doProcessFile(path);
     })();
     this.inFlight.set(path, next);
@@ -181,7 +190,7 @@ export function createLiveIndexer(opts: LiveIndexerOpts): SemanticIndexer {
 export type LowPowerIndexerOpts = {
   vault: VaultLike;
   chunker: ChunkerFn;
-  embedder: Embedder;
+  embedder: EmbeddingProvider;
   store: EmbeddingStore;
   /** Scan interval. Default 5 minutes (300_000 ms). */
   intervalMs?: number;
@@ -214,9 +223,11 @@ class LowPowerIndexerImpl implements SemanticIndexer {
   private cycleInFlight: Promise<void> | null = null;
   private lastSeenMtime = new Map<string, number>();
   private readonly intervalMs: number;
+  private readonly opts: LowPowerIndexerOpts;
 
-  constructor(private opts: LowPowerIndexerOpts) {
+  constructor(opts: LowPowerIndexerOpts) {
     this.intervalMs = opts.intervalMs ?? DEFAULT_LOW_POWER_INTERVAL_MS;
+    this.opts = { ...opts, chunker: wrapChunkerWithOverlap(opts.chunker) };
   }
 
   async start(): Promise<void> {
@@ -247,6 +258,12 @@ class LowPowerIndexerImpl implements SemanticIndexer {
   }
 
   async rebuildAll(): Promise<void> {
+    if (!(await this.opts.embedder.isAvailable())) {
+      logger.warn(
+        "low-power indexer: embedding provider not available, skipping rebuild",
+      );
+      return;
+    }
     // Force every file to be considered stale, then run a cycle.
     this.lastSeenMtime.clear();
     await this.runCycle();
@@ -312,7 +329,7 @@ export function createLowPowerIndexer(
 type ProcessDeps = {
   vault: VaultLike;
   chunker: ChunkerFn;
-  embedder: Embedder;
+  embedder: EmbeddingProvider;
   store: EmbeddingStore;
 };
 
@@ -366,7 +383,8 @@ async function processOnePath(deps: ProcessDeps, path: string): Promise<void> {
   const records: EmbeddingRecord[] = [];
   for (const c of chunks) {
     const reused = existingByHash.get(c.contentHash);
-    const vector = reused?.vector ?? (await deps.embedder.embed(c.text));
+    const vector =
+      reused?.vector ?? (await deps.embedder.embed([c.text], "document"))[0]!;
     records.push({
       chunkId: `${path}#${c.id}`,
       filePath: path,

--- a/packages/obsidian-plugin/src/features/semantic-search/services/langDetect.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/langDetect.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { detectNonAsciiRatio } from "./langDetect";
+import type { VaultLike } from "./indexer";
+
+function makeVault(contents: Record<string, string>): VaultLike {
+  const files = new Map(Object.entries(contents));
+  return {
+    getMarkdownFiles: () => Array.from(files.keys()).map((path) => ({ path })),
+    read: async (path) => {
+      const v = files.get(path);
+      if (v === undefined) throw new Error(`ENOENT ${path}`);
+      return v;
+    },
+    on: () => () => undefined,
+  };
+}
+
+describe("detectNonAsciiRatio", () => {
+  test("empty vault returns 0", async () => {
+    const vault = makeVault({});
+    expect(await detectNonAsciiRatio(vault)).toBe(0);
+  });
+
+  test("all-ASCII content returns 0", async () => {
+    const vault = makeVault({
+      "a.md": "Hello world! This is a plain English note.",
+      "b.md": "More plain text with numbers 1234 and symbols !@#.",
+    });
+    expect(await detectNonAsciiRatio(vault)).toBe(0);
+  });
+
+  test("CJK-heavy vault returns ratio above 0.30", async () => {
+    // Japanese text — every character is non-ASCII.
+    const vault = makeVault({
+      "a.md": "日本語のノートです。検索機能を使います。",
+      "b.md": "もう一つの日本語のノートです。",
+    });
+    const ratio = await detectNonAsciiRatio(vault);
+    expect(ratio).toBeGreaterThan(0.3);
+  });
+
+  test("mixed content: ratio is proportional to non-ASCII fraction", async () => {
+    // 4 ASCII chars + 4 non-ASCII (e.g. é, ü, ñ, ç) → ratio = 0.5.
+    const vault = makeVault({ "a.md": "abcdéüñç" });
+    const ratio = await detectNonAsciiRatio(vault);
+    expect(ratio).toBeCloseTo(0.5, 2);
+  });
+
+  test("respects sampleSize: only first N files are read", async () => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 10; i++) {
+      files[`${i}.md`] = "ASCII only";
+    }
+    // Inject a non-ASCII file beyond sampleSize=5.
+    files["9.md"] = "日本語";
+    const vault = makeVault(files);
+    // With sampleSize=5, only files 0-4 are sampled (all ASCII).
+    const ratio = await detectNonAsciiRatio(vault, 5);
+    expect(ratio).toBe(0);
+  });
+
+  test("read errors are skipped gracefully", async () => {
+    const vault: VaultLike = {
+      getMarkdownFiles: () => [{ path: "bad.md" }, { path: "good.md" }],
+      read: async (path) => {
+        if (path === "bad.md") throw new Error("EBUSY");
+        return "ASCII text";
+      },
+      on: () => () => undefined,
+    };
+    // bad.md is skipped; good.md is all ASCII → ratio 0.
+    expect(await detectNonAsciiRatio(vault)).toBe(0);
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/services/langDetect.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/langDetect.ts
@@ -1,0 +1,31 @@
+import type { VaultLike } from "./indexer";
+
+/**
+ * Sample up to `sampleSize` files and return the ratio of non-ASCII
+ * characters to total characters. Used by the `"auto"` provider path
+ * to surface a multilingual-provider suggestion when the vault
+ * appears to contain significant non-English content.
+ *
+ * Returns 0 for an empty vault or when all sampled files fail to read.
+ */
+export async function detectNonAsciiRatio(
+  vault: VaultLike,
+  sampleSize = 50,
+): Promise<number> {
+  const files = vault.getMarkdownFiles().slice(0, sampleSize);
+  let total = 0;
+  let nonAscii = 0;
+  for (const f of files) {
+    let content: string;
+    try {
+      content = await vault.read(f.path);
+    } catch {
+      continue;
+    }
+    total += content.length;
+    for (let i = 0; i < content.length; i++) {
+      if (content.charCodeAt(i) > 127) nonAscii++;
+    }
+  }
+  return total === 0 ? 0 : nonAscii / total;
+}

--- a/packages/obsidian-plugin/src/features/semantic-search/services/multilingualE5Provider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/multilingualE5Provider.ts
@@ -1,0 +1,18 @@
+import type { EmbeddingProvider } from "../types";
+import type { PipelineFactory } from "./embedder";
+import { createTransformersProvider } from "./transformersProvider";
+
+export function createMultilingualE5Provider(
+  pipelineFactory: PipelineFactory,
+): EmbeddingProvider {
+  return createTransformersProvider({
+    modelId: "Xenova/multilingual-e5-base",
+    providerKey: "multilingual-e5-base",
+    dimensions: 768,
+    maxInputTokens: 512,
+    modelSizeBytes: 100_000_000,
+    taskPrompt: (text, role) =>
+      (role === "query" ? "query: " : "passage: ") + text,
+    pipelineFactory,
+  });
+}

--- a/packages/obsidian-plugin/src/features/semantic-search/services/nativeEmbeddingProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/nativeEmbeddingProvider.ts
@@ -1,0 +1,47 @@
+/**
+ * Adapter that exposes the existing `Embedder` abstraction (MiniLM-L6-v2)
+ * as an `EmbeddingProvider`. This allows the indexer and store registry
+ * to treat the native backend identically to the new multilingual providers
+ * while reusing the existing pipeline + LRU-cache + idle-unload logic.
+ *
+ * MiniLM does not use asymmetric task prompts, so `role` is ignored.
+ */
+
+import type { Embedder } from "./embedder";
+import type { EmbeddingProvider } from "../types";
+
+const PROVIDER_KEY = "native-minilm-l6-v2";
+const DIMENSIONS = 384;
+const MAX_INPUT_TOKENS = 256;
+const MODEL_SIZE_BYTES = 25_000_000;
+
+class NativeEmbeddingProviderImpl implements EmbeddingProvider {
+  readonly providerKey = PROVIDER_KEY;
+  readonly dimensions = DIMENSIONS;
+  readonly maxInputTokens = MAX_INPUT_TOKENS;
+
+  constructor(private embedder: Embedder) {}
+
+  getModelSizeBytes(): number {
+    return MODEL_SIZE_BYTES;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    // Native MiniLM lazy-loads on the first embed() call; it is
+    // always available to callers (no download gate required).
+    return true;
+  }
+
+  async embed(
+    texts: string[],
+    _role: "document" | "query",
+  ): Promise<Float32Array[]> {
+    return this.embedder.embedBatch(texts);
+  }
+}
+
+export function createNativeEmbeddingProvider(
+  embedder: Embedder,
+): EmbeddingProvider {
+  return new NativeEmbeddingProviderImpl(embedder);
+}

--- a/packages/obsidian-plugin/src/features/semantic-search/services/nativeProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/nativeProvider.test.ts
@@ -56,6 +56,7 @@ function makeMemAdapter(): VaultAdapter {
       files.delete(p);
       bins.delete(p);
     },
+    async mkdir() {},
   };
 }
 

--- a/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
@@ -1,0 +1,56 @@
+/**
+ * One-shot ONNX / Transformers.js environment configuration.
+ *
+ * Shared by embedder.ts (MiniLM path) and transformersProvider.ts
+ * (multilingual providers) so the call-once guard is a module-level
+ * singleton and both importers see the same `_envConfigured` flag.
+ *
+ * Why each setting:
+ *
+ * * `env.backends.onnx.wasm.wasmPaths`: onnxruntime-web's default
+ *   wasm-blob loader resolves siblings via `fetch(new URL(...,
+ *   import.meta.url))`. Bun's CJS bundle does not preserve
+ *   `import.meta.url` meaningfully, so the loader 404s. Pointing at
+ *   the matching CDN sidesteps the `import.meta.url` dance. Pinned to
+ *   1.14.0 to match @xenova/transformers@2.17.2; updating the lib
+ *   requires updating this URL or the WASM ABI may not match the JS
+ *   glue.
+ * * `env.backends.onnx.wasm.numThreads = 1`: Electron's renderer does
+ *   not have COOP/COEP cross-origin isolation, so SharedArrayBuffer is
+ *   restricted. Single-threaded WASM avoids the worker spin-up path.
+ * * `env.allowLocalModels = false`: always use the remote (Hugging
+ *   Face Hub) so the lazy first-call download flow drives the UI.
+ * * `env.useBrowserCache = true`: persist the downloaded model to the
+ *   Cache API so subsequent loads are fast.
+ */
+
+// Static import required: Obsidian's eval-based plugin loader cannot
+// resolve node_modules at runtime; a bundled require() works, a
+// dynamic `import(...)` would 404.
+import { env as _xenovaEnv } from "@xenova/transformers";
+
+const ORT_WASM_PATHS =
+  "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.14.0/dist/";
+
+let _envConfigured = false;
+
+export function configureEnv(): void {
+  if (_envConfigured) return;
+  _envConfigured = true;
+  const e = _xenovaEnv as unknown as {
+    backends?: {
+      onnx?: {
+        wasm?: { numThreads?: number; simd?: boolean; wasmPaths?: string };
+      };
+    };
+    allowLocalModels?: boolean;
+    useBrowserCache?: boolean;
+  };
+  if (e.backends?.onnx?.wasm) {
+    e.backends.onnx.wasm.wasmPaths = ORT_WASM_PATHS;
+    e.backends.onnx.wasm.numThreads = 1;
+    e.backends.onnx.wasm.simd = true;
+  }
+  e.allowLocalModels = false;
+  e.useBrowserCache = true;
+}

--- a/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.test.ts
@@ -6,8 +6,10 @@ import {
 } from "./providerFactory";
 import type McpToolsPlugin from "$/main";
 import type { SemanticSearchSettings } from "$/features/semantic-search/types";
+import type { EmbeddingProvider } from "$/features/semantic-search/types";
 import type { Embedder } from "./embedder";
 import { createEmbeddingStore, type VaultAdapter } from "./store";
+import { createEmbeddingStoreRegistry } from "./storeRegistry";
 import { SmartConnectionsUnavailableError } from "./smartConnectionsProvider";
 
 const DIM = 4;
@@ -48,6 +50,7 @@ function memAdapter(): VaultAdapter {
       files.delete(p);
       bins.delete(p);
     },
+    async mkdir() {},
   };
 }
 
@@ -92,7 +95,50 @@ const SETTINGS = {
     indexingMode: "live",
     unloadModelWhenIdle: true,
   } as SemanticSearchSettings,
+  embeddingGemma: {
+    provider: "embedding-gemma",
+    indexingMode: "live",
+    unloadModelWhenIdle: true,
+  } as SemanticSearchSettings,
+  multilingualE5: {
+    provider: "multilingual-e5-base",
+    indexingMode: "live",
+    unloadModelWhenIdle: true,
+  } as SemanticSearchSettings,
 };
+
+function fakeEmbeddingProvider(dim: number): EmbeddingProvider {
+  return {
+    providerKey: `fake-${dim}d`,
+    dimensions: dim,
+    maxInputTokens: 512,
+    embed: async (texts, _role) => texts.map(() => new Float32Array(dim)),
+    isAvailable: async () => true,
+    getModelSizeBytes: () => 0,
+  };
+}
+
+async function makeDepsWithRegistry(
+  scPresent: boolean,
+): Promise<ProviderFactoryDeps> {
+  const adapter = memAdapter();
+  const registry = createEmbeddingStoreRegistry(adapter, "/plugin/embeddings");
+  const gemmaStore = registry.storeFor("embedding-gemma-300m", 768);
+  await gemmaStore.init();
+  const e5Store = registry.storeFor("multilingual-e5-base", 768);
+  await e5Store.init();
+
+  return {
+    plugin: pluginWithSmartSearch(scPresent),
+    embedder: fakeEmbedder(),
+    store: await makeStore(),
+    registry,
+    embeddingProviders: {
+      "embedding-gemma-300m": fakeEmbeddingProvider(768),
+      "multilingual-e5-base": fakeEmbeddingProvider(768),
+    },
+  };
+}
 
 describe("provider factory — chooser", () => {
   test("provider='native' returns a NativeProvider", async () => {
@@ -175,6 +221,49 @@ describe("provider factory — chooser", () => {
     expect(c).not.toBe(b);
     // With SC removed, auto resolves to native.
     expect(c.isReady()).toBe(true);
+  });
+
+  test("provider='embedding-gemma' returns a NativeProvider backed by gemma store", async () => {
+    const deps = await makeDepsWithRegistry(false);
+    const choose = createProviderFactory(deps);
+    const provider = choose(SETTINGS.embeddingGemma);
+    expect(provider.isReady()).toBe(true);
+    const out = await provider.search("anything", {});
+    expect(out).toEqual([]);
+  });
+
+  test("provider='multilingual-e5-base' returns a NativeProvider backed by e5 store", async () => {
+    const deps = await makeDepsWithRegistry(false);
+    const choose = createProviderFactory(deps);
+    const provider = choose(SETTINGS.multilingualE5);
+    expect(provider.isReady()).toBe(true);
+    const out = await provider.search("anything", {});
+    expect(out).toEqual([]);
+  });
+
+  test("embedding-gemma without registry falls back to native", async () => {
+    const deps = await makeDeps(false);
+    const choose = createProviderFactory(deps);
+    const provider = choose(SETTINGS.embeddingGemma);
+    // Falls back to NativeProvider (always ready).
+    expect(provider.isReady()).toBe(true);
+    const out = await provider.search("anything", {});
+    expect(out).toEqual([]);
+  });
+
+  test("embedding-gemma query text uses 'query' role via the search embedder", async () => {
+    const roles: string[] = [];
+    const deps = await makeDepsWithRegistry(false);
+    const ep = deps.embeddingProviders!["embedding-gemma-300m"]!;
+    const origEmbed = ep.embed.bind(ep);
+    ep.embed = async (texts, role) => {
+      roles.push(role);
+      return origEmbed(texts, role);
+    };
+    const choose = createProviderFactory(deps);
+    const provider = choose(SETTINGS.embeddingGemma);
+    await provider.search("hello", {});
+    expect(roles).toEqual(["query"]);
   });
 });
 

--- a/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.ts
@@ -1,35 +1,40 @@
 /**
  * Provider factory — selects the active SemanticSearchProvider based
- * on the user's tri-state setting.
+ * on the user's setting.
  *
  * Behavior matrix:
- *   provider="native"            → always NativeProvider
- *   provider="smart-connections" → always SmartConnectionsProvider
- *                                  (its `search` throws an actionable
- *                                  error if SC is not loaded)
- *   provider="auto"              → SmartConnectionsProvider if SC is
- *                                  loaded, else NativeProvider
+ *   provider="native"              → always NativeProvider (MiniLM)
+ *   provider="smart-connections"   → always SmartConnectionsProvider
+ *   provider="auto"                → SmartConnectionsProvider if SC
+ *                                    is loaded, else NativeProvider
+ *   provider="embedding-gemma"     → NativeProvider backed by the
+ *                                    EmbeddingGemma 300M store
+ *   provider="multilingual-e5-base"→ NativeProvider backed by the
+ *                                    multilingual-e5-base store
  *
- * The factory is constructed once with stable dependencies (embedder,
- * store, excerptResolver, plugin handle) and returns a closure that
- * maps a `SemanticSearchSettings` instance to a provider. Settings
- * changes (T12 UI swap) call the closure again to swap the live
- * provider; the dependencies are unchanged across swaps.
+ * For "embedding-gemma" and "multilingual-e5-base", `deps.registry`
+ * and `deps.embeddingProviders` must be supplied; when absent the
+ * factory falls back to the native provider (degraded but safe).
  */
 
 import type McpToolsPlugin from "$/main";
 import type { SemanticSearchProvider } from "$/features/semantic-search";
 import type { SemanticSearchSettings } from "$/features/semantic-search/types";
+import type { EmbeddingProvider } from "$/features/semantic-search/types";
 import { createNativeProvider, type ExcerptResolver } from "./nativeProvider";
 import { createSmartConnectionsProvider } from "./smartConnectionsProvider";
 import type { Embedder } from "./embedder";
 import type { EmbeddingStore } from "./store";
+import type { EmbeddingStoreRegistry } from "./storeRegistry";
 
 export type ProviderFactoryDeps = {
   plugin: McpToolsPlugin;
   embedder: Embedder;
   store: EmbeddingStore;
   excerptResolver?: ExcerptResolver;
+  /** Required for "embedding-gemma" and "multilingual-e5-base" cases. */
+  registry?: EmbeddingStoreRegistry;
+  embeddingProviders?: Record<string, EmbeddingProvider>;
 };
 
 export type ProviderChooser = (
@@ -38,15 +43,30 @@ export type ProviderChooser = (
 
 /**
  * Probe whether the Smart Connections plugin's SmartSearch surface
- * is loaded and ready to be called. The check is the same as the
- * one inside SmartConnectionsProvider but lives here too so the
- * factory can resolve `provider="auto"` without constructing a
- * provider just to ask.
+ * is loaded and ready to be called.
  */
 export function isSmartConnectionsAvailable(plugin: McpToolsPlugin): boolean {
   const sc = (plugin as unknown as { smartSearch?: { search?: unknown } })
     .smartSearch;
   return typeof sc?.search === "function";
+}
+
+/**
+ * Adapts an `EmbeddingProvider` to the `Embedder` interface expected
+ * by `NativeProviderImpl`. Role is fixed to `"query"` since this
+ * adapter is only used on the search path.
+ */
+function makeSearchEmbedder(provider: EmbeddingProvider): Embedder {
+  return {
+    embed: async (text: string): Promise<Float32Array> => {
+      const vecs = await provider.embed([text], "query");
+      return vecs[0]!;
+    },
+    embedBatch: async (texts: string[]): Promise<Float32Array[]> =>
+      provider.embed(texts, "query"),
+    unload: async () => {},
+    isLoaded: () => true,
+  };
 }
 
 export function createProviderFactory(
@@ -62,6 +82,16 @@ export function createProviderFactory(
   const buildSmart = (): SemanticSearchProvider =>
     createSmartConnectionsProvider(deps.plugin);
 
+  const buildNativeSearchProvider = (
+    ep: EmbeddingProvider,
+    store: EmbeddingStore,
+  ): SemanticSearchProvider =>
+    createNativeProvider({
+      embedder: makeSearchEmbedder(ep),
+      store,
+      excerptResolver: deps.excerptResolver,
+    });
+
   return (settings) => {
     switch (settings.provider) {
       case "native":
@@ -72,6 +102,22 @@ export function createProviderFactory(
         return isSmartConnectionsAvailable(deps.plugin)
           ? buildSmart()
           : buildNative();
+      case "embedding-gemma": {
+        const ep = deps.embeddingProviders?.["embedding-gemma-300m"];
+        if (!ep || !deps.registry) return buildNative();
+        return buildNativeSearchProvider(
+          ep,
+          deps.registry.storeFor("embedding-gemma-300m", 768),
+        );
+      }
+      case "multilingual-e5-base": {
+        const ep = deps.embeddingProviders?.["multilingual-e5-base"];
+        if (!ep || !deps.registry) return buildNative();
+        return buildNativeSearchProvider(
+          ep,
+          deps.registry.storeFor("multilingual-e5-base", 768),
+        );
+      }
     }
   };
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
@@ -44,6 +44,7 @@ function makeMemAdapter(): {
       files.delete(path);
       bins.delete(path);
     },
+    async mkdir() {},
   };
   return { adapter, files, bins };
 }
@@ -304,6 +305,70 @@ describe("embedding store", () => {
     );
     expect(written.version).toBe(FORMAT_VERSION);
     expect(written.records).toHaveLength(0);
+  });
+
+  test("FORMAT_VERSION 2 round-trip: flushed index carries version 2", async () => {
+    const opts = {
+      adapter: mem.adapter,
+      binPath: "/p/embeddings.bin",
+      indexPath: "/p/embeddings.index.json",
+      vectorDim: DIM,
+    };
+    const store = createEmbeddingStore(opts);
+    await store.init();
+    await store.upsert([makeRecord({ chunkId: "a:0" })]);
+    await store.flush();
+    const written = JSON.parse(
+      mem.files.get("/p/embeddings.index.json") ?? "{}",
+    );
+    expect(written.version).toBe(FORMAT_VERSION);
+    expect(FORMAT_VERSION).toBe(2);
+  });
+
+  test("v1 index readable without re-index; dirty=true upgrades to v2 on flush", async () => {
+    const opts = {
+      adapter: mem.adapter,
+      binPath: "/p/embeddings.bin",
+      indexPath: "/p/embeddings.index.json",
+      vectorDim: DIM,
+    };
+    // Craft a v1 index with one record.
+    const v1Vec = makeVector(3);
+    const bin = new Float32Array(DIM);
+    bin.set(v1Vec, 0);
+    await mem.adapter.writeBinary("/p/embeddings.bin", bin.buffer.slice(0));
+    await mem.adapter.write(
+      "/p/embeddings.index.json",
+      JSON.stringify({
+        version: 1,
+        records: [
+          {
+            chunkId: "legacy:0",
+            filePath: "Legacy.md",
+            offset: 0,
+            heading: null,
+            contentHash: "abc123",
+            byteOffset: 0,
+            byteLength: DIM * 4,
+          },
+        ],
+      }),
+    );
+
+    const store = createEmbeddingStore(opts);
+    await store.init();
+    // Records must be loaded (not discarded).
+    expect(store.size()).toBe(1);
+    const seen: EmbeddingRecord[] = [];
+    for await (const r of store.scan()) seen.push(r);
+    expect(seen[0]?.chunkId).toBe("legacy:0");
+    // Flush should write a version-2 index.
+    await store.flush();
+    const written = JSON.parse(
+      mem.files.get("/p/embeddings.index.json") ?? "{}",
+    );
+    expect(written.version).toBe(FORMAT_VERSION);
+    expect(written.records).toHaveLength(1);
   });
 
   test("bin shorter than a record's byteOffset+byteLength: skip that record, keep valid ones, no throw", async () => {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
@@ -43,6 +43,7 @@ export interface VaultAdapter {
   readBinary(path: string): Promise<ArrayBuffer>;
   writeBinary(path: string, data: ArrayBuffer): Promise<void>;
   remove(path: string): Promise<void>;
+  mkdir(path: string): Promise<void>;
 }
 
 export interface EmbeddingStore {
@@ -64,7 +65,7 @@ export type EmbeddingStoreOpts = {
   vectorDim?: number;
 };
 
-export const FORMAT_VERSION = 1;
+export const FORMAT_VERSION = 2;
 const DEFAULT_VECTOR_DIM = 384;
 
 type IndexRecord = {
@@ -135,7 +136,7 @@ class EmbeddingStoreImpl implements EmbeddingStore {
       return;
     }
 
-    if (parsed.version !== FORMAT_VERSION) {
+    if (parsed.version !== FORMAT_VERSION && parsed.version !== 1) {
       logger.warn("embedding index format version mismatch, re-indexing", {
         expected: FORMAT_VERSION,
         found: parsed.version,
@@ -195,10 +196,10 @@ class EmbeddingStoreImpl implements EmbeddingStore {
     }
 
     this.initialized = true;
-    // If any record was skipped, the in-memory set no longer matches
-    // the on-disk pair — mark dirty so the next flush rewrites a
-    // consistent one.
-    this.dirty = skippedAny;
+    // v1 index: records are valid but version marker is stale —
+    // mark dirty so the next flush upgrades the index to v2.
+    // If any record was also skipped, that further requires a flush.
+    this.dirty = skippedAny || parsed.version === 1;
   }
 
   size(): number {
@@ -239,6 +240,11 @@ class EmbeddingStoreImpl implements EmbeddingStore {
 
   async flush(): Promise<void> {
     if (!this.dirty) return;
+
+    // Ensure the parent directory exists before writing — on a fresh
+    // install the per-providerKey subdirectory may not exist yet.
+    const dir = this.opts.binPath.split("/").slice(0, -1).join("/");
+    if (dir) await this.opts.adapter.mkdir(dir);
 
     const recordList = Array.from(this.records.values());
     let totalFloats = 0;

--- a/packages/obsidian-plugin/src/features/semantic-search/services/storeRegistry.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/storeRegistry.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  createEmbeddingStoreRegistry,
+  migrateV1FlatStore,
+} from "./storeRegistry";
+import type { VaultAdapter } from "./store";
+
+function makeMemAdapter(): {
+  adapter: VaultAdapter;
+  files: Map<string, string>;
+  bins: Map<string, ArrayBuffer>;
+} {
+  const files = new Map<string, string>();
+  const bins = new Map<string, ArrayBuffer>();
+  const adapter: VaultAdapter = {
+    async exists(path) {
+      return files.has(path) || bins.has(path);
+    },
+    async read(path) {
+      const v = files.get(path);
+      if (v === undefined) throw new Error(`ENOENT ${path}`);
+      return v;
+    },
+    async write(path, data) {
+      files.set(path, data);
+    },
+    async readBinary(path) {
+      const v = bins.get(path);
+      if (v === undefined) throw new Error(`ENOENT ${path}`);
+      return v.slice(0);
+    },
+    async writeBinary(path, data) {
+      bins.set(path, data.slice(0));
+    },
+    async remove(path) {
+      files.delete(path);
+      bins.delete(path);
+    },
+    async mkdir() {},
+  };
+  return { adapter, files, bins };
+}
+
+describe("EmbeddingStoreRegistry", () => {
+  let mem: ReturnType<typeof makeMemAdapter>;
+
+  beforeEach(() => {
+    mem = makeMemAdapter();
+  });
+
+  test("storeFor returns the same instance for the same providerKey", () => {
+    const registry = createEmbeddingStoreRegistry(
+      mem.adapter,
+      "/plugin/embeddings",
+    );
+    const a = registry.storeFor("native-minilm-l6-v2", 384);
+    const b = registry.storeFor("native-minilm-l6-v2", 384);
+    expect(a).toBe(b);
+  });
+
+  test("storeFor returns different instances for different providerKeys", () => {
+    const registry = createEmbeddingStoreRegistry(
+      mem.adapter,
+      "/plugin/embeddings",
+    );
+    const a = registry.storeFor("native-minilm-l6-v2", 384);
+    const b = registry.storeFor("embedding-gemma-300m", 768);
+    expect(a).not.toBe(b);
+  });
+
+  test("markReady + isReady round-trip", () => {
+    const registry = createEmbeddingStoreRegistry(
+      mem.adapter,
+      "/plugin/embeddings",
+    );
+    expect(registry.isReady("native-minilm-l6-v2")).toBe(false);
+    registry.markReady("native-minilm-l6-v2");
+    expect(registry.isReady("native-minilm-l6-v2")).toBe(true);
+  });
+
+  test("close removes store and ready flag", async () => {
+    const registry = createEmbeddingStoreRegistry(
+      mem.adapter,
+      "/plugin/embeddings",
+    );
+    const s1 = registry.storeFor("native-minilm-l6-v2", 384);
+    registry.markReady("native-minilm-l6-v2");
+    await registry.close("native-minilm-l6-v2");
+    expect(registry.isReady("native-minilm-l6-v2")).toBe(false);
+    // After close, storeFor creates a fresh instance.
+    const s2 = registry.storeFor("native-minilm-l6-v2", 384);
+    expect(s2).not.toBe(s1);
+  });
+
+  test("closeAll closes every known store", async () => {
+    const registry = createEmbeddingStoreRegistry(
+      mem.adapter,
+      "/plugin/embeddings",
+    );
+    registry.storeFor("native-minilm-l6-v2", 384);
+    registry.storeFor("embedding-gemma-300m", 768);
+    registry.markReady("native-minilm-l6-v2");
+    registry.markReady("embedding-gemma-300m");
+    await registry.closeAll();
+    expect(registry.isReady("native-minilm-l6-v2")).toBe(false);
+    expect(registry.isReady("embedding-gemma-300m")).toBe(false);
+  });
+});
+
+describe("migrateV1FlatStore", () => {
+  let mem: ReturnType<typeof makeMemAdapter>;
+
+  beforeEach(() => {
+    mem = makeMemAdapter();
+  });
+
+  test("no-op when flat bin is absent", async () => {
+    await migrateV1FlatStore(mem.adapter, "/plugin");
+    expect(mem.bins.size).toBe(0);
+    expect(mem.files.size).toBe(0);
+  });
+
+  test("moves bin and index to per-providerKey path", async () => {
+    const binData = new Float32Array([1, 2, 3, 4]).buffer;
+    const indexData = JSON.stringify({ version: 1, records: [] });
+    await mem.adapter.writeBinary("/plugin/embeddings.bin", binData);
+    await mem.adapter.write("/plugin/embeddings.index.json", indexData);
+
+    await migrateV1FlatStore(mem.adapter, "/plugin");
+
+    expect(await mem.adapter.exists("/plugin/embeddings.bin")).toBe(false);
+    expect(await mem.adapter.exists("/plugin/embeddings.index.json")).toBe(
+      false,
+    );
+    expect(
+      await mem.adapter.exists(
+        "/plugin/embeddings/native-minilm-l6-v2/embeddings.bin",
+      ),
+    ).toBe(true);
+    expect(
+      await mem.adapter.exists(
+        "/plugin/embeddings/native-minilm-l6-v2/embeddings.index.json",
+      ),
+    ).toBe(true);
+  });
+
+  test("idempotent: second call is a no-op", async () => {
+    const binData = new Float32Array([1]).buffer;
+    await mem.adapter.writeBinary("/plugin/embeddings.bin", binData);
+
+    await migrateV1FlatStore(mem.adapter, "/plugin");
+    // Flat bin is gone after first migration.
+    expect(await mem.adapter.exists("/plugin/embeddings.bin")).toBe(false);
+
+    // Second call: no-op, no error.
+    await expect(
+      migrateV1FlatStore(mem.adapter, "/plugin"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("gracefully handles missing index file (bin-only state)", async () => {
+    const binData = new Float32Array([1]).buffer;
+    await mem.adapter.writeBinary("/plugin/embeddings.bin", binData);
+    // No index.json present.
+
+    await migrateV1FlatStore(mem.adapter, "/plugin");
+
+    expect(await mem.adapter.exists("/plugin/embeddings.bin")).toBe(false);
+    expect(
+      await mem.adapter.exists(
+        "/plugin/embeddings/native-minilm-l6-v2/embeddings.bin",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/services/storeRegistry.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/storeRegistry.ts
@@ -1,0 +1,116 @@
+import { logger } from "$/shared/logger";
+import {
+  createEmbeddingStore,
+  type EmbeddingStore,
+  type VaultAdapter,
+} from "./store";
+
+export interface EmbeddingStoreRegistry {
+  storeFor(providerKey: string, vectorDim: number): EmbeddingStore;
+  markReady(providerKey: string): void;
+  isReady(providerKey: string): boolean;
+  close(providerKey: string): Promise<void>;
+  closeAll(): Promise<void>;
+}
+
+class EmbeddingStoreRegistryImpl implements EmbeddingStoreRegistry {
+  private stores = new Map<string, EmbeddingStore>();
+  private ready = new Set<string>();
+
+  constructor(
+    private adapter: VaultAdapter,
+    private baseDir: string,
+  ) {}
+
+  storeFor(providerKey: string, vectorDim: number): EmbeddingStore {
+    const existing = this.stores.get(providerKey);
+    if (existing) return existing;
+    const store = createEmbeddingStore({
+      adapter: this.adapter,
+      binPath: `${this.baseDir}/${providerKey}/embeddings.bin`,
+      indexPath: `${this.baseDir}/${providerKey}/embeddings.index.json`,
+      vectorDim,
+    });
+    this.stores.set(providerKey, store);
+    return store;
+  }
+
+  markReady(providerKey: string): void {
+    this.ready.add(providerKey);
+  }
+
+  isReady(providerKey: string): boolean {
+    return this.ready.has(providerKey);
+  }
+
+  async close(providerKey: string): Promise<void> {
+    const store = this.stores.get(providerKey);
+    if (!store) return;
+    await store.close();
+    this.stores.delete(providerKey);
+    this.ready.delete(providerKey);
+  }
+
+  async closeAll(): Promise<void> {
+    const keys = Array.from(this.stores.keys());
+    await Promise.all(keys.map((k) => this.close(k)));
+  }
+}
+
+export function createEmbeddingStoreRegistry(
+  adapter: VaultAdapter,
+  baseDir: string,
+): EmbeddingStoreRegistry {
+  return new EmbeddingStoreRegistryImpl(adapter, baseDir);
+}
+
+/**
+ * One-time migration: moves the v1 flat store pair
+ * (`${pluginDir}/embeddings.bin` + `embeddings.index.json`) to the
+ * per-providerKey directory (`embeddings/native-minilm-l6-v2/`).
+ * Idempotent: no-op when the flat bin is absent.
+ * Failures are logged and swallowed — the re-index banner handles
+ * the case where the store is absent at the new path.
+ */
+export async function migrateV1FlatStore(
+  adapter: VaultAdapter,
+  pluginDir: string,
+): Promise<void> {
+  const srcBin = `${pluginDir}/embeddings.bin`;
+  try {
+    if (!(await adapter.exists(srcBin))) return;
+
+    const srcIndex = `${pluginDir}/embeddings.index.json`;
+    const dstDir = `${pluginDir}/embeddings/native-minilm-l6-v2`;
+
+    const sentinelPath = `${dstDir}/.migrating`;
+
+    // If a prior interrupted migration left a sentinel, skip — the
+    // partial destination will be ignored (no index at new path → re-index
+    // banner fires on next startup).
+    if (await adapter.exists(sentinelPath)) return;
+
+    const binData = await adapter.readBinary(srcBin);
+    await adapter.mkdir(dstDir);
+    await adapter.write(sentinelPath, "");
+    await adapter.writeBinary(`${dstDir}/embeddings.bin`, binData);
+    await adapter.remove(srcBin);
+
+    if (await adapter.exists(srcIndex)) {
+      const indexData = await adapter.read(srcIndex);
+      await adapter.write(`${dstDir}/embeddings.index.json`, indexData);
+      await adapter.remove(srcIndex);
+    }
+
+    await adapter.remove(sentinelPath);
+    logger.info(
+      "semantic-search: v1 flat store migrated to per-provider directory",
+      { pluginDir },
+    );
+  } catch (error) {
+    logger.warn("v1 flat store migration failed; store will be re-indexed", {
+      pluginDir,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test";
+import { createTransformersProvider } from "./transformersProvider";
+import { createEmbeddingGemmaProvider } from "./embeddingGemmaProvider";
+import { createMultilingualE5Provider } from "./multilingualE5Provider";
+import { createNativeEmbeddingProvider } from "./nativeEmbeddingProvider";
+import type { Embedder } from "./embedder";
+
+type MockPipelineFn = (
+  input: string | string[],
+  opts?: object,
+) => Promise<{ data: Float32Array; dims: number[] }>;
+
+function makeMockFactory(dim: number): {
+  factory: (model: string) => Promise<MockPipelineFn>;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const factory = async (_model: string): Promise<MockPipelineFn> => {
+    return async (input) => {
+      const texts = Array.isArray(input) ? input : [input];
+      calls.push(...texts);
+      return { data: new Float32Array(dim), dims: [1, dim] };
+    };
+  };
+  return { factory, calls };
+}
+
+function makeMockEmbedder(loaded = true): Embedder {
+  return {
+    embed: async (_text) => new Float32Array(384),
+    embedBatch: async (texts) => texts.map(() => new Float32Array(384)),
+    unload: async () => {},
+    isLoaded: () => loaded,
+  };
+}
+
+describe("TransformersProviderImpl", () => {
+  test("applies task prompt before calling pipeline", async () => {
+    const { factory, calls } = makeMockFactory(768);
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokens: 512,
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (text, role) => `${role}: ${text}`,
+      pipelineFactory: factory,
+    });
+
+    await provider.embed(["hello", "world"], "document");
+    expect(calls).toEqual(["document: hello", "document: world"]);
+
+    await provider.embed(["find me"], "query");
+    expect(calls).toContain("query: find me");
+  });
+
+  test("isAvailable always returns true (pipeline lazy-loads on embed)", async () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokens: 512,
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (t) => t,
+      pipelineFactory: factory,
+    });
+
+    expect(await provider.isAvailable()).toBe(true);
+    await provider.embed(["hello"], "document");
+    expect(await provider.isAvailable()).toBe(true);
+  });
+
+  test("returns Float32Array vectors of declared dimensions", async () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokens: 512,
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (t) => t,
+      pipelineFactory: factory,
+    });
+
+    const vectors = await provider.embed(["text"], "document");
+    expect(vectors).toHaveLength(1);
+    expect(vectors[0]).toBeInstanceOf(Float32Array);
+    expect(vectors[0]!.length).toBe(768);
+  });
+
+  test("getModelSizeBytes returns the declared constant", () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokens: 512,
+      modelSizeBytes: 42_000_000,
+      taskPrompt: (t) => t,
+      pipelineFactory: factory,
+    });
+    expect(provider.getModelSizeBytes()).toBe(42_000_000);
+  });
+
+  test("pipeline is constructed exactly once under concurrent embed calls", async () => {
+    let loadCount = 0;
+    const factory = async (
+      _model: string,
+    ): Promise<(input: string) => Promise<{ data: Float32Array }>> => {
+      loadCount++;
+      return async () => ({ data: new Float32Array(768) });
+    };
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokens: 512,
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (t) => t,
+      pipelineFactory: factory,
+    });
+
+    await Promise.all([
+      provider.embed(["a"], "document"),
+      provider.embed(["b"], "document"),
+    ]);
+    expect(loadCount).toBe(1);
+  });
+});
+
+describe("EmbeddingGemmaProvider", () => {
+  test("providerKey, dimensions, maxInputTokens", () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createEmbeddingGemmaProvider(factory);
+    expect(provider.providerKey).toBe("embedding-gemma-300m");
+    expect(provider.dimensions).toBe(768);
+    expect(provider.maxInputTokens).toBe(2048);
+  });
+
+  test("getModelSizeBytes returns 190 MB", () => {
+    const { factory } = makeMockFactory(768);
+    expect(createEmbeddingGemmaProvider(factory).getModelSizeBytes()).toBe(
+      190_000_000,
+    );
+  });
+
+  test("document role → title/text prompt format", async () => {
+    const { factory, calls } = makeMockFactory(768);
+    await createEmbeddingGemmaProvider(factory).embed(
+      ["my document"],
+      "document",
+    );
+    expect(calls[0]).toBe("title: none | text: my document");
+  });
+
+  test("query role → task/query prompt format", async () => {
+    const { factory, calls } = makeMockFactory(768);
+    await createEmbeddingGemmaProvider(factory).embed(["my query"], "query");
+    expect(calls[0]).toBe("task: search result | query: my query");
+  });
+});
+
+describe("MultilingualE5Provider", () => {
+  test("providerKey, dimensions, maxInputTokens", () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createMultilingualE5Provider(factory);
+    expect(provider.providerKey).toBe("multilingual-e5-base");
+    expect(provider.dimensions).toBe(768);
+    expect(provider.maxInputTokens).toBe(512);
+  });
+
+  test("getModelSizeBytes returns 100 MB", () => {
+    const { factory } = makeMockFactory(768);
+    expect(createMultilingualE5Provider(factory).getModelSizeBytes()).toBe(
+      100_000_000,
+    );
+  });
+
+  test("document role → passage prefix", async () => {
+    const { factory, calls } = makeMockFactory(768);
+    await createMultilingualE5Provider(factory).embed(
+      ["my document"],
+      "document",
+    );
+    expect(calls[0]).toBe("passage: my document");
+  });
+
+  test("query role → query prefix", async () => {
+    const { factory, calls } = makeMockFactory(768);
+    await createMultilingualE5Provider(factory).embed(["my query"], "query");
+    expect(calls[0]).toBe("query: my query");
+  });
+});
+
+describe("NativeEmbeddingProvider", () => {
+  test("providerKey, dimensions, maxInputTokens", () => {
+    const provider = createNativeEmbeddingProvider(makeMockEmbedder());
+    expect(provider.providerKey).toBe("native-minilm-l6-v2");
+    expect(provider.dimensions).toBe(384);
+    expect(provider.maxInputTokens).toBe(256);
+  });
+
+  test("getModelSizeBytes returns 25 MB", () => {
+    expect(
+      createNativeEmbeddingProvider(makeMockEmbedder()).getModelSizeBytes(),
+    ).toBe(25_000_000);
+  });
+
+  test("isAvailable always returns true (lazy-loads on demand)", async () => {
+    expect(
+      await createNativeEmbeddingProvider(makeMockEmbedder(true)).isAvailable(),
+    ).toBe(true);
+    expect(
+      await createNativeEmbeddingProvider(
+        makeMockEmbedder(false),
+      ).isAvailable(),
+    ).toBe(true);
+  });
+
+  test("embed delegates to embedder.embedBatch ignoring role", async () => {
+    const captured: string[] = [];
+    const embedder: Embedder = {
+      embed: async (_text) => new Float32Array(384),
+      embedBatch: async (texts) => {
+        captured.push(...texts);
+        return texts.map(() => new Float32Array(384));
+      },
+      unload: async () => {},
+      isLoaded: () => true,
+    };
+    const provider = createNativeEmbeddingProvider(embedder);
+    const result = await provider.embed(["hello", "world"], "query");
+    expect(captured).toEqual(["hello", "world"]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBeInstanceOf(Float32Array);
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
@@ -1,0 +1,92 @@
+/**
+ * Generic `EmbeddingProvider` implementation backed by a Transformers.js
+ * feature-extraction pipeline.
+ *
+ * Providers that use asymmetric task prompts (EmbeddingGemma, multilingual-e5)
+ * inject a `TaskPromptFn`; providers that do not (plain cosine models) can
+ * pass the identity function `(t) => t`.
+ *
+ * The underlying pipeline is loaded lazily on the first `embed()` call;
+ * concurrent calls during cold load share the same `Promise<PipelineFn>` so
+ * the model is constructed exactly once.
+ */
+
+import type { EmbeddingProvider } from "../types";
+import type { EmbedTensor, PipelineFactory, PipelineFn } from "./embedder";
+import { configureEnv } from "./onnxEnv";
+
+export type TaskPromptFn = (text: string, role: "document" | "query") => string;
+
+export type TransformersProviderOpts = {
+  modelId: string;
+  providerKey: string;
+  dimensions: number;
+  maxInputTokens: number;
+  modelSizeBytes: number;
+  taskPrompt: TaskPromptFn;
+  pipelineFactory: PipelineFactory;
+};
+
+class TransformersProviderImpl implements EmbeddingProvider {
+  readonly providerKey: string;
+  readonly dimensions: number;
+  readonly maxInputTokens: number;
+
+  private pipeline: PipelineFn | null = null;
+  private loadPromise: Promise<PipelineFn> | null = null;
+
+  constructor(private opts: TransformersProviderOpts) {
+    this.providerKey = opts.providerKey;
+    this.dimensions = opts.dimensions;
+    this.maxInputTokens = opts.maxInputTokens;
+  }
+
+  getModelSizeBytes(): number {
+    return this.opts.modelSizeBytes;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async embed(
+    texts: string[],
+    role: "document" | "query",
+  ): Promise<Float32Array[]> {
+    const pipe = await this.ensurePipeline();
+    return Promise.all(
+      texts.map(async (text) => {
+        const prompted = this.opts.taskPrompt(text, role);
+        const result = await pipe(prompted, {
+          pooling: "mean",
+          normalize: true,
+        });
+        return new Float32Array((result as EmbedTensor).data);
+      }),
+    );
+  }
+
+  private async ensurePipeline(): Promise<PipelineFn> {
+    if (this.pipeline) return this.pipeline;
+    if (!this.loadPromise) {
+      configureEnv();
+      this.loadPromise = this.opts
+        .pipelineFactory(this.opts.modelId)
+        .then((p) => {
+          this.pipeline = p;
+          return p;
+        })
+        .catch((e: unknown) => {
+          this.loadPromise = null;
+          throw e;
+        });
+    }
+    return this.loadPromise;
+  }
+}
+
+export function createTransformersProvider(
+  opts: TransformersProviderOpts,
+): EmbeddingProvider {
+  return new TransformersProviderImpl(opts);
+}

--- a/packages/obsidian-plugin/src/features/semantic-search/types.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/types.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { type } from "arktype";
+import { semanticSearchSettingsSchema } from "./types";
+
+const BASE = { indexingMode: "live", unloadModelWhenIdle: true } as const;
+
+describe("semanticSearchSettingsSchema — provider union", () => {
+  const valid = [
+    "native",
+    "smart-connections",
+    "auto",
+    "embedding-gemma",
+    "multilingual-e5-base",
+  ] as const;
+
+  for (const provider of valid) {
+    test(`accepts "${provider}"`, () => {
+      const result = semanticSearchSettingsSchema({ ...BASE, provider });
+      expect(result instanceof type.errors).toBe(false);
+    });
+  }
+
+  test("rejects unknown provider value", () => {
+    const result = semanticSearchSettingsSchema({
+      ...BASE,
+      provider: "unknown-provider",
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/types.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/types.ts
@@ -1,12 +1,31 @@
 import { type } from "arktype";
 
 /**
+ * Embedding layer abstraction. One `EmbeddingProvider` per model;
+ * the store registry and indexer are keyed on `providerKey`.
+ *
+ * `embed` accepts a batch and a role so providers that use asymmetric
+ * task prompts (EmbeddingGemma, multilingual-e5) can apply them
+ * internally without leaking the prompt format to callers.
+ */
+export interface EmbeddingProvider {
+  readonly providerKey: string;
+  readonly dimensions: number;
+  readonly maxInputTokens: number;
+  embed(texts: string[], role: "document" | "query"): Promise<Float32Array[]>;
+  isAvailable(): Promise<boolean>;
+  getModelSizeBytes(): number;
+}
+
+/**
  * Runtime schema for the semantic-search settings block.
  *
- * `provider` is the user-facing tri-state:
- *   - "native"            → always Transformers.js (NativeProvider)
- *   - "smart-connections" → always Smart Connections; errors actionably if not installed
- *   - "auto"              → Smart Connections if loaded and ready, otherwise native
+ * `provider` values:
+ *   - "native"              → always Transformers.js MiniLM (NativeProvider)
+ *   - "smart-connections"   → always Smart Connections; errors if not installed
+ *   - "auto"                → Smart Connections if loaded and ready, else native
+ *   - "embedding-gemma"     → EmbeddingGemma 300M (~190 MB, multilingual, 768d)
+ *   - "multilingual-e5-base"→ Multilingual E5 base (~100 MB, multilingual, 768d)
  *
  * `indexingMode`: live re-embedding on file change vs.
  * 5-minute batched scan. Only meaningful when the active provider
@@ -17,7 +36,8 @@ import { type } from "arktype";
  * next call re-loads (cold ~1s).
  */
 export const semanticSearchSettingsSchema = type({
-  provider: '"native"|"smart-connections"|"auto"',
+  provider:
+    '"native"|"smart-connections"|"auto"|"embedding-gemma"|"multilingual-e5-base"',
   indexingMode: '"live"|"low-power"',
   unloadModelWhenIdle: "boolean",
 });

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -30,7 +30,14 @@ import {
   createEmbedder,
   realPipelineFactory,
 } from "./features/semantic-search/services/embedder";
-import { createEmbeddingStore } from "./features/semantic-search/services/store";
+import { createNativeEmbeddingProvider } from "./features/semantic-search/services/nativeEmbeddingProvider";
+import {
+  createEmbeddingStoreRegistry,
+  migrateV1FlatStore,
+} from "./features/semantic-search/services/storeRegistry";
+import { createEmbeddingGemmaProvider } from "./features/semantic-search/services/embeddingGemmaProvider";
+import { createMultilingualE5Provider } from "./features/semantic-search/services/multilingualE5Provider";
+import { detectNonAsciiRatio } from "./features/semantic-search/services/langDetect";
 import type { VaultAdapter } from "./features/semantic-search/services/store";
 import {
   createLiveIndexer,
@@ -323,13 +330,14 @@ export default class McpToolsPlugin extends Plugin {
         readBinary: (p) => this.app.vault.adapter.readBinary(p),
         writeBinary: (p, d) => this.app.vault.adapter.writeBinary(p, d),
         remove: (p) => this.app.vault.adapter.remove(p),
+        mkdir: (p) => this.app.vault.adapter.mkdir(p),
       };
 
       const ssVault: VaultLike = {
         getMarkdownFiles: () =>
           this.app.vault.getMarkdownFiles().map((f) => ({
             path: f.path,
-            mtime: f.stat.mtime,
+            mtime: f.stat?.mtime,
           })),
         read: async (path) => {
           const f = this.app.vault.getAbstractFileByPath(path);
@@ -357,54 +365,87 @@ export default class McpToolsPlugin extends Plugin {
         return text.slice(_offset, _offset + maxLen);
       };
 
-      const downloader = createModelDownloader({
+      const pluginDir =
+        this.manifest.dir ?? `.obsidian/plugins/${this.manifest.id}`;
+
+      // Migrate v1 flat store before constructing any registry entry.
+      await migrateV1FlatStore(ssAdapter, pluginDir);
+
+      const registry = createEmbeddingStoreRegistry(
+        ssAdapter,
+        `${pluginDir}/embeddings`,
+      );
+
+      // Native MiniLM — eager init; always available.
+      const nativeDownloader = createModelDownloader({
         innerFactory: realPipelineFactory,
       });
       const embedder = createEmbedder({
-        pipelineFactory: downloader.factory,
+        pipelineFactory: nativeDownloader.factory,
       });
+      const nativeEp = createNativeEmbeddingProvider(embedder);
+      const nativeStore = registry.storeFor("native-minilm-l6-v2", 384);
+      await nativeStore.init();
+      registry.markReady("native-minilm-l6-v2");
 
-      const pluginDir =
-        this.manifest.dir ?? `.obsidian/plugins/${this.manifest.id}`;
-      const store = createEmbeddingStore({
-        adapter: ssAdapter,
-        binPath: `${pluginDir}/embeddings.bin`,
-        indexPath: `${pluginDir}/embeddings.index.json`,
-        vectorDim: 384,
+      // DLC providers — pipeline loads lazily on first embed call.
+      const gemmaDownloader = createModelDownloader({
+        innerFactory: realPipelineFactory,
       });
-      await store.init();
+      const gemmaProvider = createEmbeddingGemmaProvider(
+        gemmaDownloader.factory,
+      );
+      const e5Downloader = createModelDownloader({
+        innerFactory: realPipelineFactory,
+      });
+      const e5Provider = createMultilingualE5Provider(e5Downloader.factory);
+
+      const embeddingProviders = {
+        "embedding-gemma-300m": gemmaProvider,
+        "multilingual-e5-base": e5Provider,
+      };
 
       const semanticResult = await semanticSearchSetup(this, {
         factoryDeps: {
           plugin: this,
           embedder,
-          store,
+          store: nativeStore,
           excerptResolver: ssExcerpt,
+          registry,
+          embeddingProviders,
         },
       });
 
       if (semanticResult.success) {
         const state = semanticResult.state;
-        state.downloader = downloader;
-        state.store = store;
+        state.downloader = nativeDownloader;
+        state.store = nativeStore;
+        state.registry = registry;
 
-        // Construct the indexer matching the saved indexing mode but
-        // do NOT auto-start (Q4 = lazy). The search tool will call
-        // startIndexerIfNeeded() on first use, kicking off the full
-        // build + the model download in background.
+        // Check whether DLC stores are already built from a prior session.
+        for (const [key, dim] of [
+          ["embedding-gemma-300m", 768],
+          ["multilingual-e5-base", 768],
+        ] as const) {
+          const dlcStore = registry.storeFor(key, dim);
+          await dlcStore.init();
+          if (dlcStore.size() > 0) registry.markReady(key);
+        }
+
+        // Native indexer — lazy start on first search tool call.
         const indexer =
           state.settings.indexingMode === "low-power"
             ? createLowPowerIndexer({
                 vault: ssVault,
                 chunker: semanticChunk,
-                embedder,
-                store,
+                embedder: nativeEp,
+                store: nativeStore,
               })
             : createLiveIndexer({
                 vault: ssVault,
                 chunker: semanticChunk,
-                embedder,
-                store,
+                embedder: nativeEp,
+                store: nativeStore,
               });
         state.indexer = indexer;
 
@@ -419,12 +460,67 @@ export default class McpToolsPlugin extends Plugin {
           });
         };
 
+        // Language detection for multilingual provider suggestion (fire-and-forget).
+        detectNonAsciiRatio(ssVault)
+          .then((ratio) => {
+            if (
+              ratio > 0.3 &&
+              state.settings.provider !== "embedding-gemma" &&
+              state.settings.provider !== "multilingual-e5-base"
+            ) {
+              state.autoSuggestProvider = "embedding-gemma-300m";
+            }
+          })
+          .catch(() => {
+            // best-effort — non-ASCII sampling failure must not affect startup
+          });
+
+        // DLC rebuild hook — download + full index for one provider.
+        const _rebuildingProviders = new Set<string>();
+        state.startRebuildFor = (providerKey: string) => {
+          if (_rebuildingProviders.has(providerKey)) return;
+          _rebuildingProviders.add(providerKey);
+          const ep =
+            embeddingProviders[providerKey as keyof typeof embeddingProviders];
+          if (!ep) {
+            _rebuildingProviders.delete(providerKey);
+            return;
+          }
+          const dlcStore = registry.storeFor(providerKey, ep.dimensions);
+          const dlcIndexer = createLiveIndexer({
+            vault: ssVault,
+            chunker: semanticChunk,
+            embedder: ep,
+            store: dlcStore,
+          });
+          dlcIndexer
+            .rebuildAll()
+            .then(async () => {
+              await dlcStore.flush();
+              registry.markReady(providerKey);
+              if (state.pendingProvider === providerKey)
+                state.pendingProvider = null;
+              if (state.chooser) {
+                state.provider = state.chooser(state.settings);
+              }
+            })
+            .catch((err) => {
+              logger.error("semantic-search: DLC rebuild failed", {
+                providerKey,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            })
+            .finally(() => {
+              _rebuildingProviders.delete(providerKey);
+            });
+        };
+
         state.teardown = async () => {
           if (indexerStarted) {
             try {
               await indexer.stop();
             } catch {
-              // best-effort: don't block plugin unload
+              // best-effort
             }
           }
           try {
@@ -433,7 +529,7 @@ export default class McpToolsPlugin extends Plugin {
             // best-effort
           }
           try {
-            await store.close();
+            await registry.closeAll();
           } catch {
             // best-effort
           }


### PR DESCRIPTION
## Summary

- Introduces a pluggable `EmbeddingProvider` interface and three new ONNX providers: **Gemma 300M** (768d), **Multilingual-E5-Base** (768d), and a **native MiniLM-L6-v2** adapter — all loaded on demand from Hugging Face via a download-on-demand (DLC) flow
- Per-provider-key `EmbeddingStoreRegistry` with v1 flat-store migration (crash-safe `.migrating` sentinel) and parallel `closeAll()`
- `providerFactory`: DLC orchestration, `_rebuildingProviders` concurrency guard, `detectNonAsciiRatio` fire-and-forget auto-suggest (ratio > 0.3 → gemma)
- Chunker enhancements: `#frontmatter` chunks, H3 sub-split, sentence-overlap wrapper, CRLF-safe heading match
- `processFile` serializer swallows prior rejection to prevent error bleed
- `SemanticSettingsSection`: DLC progress UI, auto-suggest banner, provider switcher
- `main.ts`: startup DLC loop guards `markReady` on `size() > 0` (first-run stores stay unready until rebuild)

Closes #187

## Test plan

- [ ] 999 unit tests pass (`cd packages/obsidian-plugin && bun test`)
- [ ] Build succeeds (`bun run build`)
- [ ] Manual: switch provider in settings → DLC download progress shown → rebuild completes → search returns results
- [ ] Manual: vault with > 30% non-ASCII characters → auto-suggest banner for Gemma provider appears
- [ ] Manual: reload Obsidian → previously built DLC stores are recognised as ready (no spurious rebuild banner)
- [ ] Manual: native MiniLM provider still works as before (regression check)