### PR TITLE
feat(find-broken-links): add scope parameter to limit vault scan

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.test.ts
@@ -118,6 +118,69 @@ describe("find_broken_links tool", () => {
     expect(data.scanned_files).toBe(2);
   });
 
+  test("scope limits scan to matching path prefix", async () => {
+    setMockFile("Projects/2026/note.md", "");
+    setMockFile("Resources/ref.md", "");
+    setMockFile("Archive/old.md", "");
+    setMockMetadata("Projects/2026/note.md", {
+      links: [{ link: "BrokenA", line: 1 }],
+    });
+    setMockMetadata("Resources/ref.md", {
+      links: [{ link: "BrokenB", line: 1 }],
+    });
+    setMockMetadata("Archive/old.md", {
+      links: [{ link: "BrokenC", line: 1 }],
+    });
+    const r = await findBrokenLinksHandler({
+      arguments: { scope: ["Projects/2026", "Resources"], exclude_folders: [] },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    const sources = data.broken_links.map(
+      (e: { source_path: string }) => e.source_path,
+    );
+    expect(sources).toContain("Projects/2026/note.md");
+    expect(sources).toContain("Resources/ref.md");
+    expect(sources).not.toContain("Archive/old.md");
+    expect(data.scope).toEqual(["Projects/2026", "Resources"]);
+    expect(data.scanned_files).toBe(2);
+  });
+
+  test("scope with trailing slash is normalised", async () => {
+    setMockFile("Projects/note.md", "");
+    setMockFile("Other/note.md", "");
+    setMockMetadata("Projects/note.md", {
+      links: [{ link: "Broken", line: 1 }],
+    });
+    setMockMetadata("Other/note.md", {
+      links: [{ link: "AlsoBroken", line: 1 }],
+    });
+    const r = await findBrokenLinksHandler({
+      arguments: { scope: ["Projects/"], exclude_folders: [] },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    const sources = data.broken_links.map(
+      (e: { source_path: string }) => e.source_path,
+    );
+    expect(sources).toContain("Projects/note.md");
+    expect(sources).not.toContain("Other/note.md");
+  });
+
+  test("omitting scope scans the entire vault", async () => {
+    setMockFile("A/note.md", "");
+    setMockFile("B/note.md", "");
+    setMockMetadata("A/note.md", { links: [{ link: "Broken", line: 1 }] });
+    setMockMetadata("B/note.md", { links: [{ link: "BrokenB", line: 1 }] });
+    const r = await findBrokenLinksHandler({
+      arguments: { exclude_folders: [] },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.scanned_files).toBe(2);
+    expect(data.scope).toBeUndefined();
+  });
+
   test("skips files with no metadata cache gracefully", async () => {
     setMockFile("no-cache.md", "[[BrokenLink]]");
     // no setMockMetadata → getFileCache returns null — file is skipped, not an error

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.ts
@@ -8,13 +8,16 @@ export const findBrokenLinksSchema = type({
     "exclude_folders?": type("string[]").describe(
       'Vault-relative folder prefixes to skip. Default: `["templates","attachments","_archive"]`. Override is complete (not additive): passing `["custom"]` scans templates too.',
     ),
+    "scope?": type("string[]").describe(
+      "Optional list of vault-relative paths or folder prefixes to limit the scan. A folder prefix matches any file under it. Omit for vault-wide scan.",
+    ),
   },
 }).describe(
-  "Scans the entire vault for unresolved links (wiki-links, markdown links, embeds, frontmatter links) and returns every broken link with its source file, 1-based line number, link target, original syntax, and link type. Uses Obsidian's metadata cache — no file I/O. Always read-only.",
+  "Scans the vault (or a scoped subset) for unresolved links (wiki-links, markdown links, embeds, frontmatter links) and returns every broken link with its source file, 1-based line number, link target, original syntax, and link type. Uses Obsidian's metadata cache — no file I/O. Always read-only.",
 );
 
 export type FindBrokenLinksContext = {
-  arguments: { exclude_folders?: string[] };
+  arguments: { exclude_folders?: string[]; scope?: string[] };
   app: App;
 };
 
@@ -42,9 +45,14 @@ export async function findBrokenLinksHandler(
   const rawExcludes = ctx.arguments.exclude_folders ?? DEFAULT_EXCLUDE;
   // Normalise: strip trailing slash for consistent prefix-match.
   const excludes = rawExcludes.map((e) => e.replace(/\/+$/, ""));
+  const scope = ctx.arguments.scope?.map((s) => s.replace(/\/+$/, ""));
 
   const isExcluded = (path: string): boolean =>
     excludes.some((ex) => path === ex || path.startsWith(ex + "/"));
+
+  const inScope = (path: string): boolean =>
+    scope === undefined ||
+    scope.some((s) => path === s || path.startsWith(s + "/"));
 
   const files = ctx.app.vault.getMarkdownFiles();
   const broken: BrokenLinkEntry[] = [];
@@ -52,6 +60,7 @@ export async function findBrokenLinksHandler(
 
   for (const file of files) {
     if (isExcluded(file.path)) continue;
+    if (!inScope(file.path)) continue;
     scannedFiles++;
 
     const cache = ctx.app.metadataCache.getFileCache(file as TFile);
@@ -102,6 +111,7 @@ export async function findBrokenLinksHandler(
             total_broken_links: broken.length,
             scanned_files: scannedFiles,
             excluded_folders: excludes,
+            ...(scope !== undefined ? { scope } : {}),
             broken_links: broken,
           },
           null,

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/port.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/port.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { createServer, type Server } from "node:http";
 import { bindWithFallback } from "./port";
-import { PORT_RANGE } from "../constants";
 
 const openServers: Server[] = [];
 
@@ -10,42 +9,47 @@ afterEach(async () => {
     await new Promise<void>((r) => s.close(() => r()));
 });
 
+// Bind to port 0 to let the OS assign a free ephemeral port, keep the
+// server listening so the port remains occupied for the caller.
+async function occupyFreePort(): Promise<{ port: number; server: Server }> {
+  const server = createServer();
+  openServers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const port = (server.address() as { port: number }).port;
+  return { port, server };
+}
+
 describe("bindWithFallback", () => {
   test("binds to the first port in the range when free", async () => {
+    // Occupy a port, release it, then immediately use it as the range.
+    // Small TOCTOU window but acceptable for a unit test.
+    const { port, server: blocker } = await occupyFreePort();
+    await new Promise<void>((r) => blocker.close(() => r()));
+
     const server = createServer();
     openServers.push(server);
-    const port = await bindWithFallback(server, [...PORT_RANGE]);
-    expect(port).toBe(PORT_RANGE[0]);
+    const bound = await bindWithFallback(server, [port]);
+    expect(bound).toBe(port);
   });
 
   test("falls back to the next port when the first is taken", async () => {
-    const blocker = createServer();
-    openServers.push(blocker);
-    await new Promise<void>((r) =>
-      blocker.listen(PORT_RANGE[0], "127.0.0.1", () => r()),
-    );
+    const { port: p0 } = await occupyFreePort(); // p0 stays occupied
+    const { port: p1, server: blocker1 } = await occupyFreePort(); // grab p1
+    await new Promise<void>((r) => blocker1.close(() => r())); // free p1
 
     const server = createServer();
     openServers.push(server);
-    const port = await bindWithFallback(server, [...PORT_RANGE]);
-    expect(port).toBe(PORT_RANGE[1]);
+    const bound = await bindWithFallback(server, [p0, p1]);
+    expect(bound).toBe(p1);
   });
 
   test("throws when all ports in range are taken", async () => {
-    const blockers = PORT_RANGE.map(() => createServer());
-    openServers.push(...blockers);
-    await Promise.all(
-      blockers.map(
-        (s, i) =>
-          new Promise<void>((r) =>
-            s.listen(PORT_RANGE[i], "127.0.0.1", () => r()),
-          ),
-      ),
-    );
+    const { port: p0 } = await occupyFreePort();
+    const { port: p1 } = await occupyFreePort();
 
     const server = createServer();
     openServers.push(server);
-    await expect(bindWithFallback(server, [...PORT_RANGE])).rejects.toThrow(
+    await expect(bindWithFallback(server, [p0, p1])).rejects.toThrow(
       /no free port/i,
     );
   });


### PR DESCRIPTION
## Summary

- Adds optional `scope: string[]` parameter to `find_broken_links`, mirroring the same parameter in `search_and_replace`
- When provided, only files under the given vault-relative path prefixes are scanned — reduces response size on large vaults (reported: ~1860 links / 612K chars on a 1050-file vault)
- Trailing slashes in scope entries are normalised for consistent prefix matching
- When `scope` is active, the response includes a `scope` field for transparency
- Omitting `scope` preserves existing vault-wide behaviour — fully backward-compatible

## Test plan

- [ ] `bun test src/features/mcp-tools/tools/findBrokenLinks.test.ts` — 12 tests pass (3 new scope tests added)
- [ ] Manual: `{ "scope": ["Projects/2026"] }` → only files under that folder scanned
- [ ] Manual: omit `scope` → full vault scan as before

Closes #193