### PR TITLE
refactor: remove JSDoc restatements; replace console.error with logger

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.ts
@@ -110,24 +110,6 @@ export type FetchContext = {
   };
 };
 
-/**
- * Handles the fetch MCP tool request.
- *
- * Fetches the given URL using Obsidian's requestUrl API, converts HTML to
- * Markdown using Turndown (unless format="html"), and applies pagination
- * logic (startIndex and maxLength).
- *
- * Returns:
- *   - MCP-formatted response with one text content block
- *   - If content exceeds maxLength, includes a truncation hint with instructions
- *     for fetching the next chunk via startIndex
- *
- * Args:
- *   ctx: Context containing url, format, maxLength, startIndex
- *
- * Returns:
- *   MCP tool result with content array
- */
 export async function fetchHandler(ctx: FetchContext): Promise<{
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
@@ -62,24 +62,9 @@ export async function patchActiveFileHandler(
   return await applyPatch(ctx.app, file as TFile, ctx.arguments);
 }
 
-/**
- * Core patch logic — exported for reuse by patchVaultFile (T13). T13's handler
- * resolves the file by path, then delegates here.
- *
- * Per-target-type default for createTargetIfMissing (per source 0.3.7 fix +
- * issue #71):
- *   heading + frontmatter → true  (preserve 0.2.x behaviour)
- *   block → false  (fail loud on unresolved id; safer per #71 block-in-table
- *                   corruption risk)
- *
- * Args:
- *   app: Obsidian App instance.
- *   file: The TFile to patch.
- *   args: Patch parameters validated by patchActiveFileSchema.
- *
- * Returns:
- *   MCP result object, with isError=true on failure.
- */
+// Per-target-type default for createTargetIfMissing (0.3.7 fix + issue #71):
+//   heading + frontmatter → true  (preserve 0.2.x behaviour)
+//   block → false  (fail loud on unresolved id; #71 block-in-table corruption risk)
 export async function applyPatch(
   app: App,
   file: TFile,

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
@@ -45,17 +45,6 @@ export type PatchVaultFileContext = {
   app: App;
 };
 
-/**
- * Handler for the patch_vault_file MCP tool. Resolves the file by vault-relative
- * path and delegates to the shared applyPatch helper.
- *
- * Args:
- *   ctx: Context containing the vault App and the tool arguments.
- *
- * Returns:
- *   An MCP result object. Sets isError: true if the file is not found or if
- *   the patch operation fails (e.g., block not found with createTargetIfMissing=false).
- */
 export async function patchVaultFileHandler(
   ctx: PatchVaultFileContext,
 ): Promise<{

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.ts
@@ -4,6 +4,7 @@ import {
   type Server,
   type ServerResponse,
 } from "node:http";
+import { logger } from "$/shared";
 import { runMiddleware } from "./middleware";
 import { bindWithFallback } from "./port";
 import { ERROR_CODES, MAX_REQUEST_BODY_BYTES, PORT_RANGE } from "../constants";
@@ -80,12 +81,10 @@ export async function startHttpServer(
     void config.requestHandler(req, res).catch((err) => {
       if (!res.headersSent) res.writeHead(500);
       res.end();
-      // TODO(Task 12): replace with logger.error("handler failed", { err })
       // Intentionally NOT rethrowing: inside a .catch() of a void-prefixed
       // promise, throwing creates an unhandled rejection which crashes the
       // Electron renderer under default Node settings.
-      // eslint-disable-next-line no-console
-      console.error("[mcp-transport] request handler failed:", err);
+      logger.error("[mcp-transport] request handler failed", { error: err });
     });
   });
 

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -9,6 +9,7 @@ import {
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { App } from "obsidian";
 import type McpToolsPlugin from "$/main";
+import { logger } from "$/shared";
 import { ToolRegistryClass } from "./toolRegistry";
 import type { ToolRegistry } from "./toolRegistry";
 import { PromptRegistryClass } from "./promptRegistry";
@@ -120,12 +121,12 @@ export async function createMcpService(
       try {
         await transport.close();
       } catch (closeError) {
-        console.error("[mcp] transport.close failed", closeError);
+        logger.error("[mcp] transport.close failed", { error: closeError });
       }
       try {
         await server.close();
       } catch (closeError) {
-        console.error("[mcp] server.close failed", closeError);
+        logger.error("[mcp] server.close failed", { error: closeError });
       }
     }
   };


### PR DESCRIPTION
## Summary

- `patchVaultFile.ts`, `fetch.ts`: delete JSDoc blocks that only restate the function signature (no WHY content)
- `patchActiveFile.ts`: collapse 16-line JSDoc to a 3-line inline comment preserving the `createTargetIfMissing` default rationale (issue #71)
- `httpServer.ts`, `mcpServer.ts`: add `logger` import, replace `console.error` with `logger.error` and drop stale `TODO(Task 12)` reference

## Test plan

- [ ] `bun run check` passes (no type errors)
- [ ] `bunx prettier --check` passes
- [ ] No behaviour change — purely structural cleanup