### PR TITLE
feat: upgrade Transformers.js v2→v4, bump FORMAT_VERSION to 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ handoff*.md
 CLAUDE.md.bak-*
 docs/superpowers/plans/
 packages/obsidian-plugin/.claude/.triage-fix-last-main.json
+.claude/.triage-fix-last-feat_transformersjs-v4-onnx-ir10.json

--- a/BRAINSTORM.md
+++ b/BRAINSTORM.md
@@ -1,4 +1,4 @@
-# BRAINSTORM — Multilingual embedding providers for search_vault_smart
+# BRAINSTORM — Transformers.js v4 upgrade + ONNX IR v10 compatibility fix
 
 **Data:** 2026-05-27
 **Fonte requisiti:** SPEC.md at `/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/SPEC.md`
@@ -8,78 +8,68 @@
 
 ## Problema riformulato (first-principles)
 
-Il risultato irriducibile è **trovare note pertinenti in qualsiasi lingua, senza dipendenze cloud, con continuità operativa durante l'aggiornamento del modello**. Il vettore denso è uno strumento, non il fine; il modello locale è un vincolo fisso (dato non lascia il dispositivo). La dimensionalità e il provider specifico sono dettagli tecnici subordinati a questo obiettivo.
+Il risultato irriducibile è **EmbeddingGemma 300M deve caricare e produrre embedding validi dentro Obsidian, senza dipendenze cloud**. L'errore IR v10 è un sintomo; la causa è che il runtime ONNX è fermo a IR ≤ v8. La soluzione è aggiornare il runtime — non il modello. Qualsiasi altra strada (esportazione alternativa del modello, shim IR, downgrade del modello) è un workaround che non risolve la causa strutturale e accumula debito tecnico.
 
 ---
 
 ## Assunzioni sfidate
 
-- **768 dimensioni fisse** — esito: **aperta** — Matryoshka permette di servire 256/384/512/768d dallo stesso modello; il trade-off qualità/storage/latenza va esplorato nell'ADR. Non è un requisito fisico, è una scelta conservativa.
-- **Re-index totale al cambio provider** — esito: **confermata** — spazi vettoriali di provider diversi sono incompatibili; non ha senso mixarli. Il DLC pattern non evita il rebuild, ma può renderlo non-bloccante (native rimane attivo durante la build).
-- **Selezione provider sempre esplicita** — esito: **sfidabile** — l'utente vuole un `auto`-mode esteso che rilevi la lingua dominante della vault e scelga il provider ottimale senza richiedere selezione manuale.
+- **IR v10 richiede obbligatoriamente @huggingface/transformers v4** — esito: **da verificare** — potrebbe esistere un export del modello in IR ≤ v8 su HuggingFace (Task 0 del piano: verifica prima di scrivere codice). Se esiste, il fix diventa un aggiornamento di model-ID senza cambio di dipendenza. Improbabile ma non impossibile.
+- **v4 funziona nell'Obsidian Electron loader** — esito: **da verificare** — CLAUDE.md documenta che un test passato ha rotto il loader per `import.meta.url`. Il rischio è reale; il piano lo gestisce con un Task 1 spike prima di qualsiasi altra implementazione. Se fallisce, il fallback è Bug 2+3 null-guards senza upgrade.
+- **FORMAT_VERSION bump deve essere silenzioso** — esito: **sfidabile** — l'utente potrebbe non aspettarsi che l'aggiornamento cancelli il suo indice Gemma. La migrazione dovrebbe mostrare un dialog esplicito (non solo un banner) prima del wipe, specialmente se l'indice ha richiesto ore di build.
+- **WebGPU è stabile su tutti i desktop Obsidian** — esito: **da verificare** — alcuni driver GPU causano crash silenzioso nelle sessioni ONNX WebGPU. Il fallback automatico a WASM deve essere robusto (try/catch sulla sessione, non solo sulla detection di `navigator.gpu`).
 
 ---
 
 ## Alternative di approccio
 
-### Alternativa A — SPEC fedele + DLC UX
+### Alternativa A — Model-ID hunt first
 
-- **Idea:** Implementa la SPEC esattamente (EmbeddingProvider interface, native refactored, EmbeddingGemma + e5-base, chunker upgrade, migration path) ma adotta il pattern DLC per l'UX: la ricerca native rimane attiva durante il download del modello e la build dell'indice. Il nuovo provider si attiva solo quando il suo indice è pronto. Nessun blackout.
-- **Asse di differenza:** dati + UX (store per-providerKey, nessun momento in cui la ricerca è completamente disabilitata)
-- **Pro:** scope preciso, nessuna deviazione dalla SPEC concordata; DLC UX riduce la friction senza aumentare la complessità architetturale
-- **Contro:** bundle largo (EmbeddingGemma 190 MB + e5-base ~100 MB); tre provider da mantenere; PR potenzialmente grande
-- **Costo/tempo indicativo:** alto
+- **Idea:** Prima di toccare dipendenze, verificare se esiste un export di EmbeddingGemma 300M con ONNX IR ≤ v8 su HuggingFace (namespace diverso, versione più vecchia del modello). Se esiste, il fix è solo un aggiornamento di model-ID in una riga. Se non esiste, si passa ad Alt C.
+- **Asse di differenza:** deployment (zero cambio di dipendenza vs. aggiornamento pesante del runtime)
+- **Pro:** zero rischio di rompere il loader; nessun FORMAT_VERSION bump necessario; ore di lavoro risparmiate se l'export esiste
+- **Contro:** l'export probabilmente non esiste (Gemma 300M è stato esportato direttamente in IR v10); se non esiste, il tempo speso nella ricerca è overhead; posticipa la soluzione strutturale
+- **Costo/tempo indicativo:** basso (ma solo come primo check; non come alternativa finale)
 
-### Alternativa B — e5-base MVP multilingue
+### Alternativa B — Two-PR: runtime fix first, WebGPU second
 
-- **Idea:** Implementa l'EmbeddingProvider interface e aggiunge solo `multilingual-e5-base` come provider multilingue (MIT, ~100 MB, 512 context). EmbeddingGemma deferred. Chunker upgrade incluso.
-- **Asse di differenza:** deployment (meno download, meno complessità ONNX, feature parziale ma funzionante prima)
-- **Pro:** download dimezzato (~100 MB vs 190 MB); meno surface ONNX da gestire; rilascio più rapido; e5-base è già ben supportato da transformers.js
-- **Contro:** nessuna vault a 2K context; qualità inferiore su query lunghe; EmbeddingGemma richiede un secondo ciclo
-- **Costo/tempo indicativo:** medio
+- **Idea:** PR 1 si occupa solo dell'upgrade di runtime (`@xenova` → `@huggingface/transformers` v4, `onnxruntime-web` ≥ 1.20, model-ID verify, FORMAT_VERSION 2→3, migration guard) con device forzato a WASM. PR 2 aggiunge WebGPU auto-detect come feature separata, dopo validazione.
+- **Asse di differenza:** temporalità (disaccoppia fix critico da feature nuova)
+- **Pro:** blast radius minimo per PR 1 (solo runtime, nessuna nuova logica dispositivo); WebGPU va in produzione solo dopo testing dedicato su hardware reale; separazione netta di responsabilità
+- **Contro:** due cicli di review e due merge; WebGPU rimane assente finché PR 2 non è pronta; utente dovrà re-fare il PR review process
+- **Costo/tempo indicativo:** medio (due PR medie invece di una grande)
 
-### Alternativa C — Interface-first, models deferred
+### Alternativa C — Single-PR con spike obbligatorio come Task 1
 
-- **Idea:** PR 1: EmbeddingProvider interface + migration path (flat → per-providerKey) + chunker upgrade. PR 2 (follow-up): aggiunta dei due provider multilingue. La suite test coprì l'esistente prima di toccare la logica di embedding.
-- **Asse di differenza:** temporalità (disaccoppia refactor strutturale dall'aggiunta di nuove dipendenze pesanti)
-- **Pro:** massimizza la copertura test sul path native prima del rischio di regressione; ogni PR è più piccola e reviewable; il refactor strutturale è prezioso anche senza i nuovi modelli
-- **Contro:** due cicli separati; la feature "multilingue" non è utilizzabile fino alla PR 2; richiede disciplina per non riaprire la PR 1
-- **Costo/tempo indicativo:** medio (ma distribuito)
-
-### Alternativa D — Auto-detect esteso + DLC (ibrido A + auto)
-
-- **Idea:** Come A, ma il provider `"auto"` viene esteso con language detection sulla vault (campionamento di note, rilevamento lingua dominante). Se il vault è prevalentemente non-inglese e EmbeddingGemma è disponibile, auto seleziona il provider ottimale con un banner di suggerimento. La selezione esplicita resta sempre possibile.
-- **Asse di differenza:** confini di responsabilità (il sistema assume decisione di selezione, non l'utente)
-- **Pro:** UX zero-config per la maggior parte degli utenti multilingue; coerente con la logica già presente in `"auto"` per SC vs native
-- **Contro:** language detection aggiunge complessità e un possibile punto di errore; "auto che scarica 190 MB silenziosamente" è un rischio UX se non comunicato chiaramente
-- **Costo/tempo indicativo:** alto
+- **Idea:** Un'unica PR che include tutto (runtime upgrade, WebGPU auto-detect, FORMAT_VERSION bump, migration). Ma Task 1 è uno spike esplicito: verifica la compatibilità con il loader Obsidian PRIMA di implementare qualsiasi altra cosa. Se lo spike fallisce, la PR si ferma e produce solo i null-guards di Bug 2+3. Se passa, l'implementazione completa prosegue.
+- **Asse di differenza:** temporalità + confini (decision gate embedded nel piano, non nella struttura PR)
+- **Pro:** un solo ciclo di review; WebGPU incluso fin dall'inizio; il gate di compatibilità è esplicito nel piano e bloccante; meno contesto da riaprire in una seconda PR
+- **Contro:** se lo spike rivela problemi parziali (es. WebGPU OK ma threading problematico), la PR diventa più complessa da ritagliare; rischio che il reviewer veda una PR grande
+- **Costo/tempo indicativo:** medio-alto (una PR, ma potenzialmente ampia)
 
 ---
 
 ## Rischi emersi (inversione / pre-mortem)
 
-- **Setup friction** (modello troppo pesante) → l'utente avvia il download di 190 MB, aspetta 30 minuti, e abbandona il setup. Mitigazione: DLC pattern (native resta attivo), stima visibile di dimensione e tempo prima del click, possibilità di usare e5-base come alternativa più leggera.
-- **Regressioni sul path native** → il refactor del chunker o della store introduce un bug silenzioso nella ricerca inglese per chi non cambia mai provider. Mitigazione: test suite completa sul path native prima di toccare qualsiasi shared code; chunker upgrade come step separato e verificato indipendentemente.
-- **Complessità di manutenzione esplosa** → tre provider, due index path, migration code, chunker nuovo: ogni PR tocca tutto e i test non coprono l'integrazione. Mitigazione: `TransformersProvider` base class condivisa; indici per-providerKey isolati (un bug in Gemma non corrompe native); integration test per il migration path.
+- **FORMAT_VERSION wipe silenzioso** → l'utente ha appena finito di re-indicizzare 5000 note con Gemma (2 ore di lavoro) e l'aggiornamento cancella l'indice senza avvisarlo chiaramente. Mitigazione: dialog esplicito prima del wipe (non solo banner in background), con stima del tempo di re-index basata sulla dimensione del vault.
+- **WebGPU crash su driver instabili** → `navigator.gpu` è disponibile ma la sessione ONNX crasha silenziosamente a metà inference, producendo embedding corrotti o parziali. Mitigazione: il fallback WASM deve scattare su errore di sessione, non solo su assenza di `navigator.gpu`; test con un modello piccolo prima di caricare Gemma 300M.
+- **Bundle size growth inatteso** → `@huggingface/transformers` v4 porta WASM workers, threading, e backend aggiuntivi che gonfiano il bundle. Mitigazione: audit del bundle post-build; `external` declarations in `bun.config.ts` aggiornate se necessario; smoke test su Obsidian reale, non solo su `bun build`.
+- **import.meta.url non risolto in v4** → Task 1 spike fallisce: il loader Obsidian non riesce a caricare il plugin. Mitigazione: piano di fallback documentato nella SPEC (Bug 2+3 null-guards); lo spike deve fallire esplicitamente con un errore chiaro, non silenziosamente.
 
 ---
 
 ## Idee adiacenti emerse
 
-- **Ricerca ibrida vettori + BM25** — batterebbe il puro vettoriale su query corte; architetturalmente richiederebbe un layer di fusion score non previsto. [future]
-- **Matryoshka dim configurabile** (slider 256/512/768d in settings per EmbeddingGemma) — il modello lo supporta nativamente; dimensioni ridotte = indice ~2x più piccolo + ricerca più veloce, con leggera perdita di qualità. [future — da annotare come opzione nell'ADR senza implementare]
-- **Bundle e5-base nel plugin** (nessun download, +~100 MB sul plugin scaricato) — non praticabile: l'Obsidian store ha limiti di dimensione del plugin e i 100 MB a freddo penalizzano tutti gli utenti anche quelli che non usano la feature. [esplicitamente esclusa]
+- **Lazy DLC per Gemma** — invece di scaricare il modello al primo avvio, mostrare un banner "Gemma disponibile" e scaricare solo su click esplicito dell'utente. Risolverebbe il problema setup-friction (190 MB a freddo). [future — non nel scope di questo upgrade]
+- **Matryoshka dim configurabile per Gemma** — il modello supporta 256/384/512/768d nativamente; esporre come slider nelle settings riduce storage e latenza con piccola perdita di qualità. [future — annotare nell'ADR come opzione]
 
 ---
 
 ## Raccomandazione preliminare
 
-**Alternativa A** (SPEC fedele) è la scelta più solida, con due integrazioni dal brainstorm che non aumentano il costo ma riducono i rischi:
+**Ibrido B+C**: struttura single-PR (un solo ciclo di review) ma con Task 1 spike bloccante come da Alt C, e WebGPU incluso ma validato post-session da folotp prima del merge come da Alt B. In pratica: piano in 6-8 task, Task 1 è il compatibilità-spike (se fallisce → fallback; se passa → tutto il resto), Task finale è la validazione su vault reale.
 
-1. **DLC UX**: la ricerca native rimane attiva durante il download e il rebuild — nessun blackout. Questo elimina il rischio setup friction senza aggiungere complessità architetturale.
-2. **Auto-mode esteso** (Alternativa D semplificata): `"auto"` suggerisce EmbeddingGemma via banner se rileva contenuto non-inglese, ma non scarica nulla senza consenso esplicito. Language detection superficiale (campione di note, heuristica su caratteri non-ASCII).
-
-Se il team vuole ridurre il rischio di regressione e il tempo al primo rilascio, **Alternativa C** (interface-first) è la seconda scelta: il refactor strutturale è prezioso da solo e permette di verificare l'esistente prima di aggiungere i nuovi modelli pesanti.
+Task 0 (model-ID hunt, ~30 minuti) va eseguito prima del dispatch del coder, come check rapido: se un export IR ≤ v8 esiste, l'intera catena viene bypassata.
 
 **Dichiarata come raccomandazione preliminare**: da validare dall'architect.
 
@@ -87,8 +77,7 @@ Se il team vuole ridurre il rischio di regressione e il tempo al primo rilascio,
 
 ## Note per l'architect
 
-- **Matryoshka dim**: valutare se esporre dim come parametro dell'`EmbeddingProvider` interface (es. `readonly dimensions: number`) in modo che un futuro provider possa dichiarare dimensioni variabili, senza implementare il configuratore ora. Annotare come `future` nell'ADR.
-- **DLC UX e stato store**: il provider attivo nelle settings può divergere dall'indice disponibile. L'architect deve chiarire quale è la source of truth durante il rebuild e come gestire query concorrenti al vecchio indice mentre il nuovo si costruisce.
-- **Language detection per auto-mode**: la detection può essere lazy (sul primo accesso alle note) o eager (al caricamento del plugin). L'eager detection può rallentare il plugin load su vault grandi. Valutare soglia o campionamento.
-- **Migration path testing**: il migration test (flat `embeddings/` → `embeddings/native-minilm-l6-v2/`) va coperto con un integration test che usa un filesystem reale (non mock) — la logica coinvolge path-join e rename, difficile da testare in isolamento.
-- **Requisiti nuovi da riportare in SPEC**: l'auto-mode esteso con language detection non è esplicitamente in SPEC; se si adotta, aggiungere un paragrafo al comportamento di `"auto"`.
+- **Task 0 pre-spike**: verificare l'esistenza di un export IR ≤ v8 di EmbeddingGemma 300M su HuggingFace prima di scrivere codice. Se trovato, l'upgrade di runtime diventa opzionale — l'ADR deve documentare questa verifica e il suo esito.
+- **FORMAT_VERSION bump**: l'ADR deve specificare esattamente quando scatta il dialog di conferma wipe — al plugin load, al primo utilizzo di search, o su provider-switch. Il comportamento attuale (banner in background) è insufficiente per un wipe distruttivo.
+- **WebGPU fallback granularity**: il fallback non deve scattare solo su `!navigator.gpu` ma su qualsiasi errore di inizializzazione sessione. L'ADR deve specificare quale errore è recuperabile (retry WASM) e quale è terminale (log + disable provider).
+- **Requisiti nuovi da riportare in SPEC**: il dialog esplicito pre-wipe non è esplicitamente nella SPEC attuale; se si adotta, aggiungere un edge case con il comportamento atteso.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,3 +489,17 @@ ADR: `docs/architecture/ADR-0006-mcp-prompts-in-process.md`
 - **`PromptFrontmatterSchema` richiede `tags` come array** — `metadataCache.frontmatter.tags` può essere una stringa scalare YAML (`tags: mcp-tools-prompt`). Aggiungere coercizione in `promptDiscovery.ts` prima della validazione ArkType.
 - **Discovery usa `app.vault.getMarkdownFiles()` + `metadataCache`** — non HTTP calls a Local REST API. Flat directory (`Prompts/` root only, no subfolders). File senza tag `mcp-tools-prompt` esclusi silenziosamente.
 - **Nota**: la sezione "### Prompts" sopra descrive il comportamento 0.3.x (Templater + `/templates/execute`). Aggiornare quella sezione nella stessa PR che shippa ADR-0006.
+
+## Decisioni dal chain transformersjs-v4-upgrade-onnx-ir10-fix
+
+ADR: `docs/architecture/ADR-0007-transformersjs-v4-upgrade-onnx-ir10-fix.md`
+
+**Key decisions to carry forward:**
+
+- **Task 0 + Task 1 sono gate bloccanti** — prima di toccare qualsiasi codice, Task 0 verifica se esiste un export ONNX IR ≤ v8 di EmbeddingGemma 300M su HuggingFace (se sì, fix = solo model-ID); Task 1 spike verifica la compatibilità di `@huggingface/transformers` v4 con il loader Electron di Obsidian (bun bundler). Se Task 1 fallisce, il fallback è null-guards su Bug 2+3 senza upgrade runtime.
+- **`@xenova/transformers` → `@huggingface/transformers` v4** — package rename stabile da v3; `onnxruntime-web` ≥ 1.20 è il requisito minimo per supportare ONNX IR v10. Il redirect `onnxruntime-node → onnxruntime-web` in `bun.config.ts` resta necessario (Electron renderer espone `process.release.name === 'node'`); verificare se ancora richiesto dopo l'upgrade.
+- **`FORMAT_VERSION` 2 → 3: `IndexWipeMigrationModal` obbligatoria** — a differenza di v1→v2 (path rename, nessuna perdita dati), v2→v3 distrugge l'indice esistente. Prima del wipe deve apparire un `Modal` bloccante (`IndexWipeMigrationModal`, ~30 righe, pattern `CommandPermissionModal`) con un unico bottone "Rebuild now". Nessun dismiss silenzioso.
+- **`store.test.ts` line 325: literal `toBe(2)` va aggiornato a `toBe(3)`** — unico punto nel test suite che asserisce il valore letterale di `FORMAT_VERSION` anziché usare la costante esportata. Tutti gli altri test già referenziano `FORMAT_VERSION` per nome e rimangono validi dopo il bump.
+- **WebGPU fallback a livello di session-init** — il fallback a WASM non scatta solo su `!navigator.gpu` ma su qualsiasi errore durante l'inizializzazione della sessione ONNX (driver crash, `requestAdapter()` failure). Try/catch sull'intero probe; log WARN; graceful degradation a WASM.
+- **`onnxruntime-web` CDN URL in `onnxEnv.ts`** — aggiornare il path CDN dalla versione 1.14.0 pinned alla versione installata con v4 (verificare con `bun pm ls onnxruntime-web` post-install).
+- **Spike fallback documentato** — se Task 1 fallisce, l'errore esatto del loader va annotato in un commento inline in cima a `embedder.ts` per il prossimo tentativo di upgrade.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,177 +1,110 @@
-# SPEC: MCP Prompts feature for in-process server
+# SPEC: Transformers.js v4 upgrade + ONNX IR v10 compatibility fix
 
 ## Objective
 
-Wire the `prompts` capability into the in-process streamable-HTTP MCP server
-(0.4.x). The server currently declares no `prompts` capability and registers
-no `prompts/list` or `prompts/get` handlers. After this change, prompt files
-in the vault's `Prompts/` folder surface as slash-commands in MCP clients
-(e.g. `/mcp__mcp-tools-istefox__my-prompt` in Claude Code).
+Upgrade `@xenova/transformers` v2.17.2 to `@huggingface/transformers` v4 (+ matching
+`onnxruntime-web` ≥ 1.20) to resolve the ONNX IR version mismatch that prevents
+EmbeddingGemma 300M from loading. Incidentally resolves the silent-fallback and
+`.split` crash reported in issue #202.
+
+## Problem statement
+
+`@xenova/transformers` v2.17.2 ships an `onnxruntime-web` that caps ONNX IR at v8.
+EmbeddingGemma 300M is exported at ONNX IR v10. Both the `webgpu_fp32` and `wasm`
+backends fail with `Unsupported model IR version: 10, max supported IR version: 8`
+before any inference runs. Downstream bugs (silent fallback to MiniLM, `.split`
+crash at query time) are consequences of the model never loading. Full root-cause
+fix is the runtime upgrade.
 
 ## Scope
 
-**In scope:**
+### In scope
+- Replace `@xenova/transformers` with `@huggingface/transformers` v4 across all
+  embedding providers (`TransformersProvider` base, `EmbeddingGemmaProvider`,
+  `MultilingualE5Provider`, `MiniLMProvider`).
+- Update `onnxruntime-web` to ≥ 1.20 (included in `@huggingface/transformers` v4
+  peer deps or bundled; verify pinned version).
+- Verify + update HuggingFace model IDs for all three providers (IDs may differ
+  between `Xenova/` namespace and `Hugging Face/` namespace in v4).
+- Auto-detect WebGPU at provider init; fall back silently to WASM. No new settings
+  UI or user-facing device selector.
+- Bump `FORMAT_VERSION` 2 → 3 to invalidate v2-built indexes and trigger
+  automatic re-indexing on first load (consistent with `migrateV1FlatStore` pattern).
+- Update `onnxEnv.ts` `configureEnv()` for v4 API changes (env configuration,
+  WASM paths, threading).
 
-- Declare `prompts` capability on the MCP server.
-- `prompts/list` handler: scan `Prompts/` folder, filter by `mcp-tools-prompt`
-  tag, parse argument declarations, return MCP prompt list.
-- `prompts/get` handler: read prompt file, strip argument declarations, substitute
-  `{{arg_name}}` placeholders with provided values, return as user message.
-- `notifications/prompts/list_changed`: vault event watcher on `Prompts/` that
-  triggers client notification on file create / rename / delete.
-- New feature module `src/features/prompts/` with `setup()` / `teardown()` contract.
+### Out of scope
+- WebGPU manual selection UI (future work).
+- Explicit null-guard fixes for Bug 2 / Bug 3 (expected as side-effects of the
+  upgrade; covered by test assertions).
+- Migration of the `@xenova/transformers` v2 → v3 intermediate step (jump
+  directly to v4).
+- Any changes outside `features/semantic-search/`.
 
-**Out of scope:**
+## Stack / runtime constraints
 
-- Templater execution for `prompts/get` (no Templater dependency).
-- Subfolders under `Prompts/` (flat directory only, per existing vault contract).
-- New vault-side file format changes (re-use the existing `tp.mcpTools.prompt`
-  declaration syntax and `mcp-tools-prompt` tag).
-- `prompts/listChanged` subscription tracking (server sends; clients subscribe
-  at their own discretion).
-
-## Stack
-
-TypeScript strict mode, Bun workspace, `bun:test`. Obsidian plugin runtime
-(in-process, no separate binary). `@modelcontextprotocol/sdk` 1.29.0. ArkType
-for frontmatter validation at the boundary. No new npm dependencies.
+| Constraint | Detail |
+|---|---|
+| Bundler | Bun 1.3.12, `bun.config.ts` — `external: ['obsidian', '@codemirror/*', '@lezer/*']` |
+| Runtime | Obsidian Electron (desktop); WASM executed in renderer process |
+| Known risk | `@xenova/transformers` v2 was pinned because v4 broke under Obsidian's plugin loader (`import.meta.url` resolution). This may be resolved in v4 — **Task 1 of the plan must verify this before any other implementation task runs**. If verification fails, the implementation falls back to defensive fixes (Bug 2 + Bug 3 null-guards) without the v4 upgrade. |
+| Package rename | `@xenova/transformers` → `@huggingface/transformers` (occurred in v3, stable in v4) |
+| ONNX IR | `@huggingface/transformers` v4 + `onnxruntime-web` ≥ 1.20 supports IR v10+ |
 
 ## Architecture
 
-### Feature layout
+No structural changes to the embedding layer. All changes are within existing
+provider classes and `onnxEnv.ts`. The `EmbeddingProvider` interface and
+`EmbeddingStoreRegistry` are unchanged.
 
-```
-src/features/prompts/
-├── services/
-│   ├── promptDiscovery.ts   # list + parse arg declarations
-│   ├── promptRenderer.ts    # strip declarations + substitute args
-│   └── vaultWatcher.ts      # subscribe vault events → listChanged notification
-└── index.ts                 # setup(), teardown(), handler registration
-```
+### Files affected
+- `packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts` —
+  `configureEnv()` updated for v4 API; add WebGPU auto-detect + WASM fallback.
+- `packages/obsidian-plugin/src/features/semantic-search/services/providers/` —
+  `transformersProvider.ts` base class + all three concrete providers: import path
+  change, model ID verification, device selection via `env.backends`.
+- `packages/obsidian-plugin/src/features/semantic-search/constants.ts` (or
+  `types.ts`) — `FORMAT_VERSION` 2 → 3.
+- `packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts` —
+  migration guard for FORMAT_VERSION 3 (wipe v2 index, trigger re-index banner).
+- `packages/obsidian-plugin/package.json` — dependency swap.
 
-### Integration points
+## WebGPU backend selection
 
-- `src/main.ts` — calls `promptsFeature.setup(server, app)` during plugin `onload`.
-- `src/features/mcp-transport/` — server must declare `{ prompts: {} }` in its
-  capabilities object alongside the existing `tools` capability.
-- `ToolRegistry` — handlers registered through the existing registry (consistent
-  with the "single registration path" invariant in CLAUDE.md).
+On provider init, `configureEnv()` probes `navigator.gpu` availability:
+- If available: set `device: 'webgpu'`.
+- Otherwise: set `device: 'wasm'` with SIMD + multi-thread where supported.
 
-### Data flow
+No user-visible configuration. The device actually used is logged at `INFO` level
+via the shared `logger`. No settings panel change.
 
-**`prompts/list`:**
-```
-app.vault.getMarkdownFiles()
-  → filter path prefix "Prompts/"
-  → filter tag "mcp-tools-prompt" via metadataCache.getFileCache()
-  → for each file: cachedRead → parseArgDeclarations()
-  → return PromptListEntry[]
-```
+## Store migration
 
-**`prompts/get(name, args)`:**
-```
-find file by name (filename without extension → prompt name)
-  → cachedRead
-  → stripFrontmatter()
-  → stripArgDeclarations()   # remove <% tp.mcpTools.prompt(...) %> lines
-  → substituteArgs(body, args)  # {{arg_name}} → provided value; unknown keys left as-is
-  → return { messages: [{ role: "user", content: { type: "text", text: body } }] }
-```
+`FORMAT_VERSION` bump 2 → 3 at the top of `indexer.ts`. On load:
 
-**`notifications/prompts/list_changed`:**
-```
-vault.on('create' | 'rename' | 'delete')
-  → if path starts with "Prompts/" and ends with ".md"
-  → server.sendPromptListChanged()
-```
+1. Detect stored `FORMAT_VERSION < 3`.
+2. Delete the existing index directory for the active provider key.
+3. Surface the re-index banner (existing UX, already used for v1→v2 migration).
 
-## Data model
-
-### Vault-side prompt file (existing contract, read-only)
-
-```markdown
----
-tags:
-  - mcp-tools-prompt
-description: "Optional description for MCP clients"
----
-<% tp.mcpTools.prompt("topic", "The subject to explain") %>
-<% tp.mcpTools.prompt("level", "Target audience level") %>
-
-Explain {{topic}} at {{level}} level.
-```
-
-### Argument declaration parsing
-
-- Pattern: `/<% tp\.mcpTools\.prompt\("([^"]+)",\s*"([^"]*)"\) %>/g`
-- First capture: argument name (maps to `{{name}}` placeholder).
-- Second capture: argument description (exposed in MCP `PromptArgument.description`).
-- Declarations stripped from the rendered body before substitution.
-
-### MCP `PromptListEntry` shape
-
-```typescript
-{
-  name: string;          // filename without extension
-  description?: string;  // frontmatter "description" field, if present
-  arguments: Array<{
-    name: string;
-    description: string;
-    required: false;     // graceful passthrough — never hard-fail on missing arg
-  }>;
-}
-```
-
-### Prompt name derivation
-
-`filename (no extension)` — no slug transformation. File `Prompts/My Prompt.md`
-→ name `"My Prompt"`. Clients may display or slugify as they wish.
-
-## API
-
-### `prompts/list`
-
-- No parameters.
-- Returns all files in `Prompts/` (vault root only) with tag `mcp-tools-prompt`.
-- Empty list when `Prompts/` does not exist — no error.
-- Argument declarations parsed from cached file content.
-
-### `prompts/get`
-
-- Parameters: `{ name: string; arguments?: Record<string, string> }`.
-- Lookup: find `Prompts/<name>.md` (exact, case-sensitive).
-- `McpError(ErrorCode.InvalidParams)` if file not found or tag absent.
-- Missing `arguments` or absent key → placeholder left in body (no error).
-- Response: `{ messages: [{ role: "user", content: { type: "text", text: string } }] }`.
-
-### `notifications/prompts/list_changed`
-
-- Sent when a `.md` file is created, renamed into/out of, or deleted within `Prompts/`.
-- One notification per vault event (no debounce required in v1).
+Failure to delete is logged and surfaced via the re-index banner — same fail-open
+pattern as `migrateV1FlatStore`.
 
 ## Edge cases
 
-| Case | Behavior |
+| Case | Handling |
 |---|---|
-| `Prompts/` folder missing | `prompts/list` returns `[]`. No error. |
-| File missing `mcp-tools-prompt` tag | Excluded from list silently. |
-| No arg declarations in body | Valid prompt with `arguments: []`. |
-| Arg provided but no matching `{{placeholder}}` | Ignored silently. |
-| Arg declared but not provided in `prompts/get` | Placeholder left as-is in returned text. |
-| File renamed (in Obsidian) | `listChanged` fires; client re-fetches list. |
-| Duplicate name (two files differ only in extension) | Not possible: only `.md` files are scanned. |
-| Templater not installed | No impact — Templater is not invoked. |
+| WebGPU available but model load fails | `configureEnv()` catches the session error, retries with `device: 'wasm'`. Logs the fallback at WARN. |
+| v4 breaks Obsidian plugin loader (import.meta.url) | Task 1 must fail explicitly. Plan fallback = defensive Bug 2+3 fixes without runtime upgrade. |
+| User had MiniLM index from v2 (FORMAT_VERSION 2) | Wiped on first load; re-index triggered. User notified via banner. |
+| Model IDs changed in HuggingFace namespace | Task: verify each provider. If an ID is stale, update to the v4-compatible ID before writing any provider code. |
+| onnxruntime-web version conflict in bun.lock | Pin explicitly in `package.json`; run `bun install --frozen-lockfile` to validate. |
 
 ## Success criteria
 
-1. `prompts/list` returns a non-empty list when `Prompts/` contains at least
-   one `.md` file tagged `mcp-tools-prompt`.
-2. `prompts/get("my-prompt", { topic: "Rust" })` returns a user message with
-   `{{topic}}` substituted by `"Rust"`.
-3. Adding a new file to `Prompts/` while the server is running triggers a
-   `notifications/prompts/list_changed` notification within one Obsidian event
-   cycle.
-4. All existing 999 tests continue to pass.
-5. `bun run check` (type check) passes with no new errors.
-6. The feature degrades gracefully when `Prompts/` is absent — no crash, no
-   uncaught error.
+1. `bun run check` passes (no TypeScript errors).
+2. `bun run build` produces a valid `main.js` (bundle smoke).
+3. `cd packages/obsidian-plugin && bun test` — all tests green (999+/999+).
+4. EmbeddingGemma 300M loads without ONNX IR error in a real Obsidian vault.
+5. After indexing with EmbeddingGemma 300M, chunk count survives an Obsidian restart.
+6. `search_vault_smart` returns results without crashing when EmbeddingGemma is the active provider.
+7. Folotp confirms criteria 4–6 on their vault before the PR is merged to `main`.

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "fs-extra": "^11.2.0",
         "obsidian-daily-notes-interface": "^0.9.4",
         "obsidian-local-rest-api": "^2.5.4",
-        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "onnxruntime-web": "1.26.0",
         "radash": "^12.1.0",
         "rxjs": "^7.8.1",
         "semver": "^7.6.3",
@@ -81,6 +81,7 @@
     "svelte@5.18.0": "patches/svelte@5.18.0.patch",
   },
   "overrides": {
+    "onnxruntime-web": "1.26.0",
     "vite": "5.4.11",
   },
   "packages": {
@@ -866,7 +867,7 @@
 
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
-    "obsidian": ["obsidian@1.12.3", "", { "dependencies": { "@types/codemirror": "5.60.8", "moment": "2.29.4" }, "peerDependencies": { "@codemirror/state": "6.5.0", "@codemirror/view": "6.38.6" } }, "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw=="],
+    "obsidian": ["obsidian@1.13.0", "", { "dependencies": { "@types/codemirror": "5.60.8", "moment": "2.29.4" }, "peerDependencies": { "@codemirror/state": "6.5.0", "@codemirror/view": "6.38.6" } }, "sha512-PHw5+SAPlJ0S3leFvJ0wgFg63Z3DavxL6+d1ll+8toXR2ZlYKc1rMWqdUv9LgUbTwPQUyY6yfhOMMivampRRiQ=="],
 
     "obsidian-calendar-ui": ["obsidian-calendar-ui@0.3.12", "", { "dependencies": { "obsidian-daily-notes-interface": "0.8.4", "svelte": "3.35.0", "tslib": "2.1.0" } }, "sha512-hdoRqCPnukfRgCARgArXaqMQZ+Iai0eY7f0ZsFHHfywpv4gKg3Tx5p47UsLvRO5DD+4knlbrL7Gel57MkfcLTw=="],
 
@@ -882,11 +883,11 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
+    "onnxruntime-common": ["onnxruntime-common@1.26.0", "", {}, "sha512-qVyMR4lcWgbkc4getFV+GQijsTnbg/siteoqcDwa3sI/LxbrMSNw4ePyvCq/ymdQaRomCA7YuWmhzsswxvymdw=="],
 
     "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
 
-    "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260416-b7804b056c", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw=="],
+    "onnxruntime-web": ["onnxruntime-web@1.26.0", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.26.0", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-LbRr/8zZt2xilI2smrVQGGKINo0U46i8qJp+UXyMBGfqN7KjnH1BiwCwLwyNIVV4i9CKFv7Sf4PwLKWnT8/bEA=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -9,14 +10,15 @@
     "packages/obsidian-plugin": {
       "name": "@obsidian-mcp-tools/obsidian-plugin",
       "dependencies": {
+        "@huggingface/transformers": "4.2.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@types/fs-extra": "^11.0.4",
-        "@xenova/transformers": "2.17.2",
         "arktype": "^2.0.0-rc.30",
         "express": "^4.21.2",
         "fs-extra": "^11.2.0",
         "obsidian-daily-notes-interface": "^0.9.4",
         "obsidian-local-rest-api": "^2.5.4",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
         "radash": "^12.1.0",
         "rxjs": "^7.8.1",
         "semver": "^7.6.3",
@@ -96,6 +98,8 @@
 
     "@codemirror/view": ["@codemirror/view@6.36.1", "", { "dependencies": { "@codemirror/state": "^6.5.0", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-miD1nyT4m4uopZaDdO2uXU/LLHliKNYL9kB1C1wJHrunHLm/rpkb5QVSokqgw9hFqEZakrdlb/VGWX8aYZTslQ=="],
 
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
@@ -162,7 +166,11 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
-    "@huggingface/jinja": ["@huggingface/jinja@0.2.2", "", {}, "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA=="],
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.9", "", {}, "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw=="],
+
+    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@4.2.0", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "@huggingface/tokenizers": "^0.1.3", "onnxruntime-node": "1.24.3", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "sharp": "^0.34.5" } }, "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -175,6 +183,56 @@
     "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.1", "", {}, "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -216,21 +274,21 @@
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
 
-    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
 
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
 
-    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
 
     "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
 
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
 
     "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
 
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.30.1", "", { "os": "android", "cpu": "arm" }, "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q=="],
 
@@ -302,8 +360,6 @@
 
     "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
-    "@types/long": ["@types/long@4.0.2", "", {}, "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="],
-
     "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
 
     "@types/node": ["@types/node@16.18.122", "", {}, "sha512-rF6rUBS80n4oK16EW8nE75U+9fw0SSUgoPtWSvHhPXdT7itbvmS7UjB/jyM8i3AkvI6yeSM5qCwo+xN0npGDHg=="],
@@ -342,8 +398,6 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.2.1", "", {}, "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA=="],
 
-    "@xenova/transformers": ["@xenova/transformers@2.17.2", "", { "dependencies": { "@huggingface/jinja": "^0.2.2", "onnxruntime-web": "1.14.0", "sharp": "^0.32.0" }, "optionalDependencies": { "onnxruntime-node": "1.14.0" } }, "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ=="],
-
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
@@ -353,6 +407,8 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "acorn-typescript": ["acorn-typescript@1.4.13", "", { "peerDependencies": { "acorn": ">=8.9.0" } }, "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q=="],
+
+    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -394,23 +450,13 @@
 
     "bare-events": ["bare-events@2.5.0", "", {}, "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A=="],
 
-    "bare-fs": ["bare-fs@4.7.1", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw=="],
-
-    "bare-os": ["bare-os@3.9.0", "", {}, "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q=="],
-
-    "bare-path": ["bare-path@3.0.0", "", { "dependencies": { "bare-os": "^3.0.1" } }, "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw=="],
-
-    "bare-stream": ["bare-stream@2.13.0", "", { "dependencies": { "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA=="],
-
-    "bare-url": ["bare-url@2.4.2", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A=="],
-
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
-
     "body-parser": ["body-parser@1.20.3", "", { "dependencies": { "bytes": "3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "on-finished": "2.4.1", "qs": "6.13.0", "raw-body": "2.5.2", "type-is": "~1.6.18", "unpipe": "1.0.0" } }, "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g=="],
+
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
@@ -440,17 +486,11 @@
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
-    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
-
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
-
-    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
@@ -482,19 +522,21 @@
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
-    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
-
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
-
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "devalue": ["devalue@5.1.1", "", {}, "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw=="],
 
@@ -518,13 +560,13 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
-
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-object-atoms": ["es-object-atoms@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -568,13 +610,9 @@
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
-    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
-
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
-
-    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "express": ["express@4.21.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "1.20.3", "content-disposition": "0.5.4", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "1.3.1", "fresh": "0.5.2", "http-errors": "2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "0.1.12", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "0.19.0", "serve-static": "1.16.2", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="],
 
@@ -608,7 +646,7 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
-    "flatbuffers": ["flatbuffers@1.12.0", "", {}, "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="],
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
     "flatted": ["flatted@3.3.2", "", {}, "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="],
 
@@ -619,8 +657,6 @@
     "fraction.js": ["fraction.js@4.3.7", "", {}, "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="],
 
     "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
-
-    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fs-extra": ["fs-extra@11.2.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw=="],
 
@@ -634,15 +670,17 @@
 
     "get-intrinsic": ["get-intrinsic@1.2.6", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "dunder-proto": "^1.0.0", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "function-bind": "^1.1.2", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.0.0" } }, "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA=="],
 
-    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
-
     "glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
     "globals": ["globals@15.14.0", "", {}, "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
     "globalyzer": ["globalyzer@0.1.0", "", {}, "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="],
 
@@ -659,6 +697,8 @@
     "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -686,13 +726,9 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
-
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
-
-    "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -736,6 +772,8 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
     "jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
@@ -764,7 +802,7 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
-    "long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -792,15 +830,9 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
-
     "minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "moment": ["moment@2.29.4", "", {}, "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="],
 
@@ -814,15 +846,9 @@
 
     "nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
 
-    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
-
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
-
-    "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
-
-    "node-addon-api": ["node-addon-api@6.1.0", "", {}, "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="],
 
     "node-forge": ["node-forge@1.3.1", "", {}, "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="],
 
@@ -837,6 +863,8 @@
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
     "object-inspect": ["object-inspect@1.13.3", "", {}, "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "obsidian": ["obsidian@1.12.3", "", { "dependencies": { "@types/codemirror": "5.60.8", "moment": "2.29.4" }, "peerDependencies": { "@codemirror/state": "6.5.0", "@codemirror/view": "6.38.6" } }, "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw=="],
 
@@ -854,13 +882,11 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onnx-proto": ["onnx-proto@4.0.4", "", { "dependencies": { "protobufjs": "^6.8.8" } }, "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA=="],
+    "onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
-    "onnxruntime-common": ["onnxruntime-common@1.14.0", "", {}, "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew=="],
+    "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
 
-    "onnxruntime-node": ["onnxruntime-node@1.14.0", "", { "dependencies": { "onnxruntime-common": "~1.14.0" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w=="],
-
-    "onnxruntime-web": ["onnxruntime-web@1.14.0", "", { "dependencies": { "flatbuffers": "^1.12.0", "guid-typescript": "^1.0.9", "long": "^4.0.0", "onnx-proto": "^4.0.4", "onnxruntime-common": "~1.14.0", "platform": "^1.3.6" } }, "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw=="],
+    "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260416-b7804b056c", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -924,8 +950,6 @@
 
     "preact": ["preact@10.25.3", "", {}, "sha512-dzQmIFtM970z+fP9ziQ3yG4e3ULIbwZzJ734vaMVUTaKQ2+Ru1Ou/gjshOYVHCcd1rpAelC6ngjvjDXph98unQ=="],
 
-    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
-
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.4.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ=="],
@@ -938,11 +962,9 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
-    "protobufjs": ["protobufjs@6.11.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.1", "@types/node": ">=13.7.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-OKjVH3hDoXdIZ/s5MLv8O2X0s+wOxGfV7ar6WFSKGaSAxi/6gYn3px5POS4vi+mc/0zCOdL7Jkwrj0oT1Yst2A=="],
+    "protobufjs": ["protobufjs@7.6.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -959,8 +981,6 @@
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.0", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.6.3", "unpipe": "1.0.0" } }, "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g=="],
-
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
@@ -984,6 +1004,8 @@
 
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "rollup": ["rollup@4.30.1", "", { "dependencies": { "@types/estree": "1.0.6" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.30.1", "@rollup/rollup-android-arm64": "4.30.1", "@rollup/rollup-darwin-arm64": "4.30.1", "@rollup/rollup-darwin-x64": "4.30.1", "@rollup/rollup-freebsd-arm64": "4.30.1", "@rollup/rollup-freebsd-x64": "4.30.1", "@rollup/rollup-linux-arm-gnueabihf": "4.30.1", "@rollup/rollup-linux-arm-musleabihf": "4.30.1", "@rollup/rollup-linux-arm64-gnu": "4.30.1", "@rollup/rollup-linux-arm64-musl": "4.30.1", "@rollup/rollup-linux-loongarch64-gnu": "4.30.1", "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1", "@rollup/rollup-linux-riscv64-gnu": "4.30.1", "@rollup/rollup-linux-s390x-gnu": "4.30.1", "@rollup/rollup-linux-x64-gnu": "4.30.1", "@rollup/rollup-linux-x64-musl": "4.30.1", "@rollup/rollup-win32-arm64-msvc": "4.30.1", "@rollup/rollup-win32-ia32-msvc": "4.30.1", "@rollup/rollup-win32-x64-msvc": "4.30.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
@@ -1000,7 +1022,11 @@
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
     "send": ["send@0.19.0", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "0.5.2", "http-errors": "2.0.0", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "2.4.1", "range-parser": "~1.2.1", "statuses": "2.0.1" } }, "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@1.16.2", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "0.19.0" } }, "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw=="],
 
@@ -1010,7 +1036,7 @@
 
     "shared": ["shared@workspace:packages/shared"],
 
-    "sharp": ["sharp@0.32.6", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.2", "node-addon-api": "^6.1.0", "prebuild-install": "^7.1.1", "semver": "^7.5.4", "simple-get": "^4.0.1", "tar-fs": "^3.0.4", "tunnel-agent": "^0.6.0" } }, "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w=="],
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1026,12 +1052,6 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
-
-    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
-
-    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
-
     "sirv": ["sirv@3.0.0", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
@@ -1039,6 +1059,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "split-on-first": ["split-on-first@1.1.0", "", {}, "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
@@ -1076,11 +1098,7 @@
 
     "tailwindcss": ["tailwindcss@3.4.17", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.6", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og=="],
 
-    "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
-
     "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
-
-    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
 
     "test-server": ["test-server@workspace:packages/test-site"],
 
@@ -1107,8 +1125,6 @@
     "tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
 
     "tsutils": ["tsutils@3.21.0", "", { "dependencies": { "tslib": "^1.8.1" }, "peerDependencies": { "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta" } }, "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA=="],
-
-    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "turndown": ["turndown@7.2.0", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A=="],
 
@@ -1222,14 +1238,6 @@
 
     "autoprefixer/caniuse-lite": ["caniuse-lite@1.0.30001692", "", {}, "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A=="],
 
-    "bare-fs/bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
-
-    "bare-stream/streamx": ["streamx@2.25.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg=="],
-
-    "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
-
-    "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
     "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
@@ -1250,8 +1258,6 @@
 
     "eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@2.1.0", "", {}, "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="],
 
-    "events-universal/bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
-
     "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -1259,6 +1265,8 @@
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "global-agent/matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -1276,13 +1284,11 @@
 
     "obsidian-local-rest-api/express": ["express@5.0.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.0.1", "content-disposition": "^1.0.0", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "^1.2.1", "debug": "4.3.6", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "^2.0.0", "fresh": "2.0.0", "http-errors": "2.0.0", "merge-descriptors": "^2.0.0", "methods": "~1.1.2", "mime-types": "^3.0.0", "on-finished": "2.4.1", "once": "1.4.0", "parseurl": "~1.3.3", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "router": "^2.0.0", "safe-buffer": "5.2.1", "send": "^1.1.0", "serve-static": "^2.1.0", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "^2.0.0", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ=="],
 
+    "onnxruntime-node/onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
+
     "postcss-load-config/lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
 
-    "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
-
     "protobufjs/@types/node": ["@types/node@20.17.10", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA=="],
-
-    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -1293,6 +1299,8 @@
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
+    "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1309,8 +1317,6 @@
     "tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "tailwindcss/postcss-load-config": ["postcss-load-config@4.0.2", "", { "dependencies": { "lilconfig": "^3.0.0", "yaml": "^2.3.4" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ=="],
-
-    "teex/streamx": ["streamx@2.25.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg=="],
 
     "tsutils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
@@ -1458,8 +1464,6 @@
 
     "obsidian-local-rest-api/express/type-is": ["type-is@2.0.0", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw=="],
 
-    "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
-
     "rimraf/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -1563,8 +1567,6 @@
     "obsidian-local-rest-api/express/send/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "obsidian-local-rest-api/express/type-is/media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
-
-    "prebuild-install/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 

--- a/docs/architecture/ADR-0007-transformersjs-v4-upgrade-onnx-ir10-fix.md
+++ b/docs/architecture/ADR-0007-transformersjs-v4-upgrade-onnx-ir10-fix.md
@@ -1,0 +1,210 @@
+# ADR-0007 — Transformers.js v4 upgrade + ONNX IR v10 compatibility fix
+
+**Status:** Proposed  
+**Date:** 2026-05-27  
+**Deciders:** Stefano Ferri
+
+---
+
+## Context
+
+`@xenova/transformers` v2.17.2 bundles `onnxruntime-web` pinned to a version that
+caps ONNX IR at v8. `onnx-community/embeddinggemma-300m-ONNX` is exported at IR
+v10; both the `webgpu_fp32` and `wasm` backends abort with
+`Unsupported model IR version: 10, max supported IR version: 8` before any
+inference runs. Downstream symptoms (silent fallback to MiniLM, `.split` crash
+at query time) are consequences of the model never loading; they require no
+independent fix if the runtime is upgraded.
+
+`@xenova/transformers` was previously pinned to v2.17.2 after a 2026-04-26 spike
+found that v4 (`@huggingface/transformers`) fails under Obsidian's eval-based
+plugin loader due to `import.meta.url` references at module init. That spike
+outcome is the primary risk this work re-tests.
+
+Two structural questions must be resolved before any code is written:
+
+1. **Task 0 (pre-spike):** Does an ONNX IR ≤ v8 export of EmbeddingGemma 300M
+   exist on HuggingFace? If yes, the fix degrades to a model-ID update with no
+   dependency change, and the upgrade path is bypassed entirely.
+2. **Task 1 (spike):** Does `@huggingface/transformers` v4 load cleanly under
+   Obsidian's Electron plugin loader with the Bun CJS bundler? If the spike
+   fails, the implementation falls back to defensive null-guards for Bug 2 + Bug
+   3 only, with no runtime upgrade.
+
+The FORMAT_VERSION bump (2 → 3) invalidates existing indexes, which may
+represent hours of embedding work for large vaults. Silent background re-index
+(the v1 → v2 pattern) is insufficient; the upgrade must surface an explicit
+blocking dialog before wiping.
+
+---
+
+## Decision
+
+**Adopt Alternative C (single-PR with mandatory spike gate), enhanced with the
+explicit pre-wipe dialog requirement from the BRAINSTORM.**
+
+One PR encompasses the full upgrade: dependency swap, provider import updates,
+model-ID verification, `onnxEnv.ts` v4 API update, WebGPU auto-detect with
+session-level fallback, FORMAT_VERSION 2 → 3, and a blocking confirmation
+dialog before the index wipe. Task 0 (model-ID hunt) and Task 1 (compatibility
+spike) gate all downstream tasks.
+
+---
+
+## Alternatives considered
+
+### Alternative A — IR ≤ v8 model export only
+
+Find or produce an ONNX IR ≤ v8 export of EmbeddingGemma 300M and update the
+model ID; keep `@xenova/transformers` v2.17.2.
+
+**Rejected because:** This is Task 0 of the plan, not a standalone alternative.
+If Task 0 succeeds (an IR ≤ v8 export exists), it becomes the implementation
+path. If it fails — which is likely, since the upstream export is authoritative
+at IR v10 — the approach is unavailable. It accumulates technical debt regardless
+(the underlying runtime remains capped at IR v8, blocking future IR v10 models).
+Not a viable standalone strategy.
+
+### Alternative B — Two-PR: runtime first (WASM-only), WebGPU second
+
+PR 1: upgrade runtime to v4, force `device: 'wasm'`, FORMAT_VERSION bump. PR 2:
+add WebGPU auto-detect after hardware validation.
+
+**Rejected because:** Produces two review cycles with no material reduction in
+blast radius. The loader compatibility risk (the primary blocker) is identical
+in both PRs. WebGPU fallback is a self-contained add within `onnxEnv.ts` and
+adds no architectural coupling; separating it delays the feature without a
+safety benefit. The single-PR spike gate achieves the same risk management
+without the second review cycle.
+
+### Alternative C — Single-PR with spike gate (selected)
+
+One PR. Task 0 (model-ID hunt) and Task 1 (loader compatibility spike) are
+explicit gating steps. If Task 1 fails: the PR scope collapses to Bug 2 + Bug 3
+null-guards. If Task 1 passes: the full implementation proceeds.
+
+**Selected because:** One review cycle; the risk gate is explicit and blocking
+within the plan; WebGPU auto-detect is included from the start. Folotp
+validation on a real vault before merge provides the same validation that
+Alternative B's second PR was meant to gate.
+
+---
+
+## Consequences
+
+### Positive
+- EmbeddingGemma 300M loads without IR version error on all supported platforms.
+- WebGPU auto-detect removes manual configuration; WASM fallback is robust
+  against session-level failures (not just absence of `navigator.gpu`).
+- FORMAT_VERSION 3 with explicit dialog gives users informed consent before
+  their index is wiped.
+
+### Negative
+- FORMAT_VERSION 2 → 3 forces a full re-index for every user on first load.
+  For large vaults with Gemma (190 MB model, 768d vectors) this is a
+  non-trivial time cost.
+- If Task 1 spike fails, the PR produces only defensive null-guards; the
+  IR v10 root cause remains unresolved until the loader issue is worked around
+  by another means.
+- Bundle size may increase (additional ONNX backends in v4); requires a
+  post-build size audit before merge.
+
+### Neutral
+- `EmbeddingProvider` interface, `SemanticSearchProvider` interface, and
+  `EmbeddingStoreRegistry` are unchanged.
+- The DLC concurrency pattern (per-providerKey store isolation, `state.provider`
+  pointer swap on rebuild completion) is unchanged.
+- The v1 → v2 flat-store migration (`migrateV1FlatStore`) is unchanged; it runs
+  before FORMAT_VERSION 3 detection.
+- The `onnxruntime-node → onnxruntime-web` redirect in `bun.config.ts` remains
+  in place; v4 may use the same detection path (`process.release.name === 'node'`
+  in Electron renderer is still true).
+
+---
+
+## Specification: FORMAT_VERSION 2 → 3 migration
+
+The v2 → v3 migration is structurally different from v1 → v2. The v1 → v2
+migration was a path rename (flat store → per-providerKey directory) and could
+be performed silently because no user data was destroyed (the existing index
+was moved, not deleted). The v2 → v3 migration wipes every per-providerKey
+store because the vector space is incompatible after the runtime upgrade.
+
+**Sequence at plugin load:**
+
+1. `store.init()` detects `stored.version < FORMAT_VERSION` (i.e., < 3).
+2. Before any wipe, `main.ts` raises a blocking `Modal` dialog via
+   `IndexWipeMigrationModal` (new, ~30 lines, mirrors `CommandPermissionModal`
+   pattern):
+   - Title: "Semantic search index must be rebuilt"
+   - Body: "The embedding format changed. Your existing index will be deleted
+     and rebuilt automatically. This may take several minutes for large vaults."
+   - Single button: "Rebuild now" (no cancel — the index is unusable until
+     rebuilt; dismiss only delays the next trigger).
+3. On user confirmation (or on "dismiss + next trigger"), wipe the
+   per-providerKey directory and proceed with a clean init.
+4. Start re-indexing in background (existing `startIndexerIfNeeded` hook).
+5. The existing re-index banner surfaces progress as it does today.
+
+**Guard condition (store.ts):** `parsed.version !== FORMAT_VERSION` where
+`FORMAT_VERSION = 3`. The `parsed.version !== 1` carve-out that existed for v1
+stores is dropped — v1 stores were migrated to v2 by `migrateV1FlatStore`;
+any remaining v1 stores are treated as stale and wiped.
+
+**Failure path:** If the directory wipe throws (permissions, NFS), log WARN and
+surface the re-index banner — same fail-open pattern as `migrateV1FlatStore`.
+
+---
+
+## Specification: WebGPU backend selection
+
+`configureEnv()` in `onnxEnv.ts` probes WebGPU availability at provider init:
+
+```
+if (navigator.gpu exists):
+  set env for webgpu device
+  try:
+    load a minimal session probe
+  catch any error:
+    log WARN "webgpu session init failed, falling back to wasm"
+    set env for wasm device
+else:
+  set env for wasm device
+```
+
+The fallback catches session-init errors, not only `!navigator.gpu`. This covers
+driver-level crashes that expose `navigator.gpu` but fail on `requestAdapter()`
+or ONNX session creation. Logging is at WARN, not ERROR — the fallback is
+graceful and the user is not in an error state.
+
+---
+
+## Specification: bun.config.ts changes if Task 1 passes
+
+The `onnxruntime-node → onnxruntime-web` redirect plugin likely remains
+necessary (Electron renderer still reports `process.release.name === 'node'`).
+Verify whether `@huggingface/transformers` v4 still eager-imports
+`onnxruntime-node`; if not, the plugin can be removed.
+
+The CDN `wasmPaths` in `onnxEnv.ts` must be updated from
+`onnxruntime-web@1.14.0` to the version bundled with
+`@huggingface/transformers` v4. Run `bun pm ls onnxruntime-web` after install
+to determine the pinned version and update the CDN URL accordingly.
+
+The `import.meta.url` and `__dirname`/`__filename` defines in `bun.config.ts`
+remain in place — they neutralize path resolution that v4 may still perform
+at module init even if it no longer breaks the loader.
+
+---
+
+## References
+
+- SPEC.md: `/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/SPEC.md`
+- BRAINSTORM.md: `/Users/stefanoferri/Developer/Obsidian_MCP/obsidian-mcp-tools/BRAINSTORM.md`
+- Prior spike record: `embedder.ts` line 199–202 (inline comment, 2026-04-26)
+- ADR-0005: multilingual embedding providers (DLC concurrency pattern, provider
+  architecture, v2.17.2 pin rationale)
+- `onnxEnv.ts`: current env configuration with CDN pin rationale
+- `store.ts`: `FORMAT_VERSION`, migration guard, sentinel pattern
+- `storeRegistry.ts`: `migrateV1FlatStore`, fail-open pattern
+- Issue #202: `.split` crash at query time (downstream symptom, not root cause)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "svelte@5.18.0": "patches/svelte@5.18.0.patch"
   },
   "overrides": {
-    "vite": "5.4.11"
+    "vite": "5.4.11",
+    "onnxruntime-web": "1.26.0"
   },
   "dependencies": {
     "caniuse-lite": "^1.0.30001724"

--- a/packages/obsidian-plugin/bun.config.ts
+++ b/packages/obsidian-plugin/bun.config.ts
@@ -19,9 +19,9 @@ const args = process.argv.slice(2);
 const isWatch = args.includes("--watch");
 const isProd = args.includes("--prod");
 
-// `onnxruntime-node` redirect + `sharp` stub. Transformers.js v2.17.2
-// has eager `import * as ONNX_NODE from 'onnxruntime-node'` and chooses
-// it whenever `process?.release?.name === 'node'` — which in Electron
+// `onnxruntime-node` redirect + `sharp` stub. @huggingface/transformers v4
+// still imports `onnxruntime-node` at the backend level and chooses it
+// whenever `process?.release?.name === 'node'` — which in Electron
 // renderer is **true** (process.release.name === 'node' is inherited).
 // Stubbing onnxruntime-node to an empty module made
 // `ONNX.InferenceSession` undefined and produced
@@ -37,57 +37,50 @@ const stubEmptyModulesPlugin: BunPlugin = {
       path: "onnxruntime-node-shim",
       namespace: "ort-node-redirect",
     }));
-    build.onLoad(
-      { filter: /.*/, namespace: "ort-node-redirect" },
-      () => ({
-        contents: "module.exports = require('onnxruntime-web');",
-        loader: "js",
-      }),
-    );
+    build.onLoad({ filter: /.*/, namespace: "ort-node-redirect" }, () => ({
+      contents: "module.exports = require('onnxruntime-web');",
+      loader: "js",
+    }));
     // Stub sharp.
     build.onResolve({ filter: /^sharp$/ }, (args) => ({
       path: args.path,
       namespace: "stub-empty",
     }));
-    build.onLoad(
-      { filter: /.*/, namespace: "stub-empty" },
-      () => ({
-        contents: "module.exports = {};",
-        loader: "js",
-      }),
-    );
+    build.onLoad({ filter: /.*/, namespace: "stub-empty" }, () => ({
+      contents: "module.exports = {};",
+      loader: "js",
+    }));
   },
 };
 
 // Svelte plugin implementation
 const sveltePlugin: BunPlugin = {
-	name: "svelte",
-	setup(build) {
-		build.onLoad({ filter: /\.svelte$/ }, async ({ path }) => {
-			try {
+  name: "svelte",
+  setup(build) {
+    build.onLoad({ filter: /\.svelte$/ }, async ({ path }) => {
+      try {
         const parsed = parse(path);
-				const source = await Bun.file(path).text();
+        const source = await Bun.file(path).text();
         const preprocessed = await preprocess(source, svelteConfig.preprocess, {
           filename: parsed.base,
         });
         const result = compile(preprocessed.code, {
           filename: parsed.base,
-					generate: "client",
-					css: "injected",
-					dev: !isProd,
-				});
+          generate: "client",
+          css: "injected",
+          dev: !isProd,
+        });
 
-				return {
-					loader: "js",
-					contents: result.js.code,
-				};
-			} catch (error) {
-				const message =
-					error instanceof Error ? error.message : String(error);
-				throw new Error(`Error compiling Svelte component: ${message}`);
-			}
-		});
-	},
+        return {
+          loader: "js",
+          contents: result.js.code,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Error compiling Svelte component: ${message}`);
+      }
+    });
+  },
 };
 
 const config: BuildConfig = {
@@ -126,7 +119,7 @@ const config: BuildConfig = {
       isProd ? "production" : "development",
     ),
     "import.meta.filename": JSON.stringify("mcp-tools-for-obsidian.ts"),
-    // Bundled deps (notably `@xenova/transformers/src/env.js`) call
+    // Bundled deps (notably `@huggingface/transformers/src/env.js`) call
     // `fileURLToPath(import.meta.url)` eagerly at module init. Without
     // this define, Bun bakes the BUILD MACHINE's absolute path (the
     // GitHub Actions Linux runner: `file:///home/runner/...`). On
@@ -136,8 +129,8 @@ const config: BuildConfig = {
     // carry a drive letter — a drive-less `file:///x` URL throws on
     // Windows for the exact same reason (that IS the bug's mechanism);
     // `file:///C:/…` is accepted by `fileURLToPath` on every platform.
-    // The resolved value is dead in our build (`env.allowLocalModels =
-    // false`, ONNX wasm pinned to a CDN) — only the eager call must not
+    // The resolved value is dead in our build (`env.allowRemoteModels =
+    // true`, ONNX wasm pinned to a CDN) — only the eager call must not
     // throw.
     "import.meta.url": JSON.stringify("file:///C:/mcp-tools-for-obsidian.ts"),
     // Same class of bug as #100 but via the CommonJS path identifiers.
@@ -150,8 +143,8 @@ const config: BuildConfig = {
     // value is dead in our build (onnxruntime-web runs as WASM, CDN-pinned,
     // `allowLocalModels=false`, `onnxruntime-node` shimmed) — nothing reads
     // the real dirname at runtime.
-    "__dirname": JSON.stringify("/"),
-    "__filename": JSON.stringify("/mcp-tools-for-obsidian.js"),
+    __dirname: JSON.stringify("/"),
+    __filename: JSON.stringify("/mcp-tools-for-obsidian.js"),
     // These environment variables are critical for the MCP server download functionality.
     // In CI the release workflow injects the correct values (see .github/workflows/release.yml);
     // the fallback targets the active fork repo so local builds keep working.
@@ -173,45 +166,45 @@ const config: BuildConfig = {
 };
 
 async function build() {
-	try {
-		const result = await Bun.build(config);
+  try {
+    const result = await Bun.build(config);
 
-		if (!result.success) {
-			console.error("Build failed");
-			for (const message of result.logs) {
-				console.error(message);
-			}
-			process.exit(1);
-		}
+    if (!result.success) {
+      console.error("Build failed");
+      for (const message of result.logs) {
+        console.error(message);
+      }
+      process.exit(1);
+    }
 
-		console.warn("Build successful");
-	} catch (error) {
-		console.error("Build failed:", error);
-		process.exit(1);
-	}
+    console.warn("Build successful");
+  } catch (error) {
+    console.error("Build failed:", error);
+    process.exit(1);
+  }
 }
 
 async function watch() {
-	const watcher = fsp.watch(join(import.meta.dir, "src"), {
-		recursive: true,
-	});
-	console.warn("Watching for changes...");
-	for await (const event of watcher) {
-		console.warn(`Detected ${event.eventType} in ${event.filename}`);
-		await build();
-	}
+  const watcher = fsp.watch(join(import.meta.dir, "src"), {
+    recursive: true,
+  });
+  console.warn("Watching for changes...");
+  for await (const event of watcher) {
+    console.warn(`Detected ${event.eventType} in ${event.filename}`);
+    await build();
+  }
 }
 
 async function main() {
-	if (isWatch) {
-		await build();
-		return watch();
-	} else {
-		return build();
-	}
+  if (isWatch) {
+    await build();
+    return watch();
+  } else {
+    return build();
+  }
 }
 
 main().catch((err) => {
-	console.error(err);
-	process.exit(1);
+  console.error(err);
+  process.exit(1);
 });

--- a/packages/obsidian-plugin/bun.config.ts
+++ b/packages/obsidian-plugin/bun.config.ts
@@ -177,6 +177,39 @@ async function build() {
       process.exit(1);
     }
 
+    // B1: Bun's `define` does literal token-replacement and does not catch
+    // `Object(import.meta).url` or `typeof import.meta` because `import.meta`
+    // is used as a function argument, not a member-access target.
+    // @huggingface/transformers v4 emits both patterns; replace them with
+    // semantically equivalent constants after every build.
+    // Remove this step when Bun supports `define` on import.meta as an
+    // object, or when upstream fixes the emit pattern.
+    const mainJsPath = join(import.meta.dir, "../../main.js");
+    let bundle = await Bun.file(mainJsPath).text();
+
+    const objUrlPattern = "Object(import.meta).url";
+    const typeofPattern = "typeof import.meta";
+    const countObjUrl = bundle.split(objUrlPattern).length - 1;
+    const countTypeof = bundle.split(typeofPattern).length - 1;
+
+    if (countObjUrl === 0 || countTypeof === 0) {
+      console.error(
+        `[bun.config] B1 post-build: expected patterns not found — ` +
+          `Object(import.meta).url ×${countObjUrl}, typeof import.meta ×${countTypeof}. ` +
+          `Upstream may have changed its emit; review the post-build step.`,
+      );
+      process.exit(1);
+    }
+
+    bundle = bundle
+      .split(objUrlPattern)
+      .join('"file:///C:/mcp-tools-for-obsidian.ts"');
+    bundle = bundle.split(typeofPattern).join('"object"');
+    await Bun.write(mainJsPath, bundle);
+    console.warn(
+      `[bun.config] B1 post-build replace: Object(import.meta).url ×${countObjUrl}, typeof import.meta ×${countTypeof}`,
+    );
+
     console.warn("Build successful");
   } catch (error) {
     console.error("Build failed:", error);

--- a/packages/obsidian-plugin/bun.config.ts
+++ b/packages/obsidian-plugin/bun.config.ts
@@ -32,13 +32,30 @@ const isProd = args.includes("--prod");
 const stubEmptyModulesPlugin: BunPlugin = {
   name: "stub-empty-modules",
   setup(build) {
-    // Redirect onnxruntime-node → onnxruntime-web (re-export wrapper).
+    // Redirect onnxruntime-web → onnxruntime-web/all.
+    // `ort.min.js` (the default "." export) includes WASM/CPU EP only.
+    // `ort.all.min.js` adds WebGPU EP (via JSEP) + WebGL EP. Without this
+    // redirect, `device: "webgpu"` always fails with "backend not found"
+    // because the WebGPU EP is never registered at startup.
+    build.onResolve({ filter: /^onnxruntime-web$/ }, () => ({
+      path: "onnxruntime-web-all-shim",
+      namespace: "ort-all-redirect",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "ort-all-redirect" }, () => ({
+      contents: "module.exports = require('onnxruntime-web/all');",
+      loader: "js",
+    }));
+    // Redirect onnxruntime-node → onnxruntime-web/all (re-export wrapper).
+    // @huggingface/transformers v4 still imports onnxruntime-node at the
+    // backend level and chooses it whenever process?.release?.name === 'node'
+    // — which in Electron renderer is true. Using /all keeps WebGPU EP
+    // available on the node-shim path too.
     build.onResolve({ filter: /^onnxruntime-node$/ }, () => ({
       path: "onnxruntime-node-shim",
       namespace: "ort-node-redirect",
     }));
     build.onLoad({ filter: /.*/, namespace: "ort-node-redirect" }, () => ({
-      contents: "module.exports = require('onnxruntime-web');",
+      contents: "module.exports = require('onnxruntime-web/all');",
       loader: "js",
     }));
     // Stub sharp.

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -19,9 +19,10 @@
 		"zip": "bun scripts/zip.ts"
 	},
 	"dependencies": {
+		"@huggingface/transformers": "4.2.0",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@types/fs-extra": "^11.0.4",
-		"@xenova/transformers": "2.17.2",
+		"onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
 		"arktype": "^2.0.0-rc.30",
 		"express": "^4.21.2",
 		"fs-extra": "^11.2.0",

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -22,7 +22,7 @@
 		"@huggingface/transformers": "4.2.0",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@types/fs-extra": "^11.0.4",
-		"onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+		"onnxruntime-web": "1.26.0",
 		"arktype": "^2.0.0-rc.30",
 		"express": "^4.21.2",
 		"fs-extra": "^11.2.0",

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
@@ -93,10 +93,14 @@ export async function searchVaultSmartHandler(
   // Lazy indexer kick (Q4 = lazy on first query). Fire-and-forget:
   // the indexer's start() runs the first full vault build in the
   // background and subscribes to vault events for incremental
-  // updates. Subsequent calls are no-ops. Skipped entirely under
-  // Smart Connections — kicking the native indexer there triggers a
-  // pointless embedding-model download (#99).
-  if (!usingSmartConnections) {
+  // updates. Subsequent calls are no-ops. Skipped under Smart
+  // Connections (#99) and DLC providers (embedding-gemma,
+  // multilingual-e5-base) — DLC providers use their own indexer
+  // started by startRebuildFor, not the native MiniLM indexer.
+  const usingDlcProvider =
+    settings?.provider === "embedding-gemma" ||
+    settings?.provider === "multilingual-e5-base";
+  if (!usingSmartConnections && !usingDlcProvider) {
     state.startIndexerIfNeeded?.();
   }
 

--- a/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
+++ b/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
@@ -46,15 +46,20 @@
   });
 
   function refreshStatus() {
-    const state = plugin.semanticSearchState as
-      | (typeof plugin.semanticSearchState & {
-          store?: { size?: () => number };
-        })
-      | undefined;
-    storeSize = state?.store?.size?.() ?? 0;
-    pendingProvider = plugin.semanticSearchState?.pendingProvider ?? null;
-    autoSuggestProvider =
-      plugin.semanticSearchState?.autoSuggestProvider ?? null;
+    const state = plugin.semanticSearchState;
+    const provider = state?.settings?.provider;
+    const registry = state?.registry;
+    // For DLC providers, read chunk count from their own store.
+    // state.store always points to the native MiniLM store.
+    if (provider === "embedding-gemma" && registry) {
+      storeSize = registry.storeFor("embedding-gemma-300m", 768).size();
+    } else if (provider === "multilingual-e5-base" && registry) {
+      storeSize = registry.storeFor("multilingual-e5-base", 768).size();
+    } else {
+      storeSize = state?.store?.size?.() ?? 0;
+    }
+    pendingProvider = state?.pendingProvider ?? null;
+    autoSuggestProvider = state?.autoSuggestProvider ?? null;
   }
 
   async function persist(next: SemanticSearchSettings) {

--- a/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
+++ b/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
@@ -99,7 +99,37 @@
   }
 
   async function onRebuild() {
-    const indexer = plugin.semanticSearchState?.indexer;
+    const state = plugin.semanticSearchState;
+    if (!state) {
+      new Notice("Semantic index not available yet — reload Obsidian.");
+      return;
+    }
+
+    // DLC providers maintain their own stores; route through startRebuildFor.
+    const dlcProviderKey =
+      settings.provider === "embedding-gemma"
+        ? "embedding-gemma-300m"
+        : settings.provider === "multilingual-e5-base"
+          ? "multilingual-e5-base"
+          : null;
+
+    if (dlcProviderKey) {
+      if (!state.startRebuildFor) {
+        new Notice("Rebuild not available yet — reload Obsidian.");
+        return;
+      }
+      state.startRebuildFor(dlcProviderKey);
+      new Notice("Rebuilding index in background…");
+      return;
+    }
+
+    if (settings.provider === "smart-connections") {
+      new Notice("Smart Connections manages its own index.");
+      return;
+    }
+
+    // Native / auto: use the always-on MiniLM indexer.
+    const indexer = state.indexer;
     if (!indexer) {
       new Notice("Semantic index not available yet — reload Obsidian.");
       return;

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.test.ts
@@ -184,4 +184,20 @@ describe("embedder", () => {
     expect(v).toBeInstanceOf(Float32Array);
     expect(v.length).toBe(8);
   });
+
+  test("maxInputTokens: passes truncation: true and max_length to pipeline", async () => {
+    const pipeOpts: Array<object | undefined> = [];
+    const factory: PipelineFactory = async (_model) => {
+      return async (_input, opts) => {
+        pipeOpts.push(opts);
+        return { data: new Float32Array(8), dims: [1, 8] };
+      };
+    };
+    const embedder = createEmbedder({
+      pipelineFactory: factory,
+      maxInputTokens: 128,
+    });
+    await embedder.embed("hello");
+    expect(pipeOpts[0]).toMatchObject({ truncation: true, max_length: 128 });
+  });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
@@ -14,8 +14,8 @@
  *    is dropped 60s after the last call (RAM saver for memory-
  *    constrained users). The next call cold-reloads.
  *
- * Production code injects `realPipelineFactory` (dynamic import of
- * `@xenova/transformers`) so Transformers.js is not pulled into the
+ * Production code injects `realPipelineFactory` (static import of
+ * `@huggingface/transformers`) so Transformers.js is not pulled into the
  * bundle eager-side. Tests inject a deterministic mock factory: no
  * model download, no WASM, no sharp transitive resolution.
  */
@@ -193,14 +193,14 @@ export function createEmbedder(opts: EmbedderOpts): Embedder {
 // our text-only path). `onnxruntime-node` is REDIRECTED to
 // `onnxruntime-web` at bundle time — see bun.config.ts for the rationale
 // (Electron renderer reports `process.release.name === 'node'`, so
-// Transformers.js v2.17.2 picks the node branch; routing it to the WASM
-// runtime is the only way to actually run inference here).
+// Transformers.js picks the node branch; routing it to the WASM runtime
+// is the only way to actually run inference here).
 //
-// Pinned to @xenova/transformers v2.17.2. The successor
-// @huggingface/transformers v4 was tested 2026-04-26 in a spike; it
-// uses `import.meta.url` at runtime which Obsidian's eval-based plugin
-// loader cannot parse. Reverting to v2 keeps the plugin loadable.
-import { pipeline as _xenovaPipeline } from "@xenova/transformers";
+// @huggingface/transformers v4.2.0 — upgraded from @xenova/transformers
+// v2.17.2. Spike (2026-04-26) found import.meta.url failures; a later
+// re-spike confirmed v4 loads cleanly with the bun.config.ts define block
+// already in place (import.meta.url + __dirname/__filename neutralized).
+import { pipeline as _hfPipeline } from "@huggingface/transformers";
 import { configureEnv } from "./onnxEnv";
 
 export async function realPipelineFactory(
@@ -208,8 +208,8 @@ export async function realPipelineFactory(
   onProgress?: ProgressCallback,
 ): Promise<PipelineFn> {
   configureEnv();
-  const pipe = await _xenovaPipeline("feature-extraction", model, {
+  const pipe = await _hfPipeline("feature-extraction", model, {
     progress_callback: onProgress,
-  } as Parameters<typeof _xenovaPipeline>[2]);
+  } as Parameters<typeof _hfPipeline>[2]);
   return pipe as unknown as PipelineFn;
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
@@ -34,7 +34,12 @@ export type EmbedTensor = { data: Float32Array; dims?: number[] };
  */
 export type PipelineFn = (
   input: string | string[],
-  opts?: { pooling?: "mean" | "cls" | "none"; normalize?: boolean },
+  opts?: {
+    pooling?: "mean" | "cls" | "none";
+    normalize?: boolean;
+    truncation?: boolean;
+    max_length?: number;
+  },
 ) => Promise<EmbedTensor>;
 
 export type PipelineFactory = (model: string) => Promise<PipelineFn>;
@@ -73,6 +78,7 @@ export interface Embedder {
 export type EmbedderOpts = {
   pipelineFactory: PipelineFactory;
   model?: string;
+  maxInputTokens?: number;
   cacheSize?: number;
   idleMs?: number;
   unloadWhenIdle?: boolean;
@@ -108,7 +114,12 @@ class EmbedderImpl implements Embedder {
 
     const promise = (async (): Promise<Float32Array> => {
       const pipe = await this.ensurePipeline();
-      const result = await pipe(text, { pooling: "mean", normalize: true });
+      const result = await pipe(text, {
+        pooling: "mean",
+        normalize: true,
+        truncation: true,
+        max_length: this.opts.maxInputTokens,
+      });
       // Copy into a fresh Float32Array so the cache holds an owned
       // reference even if the pipeline reuses internal buffers.
       return new Float32Array(result.data);

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
@@ -66,6 +66,7 @@ export type ProgressCallback = (info: ProgressEvent) => void;
 export type PipelineFactoryWithProgress = (
   model: string,
   onProgress?: ProgressCallback,
+  opts?: { dtype?: string },
 ) => Promise<PipelineFn>;
 
 export interface Embedder {
@@ -211,16 +212,70 @@ export function createEmbedder(opts: EmbedderOpts): Embedder {
 // v2.17.2. Spike (2026-04-26) found import.meta.url failures; a later
 // re-spike confirmed v4 loads cleanly with the bun.config.ts define block
 // already in place (import.meta.url + __dirname/__filename neutralized).
+//
+// device must be explicit — Transformers.js v4 auto-selects WebGPU when
+// navigator.gpu is present (Electron exposes it). We probe once via
+// requestAdapter(); on success we configure JSEP WASM env (no numThreads
+// override) and use "webgpu"; on failure we configure CPU env (numThreads:1)
+// and use "cpu". Valid v4.2.0 devices: "coreml" | "webgpu" | "cpu".
 import { pipeline as _hfPipeline } from "@huggingface/transformers";
-import { configureEnv } from "./onnxEnv";
+import { configureEnv, configureEnvForWebGpu } from "./onnxEnv";
+import { logger } from "$/shared/logger";
+
+// Resolved once: "webgpu" if requestAdapter() returns a non-null adapter,
+// "cpu" otherwise. Cached so all subsequent factory calls share the same
+// device and env configuration without re-probing.
+let _deviceConfig: Promise<"webgpu" | "cpu"> | null = null;
+
+function resolveDevice(): Promise<"webgpu" | "cpu"> {
+  if (!_deviceConfig) {
+    _deviceConfig = (async (): Promise<"webgpu" | "cpu"> => {
+      if (typeof navigator === "undefined" || !("gpu" in navigator)) {
+        configureEnv();
+        return "cpu";
+      }
+      try {
+        const adapter = await (
+          navigator as { gpu: { requestAdapter(): Promise<unknown> } }
+        ).gpu.requestAdapter();
+        if (adapter !== null) {
+          // JSEP WASM path: omit numThreads so onnxruntime-web selects
+          // ort-wasm-simd.jsep.wasm, which registers the WebGPU EP.
+          configureEnvForWebGpu();
+          return "webgpu";
+        }
+      } catch {
+        // adapter probe failed — fall through to cpu
+      }
+      configureEnv();
+      return "cpu";
+    })();
+  }
+  return _deviceConfig;
+}
 
 export async function realPipelineFactory(
   model: string,
   onProgress?: ProgressCallback,
+  opts?: { dtype?: string },
 ): Promise<PipelineFn> {
-  configureEnv();
+  const device = await resolveDevice();
+
+  if (device === "webgpu") {
+    // No CPU fallback: a failed WebGPU attempt corrupts onnxruntime-web's
+    // internal session state — subsequent cpu calls also get "webgpu backend
+    // not found". Let the error propagate so the caller can surface it cleanly.
+    const pipe = await _hfPipeline("feature-extraction", model, {
+      device: "webgpu",
+      progress_callback: onProgress,
+    } as Parameters<typeof _hfPipeline>[2]);
+    return pipe as unknown as PipelineFn;
+  }
+
   const pipe = await _hfPipeline("feature-extraction", model, {
+    device: "cpu",
     progress_callback: onProgress,
+    ...(opts?.dtype !== undefined ? { dtype: opts.dtype } : {}),
   } as Parameters<typeof _hfPipeline>[2]);
   return pipe as unknown as PipelineFn;
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
@@ -1,3 +1,4 @@
+// Model: onnx-community/embeddinggemma-300m-ONNX (ONNX IR v10; requires onnxruntime-web ≥ 1.20 / the dev build pinned in onnxEnv.ts).
 import type { EmbeddingProvider } from "../types";
 import type { PipelineFactory } from "./embedder";
 import { createTransformersProvider } from "./transformersProvider";

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
@@ -10,7 +10,8 @@ export function createEmbeddingGemmaProvider(
     modelId: "onnx-community/embeddinggemma-300m-ONNX",
     providerKey: "embedding-gemma-300m",
     dimensions: 768,
-    maxInputTokens: 2048,
+    // Capped at 512 — onnxruntime-web@1.26.0-dev SafeInt overflow at 2048 (#202)
+    maxInputTokens: 512,
     modelSizeBytes: 190_000_000,
     taskPrompt: (text, role) =>
       role === "query"

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexWipeMigrationModal.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexWipeMigrationModal.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { mockApp } from "$/test-setup";
+import { IndexWipeMigrationModal } from "./indexWipeMigrationModal";
+
+/**
+ * Unit tests for IndexWipeMigrationModal.
+ *
+ * The modal renders plain HTML via Obsidian's `contentEl.createEl` API
+ * (no Svelte). The Modal stub in test-setup.ts provides a `contentEl`
+ * that supports `createEl` and element-level `addEventListener`, so
+ * tests can query the rendered button and simulate a click without a
+ * real browser DOM.
+ */
+
+/** Retrieve all elements created on contentEl matching a given tag. */
+function getCreatedEls(
+  modal: IndexWipeMigrationModal,
+  tag: string,
+): Array<{ tag: string; text: string; listeners: Map<string, () => void> }> {
+  const el = (
+    modal as unknown as {
+      contentEl: {
+        _created: Array<{
+          tag: string;
+          text: string;
+          listeners: Map<string, () => void>;
+        }>;
+      };
+    }
+  ).contentEl;
+  return el._created.filter((e) => e.tag === tag);
+}
+
+describe("IndexWipeMigrationModal", () => {
+  let app: ReturnType<typeof mockApp>;
+
+  beforeEach(() => {
+    app = mockApp();
+  });
+
+  test("onConfirm is NOT called immediately after onOpen", () => {
+    let called = false;
+    const modal = new IndexWipeMigrationModal({
+      app,
+      onConfirm: () => {
+        called = true;
+      },
+    });
+
+    modal.open(); // triggers onOpen()
+
+    expect(called).toBe(false);
+  });
+
+  test("clicking the button calls onConfirm and closes the modal", () => {
+    let confirmCount = 0;
+    let closedByOnClose = false;
+    const modal = new IndexWipeMigrationModal({
+      app,
+      onConfirm: () => {
+        confirmCount++;
+      },
+    });
+
+    // Patch onClose to detect it was called (the stub's close() calls onClose).
+    const originalOnClose = modal.onClose.bind(modal);
+    modal.onClose = () => {
+      closedByOnClose = true;
+      originalOnClose();
+    };
+
+    modal.open();
+
+    // Simulate button click via the click listener registered on contentEl
+    const buttons = getCreatedEls(modal, "button");
+    expect(buttons).toHaveLength(1);
+    const clickHandler = buttons[0]!.listeners.get("click");
+    expect(typeof clickHandler).toBe("function");
+
+    clickHandler!();
+
+    expect(confirmCount).toBe(1);
+    expect(closedByOnClose).toBe(true);
+  });
+
+  test("close() is invoked after button click", () => {
+    let closedByOnClose = false;
+    const modal = new IndexWipeMigrationModal({
+      app,
+      onConfirm: () => {},
+    });
+
+    // Patch onClose to detect it was called (the stub's close() calls onClose).
+    const originalOnClose = modal.onClose.bind(modal);
+    modal.onClose = () => {
+      closedByOnClose = true;
+      originalOnClose();
+    };
+
+    modal.open();
+
+    const buttons = getCreatedEls(modal, "button");
+    const clickHandler = buttons[0]!.listeners.get("click");
+    clickHandler!();
+
+    expect(closedByOnClose).toBe(true);
+  });
+
+  test("onClose empties contentEl", () => {
+    let emptied = false;
+    const modal = new IndexWipeMigrationModal({ app, onConfirm: () => {} });
+    (modal as unknown as { contentEl: { empty: () => void } }).contentEl.empty =
+      () => {
+        emptied = true;
+      };
+
+    modal.open();
+    modal.close();
+
+    expect(emptied).toBe(true);
+  });
+
+  test("dismissing the modal (calling onClose without button click) calls onCancel", () => {
+    let cancelCount = 0;
+    let confirmCount = 0;
+    const modal = new IndexWipeMigrationModal({
+      app,
+      onConfirm: () => {
+        confirmCount++;
+      },
+      onCancel: () => {
+        cancelCount++;
+      },
+    });
+
+    modal.open();
+    // Simulate Escape / overlay close: close() without a button click.
+    modal.close();
+
+    expect(cancelCount).toBe(1);
+    expect(confirmCount).toBe(0);
+  });
+
+  test("confirming the modal does NOT call onCancel", () => {
+    let cancelCount = 0;
+    const modal = new IndexWipeMigrationModal({
+      app,
+      onConfirm: () => {},
+      onCancel: () => {
+        cancelCount++;
+      },
+    });
+
+    modal.open();
+
+    const buttons = getCreatedEls(modal, "button");
+    const clickHandler = buttons[0]!.listeners.get("click");
+    clickHandler!();
+
+    expect(cancelCount).toBe(0);
+  });
+
+  test("double-clicking the button calls onConfirm only once", () => {
+    let confirmCount = 0;
+    const modal = new IndexWipeMigrationModal({
+      app,
+      onConfirm: () => {
+        confirmCount++;
+      },
+    });
+
+    modal.open();
+
+    const buttons = getCreatedEls(modal, "button");
+    const clickHandler = buttons[0]!.listeners.get("click");
+    expect(typeof clickHandler).toBe("function");
+
+    // Simulate rapid double-click — the _confirmed guard must prevent
+    // onConfirm from being called more than once.
+    clickHandler!();
+    clickHandler!();
+
+    expect(confirmCount).toBe(1);
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexWipeMigrationModal.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexWipeMigrationModal.ts
@@ -1,0 +1,43 @@
+import { Modal, type App } from "obsidian";
+
+export class IndexWipeMigrationModal extends Modal {
+  private readonly props: {
+    app: App;
+    onConfirm: () => void;
+    onCancel?: () => void;
+  };
+  private _confirmed = false;
+
+  constructor(props: {
+    app: App;
+    onConfirm: () => void;
+    onCancel?: () => void;
+  }) {
+    super(props.app);
+    this.props = props;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.createEl("h2", {
+      text: "Semantic search index must be rebuilt",
+    });
+    contentEl.createEl("p", {
+      text: "The embedding format changed. Your existing index will be deleted and rebuilt automatically. This may take several minutes for large vaults.",
+    });
+    const btn = contentEl.createEl("button", { text: "Rebuild now" });
+    btn.addEventListener("click", () => {
+      if (this._confirmed) return;
+      this._confirmed = true;
+      this.props.onConfirm();
+      this.close();
+    });
+  }
+
+  onClose() {
+    this.contentEl.empty();
+    if (!this._confirmed) {
+      this.props.onCancel?.();
+    }
+  }
+}

--- a/packages/obsidian-plugin/src/features/semantic-search/services/migration-rebuild.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/migration-rebuild.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the B3 auto-rebuild logic that fires after the migration
+ * modal wipes stale provider stores.
+ *
+ * The decision logic in main.ts maps `state.settings.provider` (the UI
+ * setting value) to a registry ProviderKey, then calls either
+ * `startRebuildFor` (DLC) or `startIndexerIfNeeded` (native MiniLM)
+ * if the active provider's store was wiped.
+ *
+ * These tests verify the mapping and dispatch logic in isolation, without
+ * requiring the full main.ts wiring.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ProviderKey } from "./providerFactory";
+
+const SETTING_TO_REGISTRY_KEY: Partial<Record<string, ProviderKey>> = {
+  native: "native-minilm-l6-v2",
+  auto: "native-minilm-l6-v2",
+  "embedding-gemma": "embedding-gemma-300m",
+  "multilingual-e5-base": "multilingual-e5-base",
+  // "smart-connections" has no local store — absent from the map.
+};
+
+function simulateAutoRebuild(
+  settingProvider: string,
+  staleProviderKeys: ProviderKey[],
+): { rebuildCalled: string | null; indexerStarted: boolean } {
+  let rebuildCalled: string | null = null;
+  let indexerStarted = false;
+
+  const startRebuildFor = (key: string) => {
+    rebuildCalled = key;
+  };
+  const startIndexerIfNeeded = () => {
+    indexerStarted = true;
+  };
+
+  const activeRegistryKey = SETTING_TO_REGISTRY_KEY[settingProvider];
+  if (activeRegistryKey && staleProviderKeys.includes(activeRegistryKey)) {
+    if (activeRegistryKey === "native-minilm-l6-v2") {
+      startIndexerIfNeeded();
+    } else {
+      startRebuildFor(activeRegistryKey);
+    }
+  }
+
+  return { rebuildCalled, indexerStarted };
+}
+
+describe("migration auto-rebuild (B3)", () => {
+  describe("setting → registry key mapping", () => {
+    test("native → native-minilm-l6-v2", () => {
+      expect(SETTING_TO_REGISTRY_KEY["native"]).toBe("native-minilm-l6-v2");
+    });
+    test("auto → native-minilm-l6-v2", () => {
+      expect(SETTING_TO_REGISTRY_KEY["auto"]).toBe("native-minilm-l6-v2");
+    });
+    test("embedding-gemma → embedding-gemma-300m", () => {
+      expect(SETTING_TO_REGISTRY_KEY["embedding-gemma"]).toBe(
+        "embedding-gemma-300m",
+      );
+    });
+    test("multilingual-e5-base → multilingual-e5-base", () => {
+      expect(SETTING_TO_REGISTRY_KEY["multilingual-e5-base"]).toBe(
+        "multilingual-e5-base",
+      );
+    });
+    test("smart-connections → no local store (undefined)", () => {
+      expect(SETTING_TO_REGISTRY_KEY["smart-connections"]).toBeUndefined();
+    });
+  });
+
+  describe("dispatch: DLC providers call startRebuildFor", () => {
+    test("embedding-gemma active + embedding-gemma-300m stale → startRebuildFor", () => {
+      const { rebuildCalled, indexerStarted } = simulateAutoRebuild(
+        "embedding-gemma",
+        ["embedding-gemma-300m"],
+      );
+      expect(rebuildCalled).toBe("embedding-gemma-300m");
+      expect(indexerStarted).toBe(false);
+    });
+
+    test("multilingual-e5-base active + stale → startRebuildFor", () => {
+      const { rebuildCalled, indexerStarted } = simulateAutoRebuild(
+        "multilingual-e5-base",
+        ["multilingual-e5-base"],
+      );
+      expect(rebuildCalled).toBe("multilingual-e5-base");
+      expect(indexerStarted).toBe(false);
+    });
+  });
+
+  describe("dispatch: native MiniLM calls startIndexerIfNeeded", () => {
+    test("native active + native-minilm-l6-v2 stale → startIndexerIfNeeded", () => {
+      const { rebuildCalled, indexerStarted } = simulateAutoRebuild("native", [
+        "native-minilm-l6-v2",
+      ]);
+      expect(indexerStarted).toBe(true);
+      expect(rebuildCalled).toBeNull();
+    });
+
+    test("auto active + native-minilm-l6-v2 stale → startIndexerIfNeeded", () => {
+      const { rebuildCalled, indexerStarted } = simulateAutoRebuild("auto", [
+        "native-minilm-l6-v2",
+      ]);
+      expect(indexerStarted).toBe(true);
+      expect(rebuildCalled).toBeNull();
+    });
+  });
+
+  describe("dispatch: no rebuild for non-active stale keys", () => {
+    test("native active, only DLC key stale → no action", () => {
+      const { rebuildCalled, indexerStarted } = simulateAutoRebuild("native", [
+        "embedding-gemma-300m",
+      ]);
+      expect(rebuildCalled).toBeNull();
+      expect(indexerStarted).toBe(false);
+    });
+
+    test("embedding-gemma active, only native key stale → no action", () => {
+      const { rebuildCalled, indexerStarted } = simulateAutoRebuild(
+        "embedding-gemma",
+        ["native-minilm-l6-v2"],
+      );
+      expect(rebuildCalled).toBeNull();
+      expect(indexerStarted).toBe(false);
+    });
+
+    test("smart-connections active → no action regardless of stale keys", () => {
+      const { rebuildCalled, indexerStarted } = simulateAutoRebuild(
+        "smart-connections",
+        ["native-minilm-l6-v2", "embedding-gemma-300m"],
+      );
+      expect(rebuildCalled).toBeNull();
+      expect(indexerStarted).toBe(false);
+    });
+
+    test("no stale keys → no action even if provider matches", () => {
+      const { rebuildCalled, indexerStarted } = simulateAutoRebuild(
+        "native",
+        [],
+      );
+      expect(rebuildCalled).toBeNull();
+      expect(indexerStarted).toBe(false);
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/services/modelDownloader.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/modelDownloader.ts
@@ -47,6 +47,8 @@ export interface ModelDownloader {
 
 export type ModelDownloaderOpts = {
   innerFactory: PipelineFactoryWithProgress;
+  /** Passed to the WASM fallback path. Unused when WebGPU succeeds. */
+  dtype?: string;
 };
 
 const IDLE: ModelState = { kind: "idle" };
@@ -84,8 +86,10 @@ class ModelDownloaderImpl implements ModelDownloader {
     this.setState({ kind: "downloading", progress: 0 });
     const promise = (async () => {
       try {
-        const pipe = await this.opts.innerFactory(model, (info) =>
-          this.onProgress(info),
+        const pipe = await this.opts.innerFactory(
+          model,
+          (info) => this.onProgress(info),
+          this.opts.dtype !== undefined ? { dtype: this.opts.dtype } : undefined,
         );
         this.setState({ kind: "ready" });
         return pipe;

--- a/packages/obsidian-plugin/src/features/semantic-search/services/multilingualE5Provider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/multilingualE5Provider.ts
@@ -10,7 +10,7 @@ export function createMultilingualE5Provider(
     providerKey: "multilingual-e5-base",
     dimensions: 768,
     maxInputTokens: 512,
-    modelSizeBytes: 100_000_000,
+    modelSizeBytes: 60_000_000,
     taskPrompt: (text, role) =>
       (role === "query" ? "query: " : "passage: ") + text,
     pipelineFactory,

--- a/packages/obsidian-plugin/src/features/semantic-search/services/nativeEmbeddingProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/nativeEmbeddingProvider.ts
@@ -12,7 +12,7 @@ import type { EmbeddingProvider } from "../types";
 
 const PROVIDER_KEY = "native-minilm-l6-v2";
 const DIMENSIONS = 384;
-const MAX_INPUT_TOKENS = 256;
+export const MAX_INPUT_TOKENS = 256;
 const MODEL_SIZE_BYTES = 25_000_000;
 
 class NativeEmbeddingProviderImpl implements EmbeddingProvider {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
@@ -28,9 +28,9 @@
 import { env as _hfEnv } from "@huggingface/transformers";
 import { logger } from "$/shared/logger";
 
-// Pre-release dev build bundled with @huggingface/transformers@4.2.0; required for ONNX IR v10 support. Stable target: onnxruntime-web ≥ 1.20.
+// Stable build; required for ONNX IR v10 support (onnxruntime-web ≥ 1.20).
 const ORT_WASM_PATHS =
-  "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0-dev.20260416-b7804b056c/dist/";
+  "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/";
 
 let _envConfigured = false;
 

--- a/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
@@ -12,14 +12,12 @@
  *   import.meta.url))`. Bun's CJS bundle does not preserve
  *   `import.meta.url` meaningfully, so the loader 404s. Pointing at
  *   the matching CDN sidesteps the `import.meta.url` dance. Pinned to
- *   1.14.0 to match @xenova/transformers@2.17.2; updating the lib
- *   requires updating this URL or the WASM ABI may not match the JS
- *   glue.
+ *   the version bundled with @huggingface/transformers@4.2.0; updating
+ *   the lib requires updating this URL or the WASM ABI may not match
+ *   the JS glue.
  * * `env.backends.onnx.wasm.numThreads = 1`: Electron's renderer does
  *   not have COOP/COEP cross-origin isolation, so SharedArrayBuffer is
  *   restricted. Single-threaded WASM avoids the worker spin-up path.
- * * `env.allowLocalModels = false`: always use the remote (Hugging
- *   Face Hub) so the lazy first-call download flow drives the UI.
  * * `env.useBrowserCache = true`: persist the downloaded model to the
  *   Cache API so subsequent loads are fast.
  */
@@ -27,30 +25,43 @@
 // Static import required: Obsidian's eval-based plugin loader cannot
 // resolve node_modules at runtime; a bundled require() works, a
 // dynamic `import(...)` would 404.
-import { env as _xenovaEnv } from "@xenova/transformers";
+import { env as _hfEnv } from "@huggingface/transformers";
+import { logger } from "$/shared/logger";
 
+// Pre-release dev build bundled with @huggingface/transformers@4.2.0; required for ONNX IR v10 support. Stable target: onnxruntime-web ≥ 1.20.
 const ORT_WASM_PATHS =
-  "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.14.0/dist/";
+  "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0-dev.20260416-b7804b056c/dist/";
 
 let _envConfigured = false;
 
 export function configureEnv(): void {
   if (_envConfigured) return;
   _envConfigured = true;
-  const e = _xenovaEnv as unknown as {
+
+  const e = _hfEnv as unknown as {
     backends?: {
       onnx?: {
         wasm?: { numThreads?: number; simd?: boolean; wasmPaths?: string };
       };
     };
-    allowLocalModels?: boolean;
     useBrowserCache?: boolean;
   };
+
   if (e.backends?.onnx?.wasm) {
     e.backends.onnx.wasm.wasmPaths = ORT_WASM_PATHS;
     e.backends.onnx.wasm.numThreads = 1;
-    e.backends.onnx.wasm.simd = true;
+    // simd: leave unset — onnxruntime-web auto-detects SIMD capability.
+    // Forcing true causes silent load failures on older Electron builds
+    // (pre-22) and in enterprise lockdown environments.
+  } else {
+    logger.warn(
+      "onnxEnv: expected WASM backend shape not found — CDN paths not configured",
+    );
   }
-  e.allowLocalModels = false;
-  e.useBrowserCache = true;
+  // Guard: `navigator` is undefined in bun test (no DOM); Cache API is a production-only concern.
+  if (typeof navigator !== "undefined") {
+    e.useBrowserCache = true;
+  }
+
+  // WebGPU: deferred — requires requestAdapter() + pipeline call wiring.
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
@@ -1,9 +1,16 @@
 /**
  * One-shot ONNX / Transformers.js environment configuration.
  *
- * Shared by embedder.ts (MiniLM path) and transformersProvider.ts
- * (multilingual providers) so the call-once guard is a module-level
- * singleton and both importers see the same `_envConfigured` flag.
+ * Two exported functions cover the two execution paths:
+ *   - `configureEnv()` — CPU WASM path; sets numThreads:1 (no SharedArrayBuffer
+ *     in Electron renderer without COOP+COEP).
+ *   - `configureEnvForWebGpu()` — WebGPU path; wasmPaths only, no numThreads,
+ *     so onnxruntime-web selects the JSEP WASM build which registers WebGPU EP.
+ *
+ * Both functions are no-ops after first call (independent flags per path).
+ * `realPipelineFactory` in embedder.ts calls the appropriate one after probing
+ * `navigator.gpu.requestAdapter()`; `transformersProvider.ts` does NOT call
+ * either directly — env configuration is centralised in the factory.
  *
  * Why each setting:
  *
@@ -15,11 +22,17 @@
  *   the version bundled with @huggingface/transformers@4.2.0; updating
  *   the lib requires updating this URL or the WASM ABI may not match
  *   the JS glue.
- * * `env.backends.onnx.wasm.numThreads = 1`: Electron's renderer does
- *   not have COOP/COEP cross-origin isolation, so SharedArrayBuffer is
- *   restricted. Single-threaded WASM avoids the worker spin-up path.
+ * * `env.backends.onnx.wasm.numThreads = 1` (CPU only): Electron's renderer
+ *   does not have COOP/COEP cross-origin isolation, so SharedArrayBuffer is
+ *   restricted. Single-threaded non-JSEP WASM avoids the worker spin-up path.
+ *   Omitted on the WebGPU path so onnxruntime-web selects JSEP WASM instead.
  * * `env.useBrowserCache = true`: persist the downloaded model to the
  *   Cache API so subsequent loads are fast.
+ *
+ * Bundle prerequisite: `bun.config.ts` redirects `onnxruntime-web` →
+ * `onnxruntime-web/all` (ort.all.min.js). The default `ort.min.js` includes
+ * only WASM/CPU EP; WebGPU EP lives in the `all` bundle. Without this redirect,
+ * `device: "webgpu"` always fails with "backend not found".
  */
 
 // Static import required: Obsidian's eval-based plugin loader cannot
@@ -32,36 +45,58 @@ import { logger } from "$/shared/logger";
 const ORT_WASM_PATHS =
   "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/";
 
-let _envConfigured = false;
-
-export function configureEnv(): void {
-  if (_envConfigured) return;
-  _envConfigured = true;
-
-  const e = _hfEnv as unknown as {
-    backends?: {
-      onnx?: {
-        wasm?: { numThreads?: number; simd?: boolean; wasmPaths?: string };
-      };
+type HfEnv = {
+  backends?: {
+    onnx?: {
+      wasm?: { numThreads?: number; simd?: boolean; wasmPaths?: string };
     };
-    useBrowserCache?: boolean;
   };
+  useBrowserCache?: boolean;
+};
 
+// Two independent configured-flags: one per execution path.
+// CPU path sets numThreads:1 (non-JSEP WASM, required for Electron renderer
+// which lacks SharedArrayBuffer/COOP+COEP). WebGPU path omits numThreads so
+// onnxruntime-web selects ort-wasm-simd.jsep.wasm (JSEP WASM), which
+// registers the WebGPU execution provider — numThreads:1 would force the
+// non-JSEP build and silently drop WebGPU EP support.
+let _cpuEnvConfigured = false;
+let _webgpuEnvConfigured = false;
+
+function applyCommon(e: HfEnv): void {
   if (e.backends?.onnx?.wasm) {
     e.backends.onnx.wasm.wasmPaths = ORT_WASM_PATHS;
-    e.backends.onnx.wasm.numThreads = 1;
-    // simd: leave unset — onnxruntime-web auto-detects SIMD capability.
-    // Forcing true causes silent load failures on older Electron builds
-    // (pre-22) and in enterprise lockdown environments.
   } else {
     logger.warn(
       "onnxEnv: expected WASM backend shape not found — CDN paths not configured",
     );
   }
-  // Guard: `navigator` is undefined in bun test (no DOM); Cache API is a production-only concern.
   if (typeof navigator !== "undefined") {
     e.useBrowserCache = true;
   }
+}
 
-  // WebGPU: deferred — requires requestAdapter() + pipeline call wiring.
+export function configureEnv(): void {
+  if (_cpuEnvConfigured) return;
+  _cpuEnvConfigured = true;
+  const e = _hfEnv as unknown as HfEnv;
+  applyCommon(e);
+  if (e.backends?.onnx?.wasm) {
+    e.backends.onnx.wasm.numThreads = 1;
+  }
+}
+
+/**
+ * WebGPU variant: same CDN paths, but NO numThreads override.
+ * numThreads:1 forces ort-wasm-simd.wasm (non-JSEP); omitting it lets
+ * onnxruntime-web pick ort-wasm-simd.jsep.wasm, which registers the
+ * WebGPU execution provider. Call this only after confirming a WebGPU
+ * adapter is available (navigator.gpu.requestAdapter() returned non-null).
+ */
+export function configureEnvForWebGpu(): void {
+  if (_webgpuEnvConfigured) return;
+  _webgpuEnvConfigured = true;
+  const e = _hfEnv as unknown as HfEnv;
+  applyCommon(e);
+  // numThreads intentionally not set — JSEP WASM handles its own threading.
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.ts
@@ -27,6 +27,19 @@ import type { Embedder } from "./embedder";
 import type { EmbeddingStore } from "./store";
 import type { EmbeddingStoreRegistry } from "./storeRegistry";
 
+/**
+ * Canonical list of all known provider keys. Used by main.ts to scan
+ * for stale per-provider index directories without hard-coding a
+ * separate array.
+ */
+export const ALL_PROVIDER_KEYS = [
+  "native-minilm-l6-v2",
+  "embedding-gemma-300m",
+  "multilingual-e5-base",
+] as const;
+
+export type ProviderKey = (typeof ALL_PROVIDER_KEYS)[number];
+
 export type ProviderFactoryDeps = {
   plugin: McpToolsPlugin;
   embedder: Embedder;

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
@@ -208,6 +208,14 @@ describe("embedding store", () => {
     });
     await store.init();
     expect(store.size()).toBe(0);
+    // Flush on empty store should produce a zero-records bin artifact.
+    await store.flush();
+    const emptyWritten = JSON.parse(
+      mem.files.get("/p/embeddings.index.json") ?? "{}",
+    );
+    expect(emptyWritten.records).toHaveLength(0);
+    const emptyBin = mem.bins.get("/p/embeddings.bin");
+    expect(emptyBin !== undefined ? emptyBin.byteLength : 0).toBe(0);
     // Subsequent upsert + flush should overwrite with the current version.
     await store.upsert([makeRecord({ chunkId: "a:0" })]);
     await store.flush();
@@ -307,7 +315,7 @@ describe("embedding store", () => {
     expect(written.records).toHaveLength(0);
   });
 
-  test("FORMAT_VERSION 2 round-trip: flushed index carries version 2", async () => {
+  test("FORMAT_VERSION 3 round-trip: flushed index carries version 3", async () => {
     const opts = {
       adapter: mem.adapter,
       binPath: "/p/embeddings.bin",
@@ -322,17 +330,19 @@ describe("embedding store", () => {
       mem.files.get("/p/embeddings.index.json") ?? "{}",
     );
     expect(written.version).toBe(FORMAT_VERSION);
-    expect(FORMAT_VERSION).toBe(2);
+    expect(FORMAT_VERSION).toBe(3);
   });
 
-  test("v1 index readable without re-index; dirty=true upgrades to v2 on flush", async () => {
+  test("v1 index treated as stale (version mismatch); re-init from scratch", async () => {
     const opts = {
       adapter: mem.adapter,
       binPath: "/p/embeddings.bin",
       indexPath: "/p/embeddings.index.json",
       vectorDim: DIM,
     };
-    // Craft a v1 index with one record.
+    // v1 indexes are no longer grandfathered: migrateV1FlatStore handles
+    // the path-rename migration (v1→v2); any remaining v1 on-disk index
+    // is treated as stale and wiped on next init().
     const v1Vec = makeVector(3);
     const bin = new Float32Array(DIM);
     bin.set(v1Vec, 0);
@@ -357,18 +367,15 @@ describe("embedding store", () => {
 
     const store = createEmbeddingStore(opts);
     await store.init();
-    // Records must be loaded (not discarded).
-    expect(store.size()).toBe(1);
-    const seen: EmbeddingRecord[] = [];
-    for await (const r of store.scan()) seen.push(r);
-    expect(seen[0]?.chunkId).toBe("legacy:0");
-    // Flush should write a version-2 index.
+    // Version mismatch → re-init from scratch, no records loaded.
+    expect(store.size()).toBe(0);
+    // Flush should write a FORMAT_VERSION index with no records.
     await store.flush();
     const written = JSON.parse(
       mem.files.get("/p/embeddings.index.json") ?? "{}",
     );
     expect(written.version).toBe(FORMAT_VERSION);
-    expect(written.records).toHaveLength(1);
+    expect(written.records).toHaveLength(0);
   });
 
   test("bin shorter than a record's byteOffset+byteLength: skip that record, keep valid ones, no throw", async () => {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
@@ -6,7 +6,7 @@
  *   per chunk, dimensions implicit from the model (default 384 for
  *   MiniLM-L6-v2). Vectors are written contiguously; the JSON index
  *   carries the byteOffset/byteLength to slice them back out.
- * - `<dir>/embeddings.index.json` — `{ version: 1, records: [...] }`.
+ * - `<dir>/embeddings.index.json` — `{ version: 3, records: [...] }`.
  *   Each record maps a chunkId to its `(filePath, offset, heading,
  *   contentHash, byteOffset, byteLength)`. Bumping `version` triggers
  *   a clean re-index on next `init()` (logged warning, no error).
@@ -65,7 +65,7 @@ export type EmbeddingStoreOpts = {
   vectorDim?: number;
 };
 
-export const FORMAT_VERSION = 2;
+export const FORMAT_VERSION = 3;
 const DEFAULT_VECTOR_DIM = 384;
 
 type IndexRecord = {
@@ -136,7 +136,10 @@ class EmbeddingStoreImpl implements EmbeddingStore {
       return;
     }
 
-    if (parsed.version !== FORMAT_VERSION && parsed.version !== 1) {
+    // v1 is intentionally not grandfathered: all v1 stores were migrated
+    // to v2 by migrateV1FlatStore; any remaining v1 index is stale and
+    // is treated as a version mismatch (triggers re-index).
+    if (parsed.version !== FORMAT_VERSION) {
       logger.warn("embedding index format version mismatch, re-indexing", {
         expected: FORMAT_VERSION,
         found: parsed.version,
@@ -196,10 +199,7 @@ class EmbeddingStoreImpl implements EmbeddingStore {
     }
 
     this.initialized = true;
-    // v1 index: records are valid but version marker is stale —
-    // mark dirty so the next flush upgrades the index to v2.
-    // If any record was also skipped, that further requires a flush.
-    this.dirty = skippedAny || parsed.version === 1;
+    this.dirty = skippedAny;
   }
 
   size(): number {
@@ -315,6 +315,7 @@ class EmbeddingStoreImpl implements EmbeddingStore {
   async close(): Promise<void> {
     await this.flush();
     this.records.clear();
+    this.dirty = false;
     this.initialized = false;
   }
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
@@ -25,6 +25,20 @@ function makeMockFactory(dim: number): {
   return { factory, calls };
 }
 
+function makeMockFactoryWithOpts(dim: number): {
+  factory: (model: string) => Promise<MockPipelineFn>;
+  optsLog: Array<object | undefined>;
+} {
+  const optsLog: Array<object | undefined> = [];
+  const factory = async (_model: string): Promise<MockPipelineFn> => {
+    return async (_input, opts) => {
+      optsLog.push(opts);
+      return { data: new Float32Array(dim), dims: [1, dim] };
+    };
+  };
+  return { factory, optsLog };
+}
+
 function makeMockEmbedder(loaded = true): Embedder {
   return {
     embed: async (_text) => new Float32Array(384),
@@ -126,6 +140,24 @@ describe("TransformersProviderImpl", () => {
       provider.embed(["b"], "document"),
     ]);
     expect(loadCount).toBe(1);
+  });
+});
+
+describe("TransformersProviderImpl — truncation opts", () => {
+  test("passes truncation: true and max_length to pipeline", async () => {
+    const { factory, optsLog } = makeMockFactoryWithOpts(768);
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokens: 512,
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (t) => t,
+      pipelineFactory: factory,
+    });
+
+    await provider.embed(["hello"], "document");
+    expect(optsLog[0]).toMatchObject({ truncation: true, max_length: 512 });
   });
 });
 

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
@@ -167,7 +167,7 @@ describe("EmbeddingGemmaProvider", () => {
     const provider = createEmbeddingGemmaProvider(factory);
     expect(provider.providerKey).toBe("embedding-gemma-300m");
     expect(provider.dimensions).toBe(768);
-    expect(provider.maxInputTokens).toBe(2048);
+    expect(provider.maxInputTokens).toBe(512);
   });
 
   test("getModelSizeBytes returns 190 MB", () => {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
@@ -202,10 +202,10 @@ describe("MultilingualE5Provider", () => {
     expect(provider.maxInputTokens).toBe(512);
   });
 
-  test("getModelSizeBytes returns 100 MB", () => {
+  test("getModelSizeBytes returns 60 MB", () => {
     const { factory } = makeMockFactory(768);
     expect(createMultilingualE5Provider(factory).getModelSizeBytes()).toBe(
-      100_000_000,
+      60_000_000,
     );
   });
 

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
@@ -60,6 +60,8 @@ class TransformersProviderImpl implements EmbeddingProvider {
         const result = await pipe(prompted, {
           pooling: "mean",
           normalize: true,
+          truncation: true,
+          max_length: this.opts.maxInputTokens,
         });
         return new Float32Array((result as EmbedTensor).data);
       }),

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
@@ -13,7 +13,6 @@
 
 import type { EmbeddingProvider } from "../types";
 import type { EmbedTensor, PipelineFactory, PipelineFn } from "./embedder";
-import { configureEnv } from "./onnxEnv";
 
 export type TaskPromptFn = (text: string, role: "document" | "query") => string;
 
@@ -71,7 +70,6 @@ class TransformersProviderImpl implements EmbeddingProvider {
   private async ensurePipeline(): Promise<PipelineFn> {
     if (this.pipeline) return this.pipeline;
     if (!this.loadPromise) {
-      configureEnv();
       this.loadPromise = this.opts
         .pipelineFactory(this.opts.modelId)
         .then((p) => {

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -470,12 +470,14 @@ export default class McpToolsPlugin extends Plugin {
       // DLC providers — pipeline loads lazily on first embed call.
       const gemmaDownloader = createModelDownloader({
         innerFactory: realPipelineFactory,
+        dtype: "q8",
       });
       const gemmaProvider = createEmbeddingGemmaProvider(
         gemmaDownloader.factory,
       );
       const e5Downloader = createModelDownloader({
         innerFactory: realPipelineFactory,
+        dtype: "q8",
       });
       const e5Provider = createMultilingualE5Provider(e5Downloader.factory);
 

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -35,6 +35,10 @@ import {
   createEmbedder,
   realPipelineFactory,
 } from "./features/semantic-search/services/embedder";
+import {
+  ALL_PROVIDER_KEYS,
+  type ProviderKey,
+} from "./features/semantic-search/services/providerFactory";
 import { createNativeEmbeddingProvider } from "./features/semantic-search/services/nativeEmbeddingProvider";
 import {
   createEmbeddingStoreRegistry,
@@ -44,6 +48,8 @@ import { createEmbeddingGemmaProvider } from "./features/semantic-search/service
 import { createMultilingualE5Provider } from "./features/semantic-search/services/multilingualE5Provider";
 import { detectNonAsciiRatio } from "./features/semantic-search/services/langDetect";
 import type { VaultAdapter } from "./features/semantic-search/services/store";
+import { FORMAT_VERSION } from "./features/semantic-search/services/store";
+import { IndexWipeMigrationModal } from "./features/semantic-search/services/indexWipeMigrationModal";
 import {
   createLiveIndexer,
   createLowPowerIndexer,
@@ -388,6 +394,57 @@ export default class McpToolsPlugin extends Plugin {
 
       // Migrate v1 flat store before constructing any registry entry.
       await migrateV1FlatStore(ssAdapter, pluginDir);
+
+      // Detect stale per-providerKey stores (version < FORMAT_VERSION).
+      // If any exist, show a blocking dialog before wiping them.
+      const embeddingsBaseDir = `${pluginDir}/embeddings`;
+      const staleProviderKeys: ProviderKey[] = [];
+      for (const key of ALL_PROVIDER_KEYS) {
+        const indexPath = `${embeddingsBaseDir}/${key}/embeddings.index.json`;
+        try {
+          if (await ssAdapter.exists(indexPath)) {
+            const text = await ssAdapter.read(indexPath);
+            const parsed = JSON.parse(text) as { version?: number };
+            if (
+              typeof parsed.version === "number" &&
+              parsed.version < FORMAT_VERSION
+            ) {
+              staleProviderKeys.push(key);
+            }
+          }
+        } catch {
+          // Unreadable index is already handled by store.init(); skip here.
+        }
+      }
+
+      if (staleProviderKeys.length > 0) {
+        await new Promise<void>((resolve) => {
+          const modal = new IndexWipeMigrationModal({
+            app: this.app,
+            onConfirm: resolve,
+            onCancel: resolve,
+          });
+          modal.open();
+        });
+        for (const key of staleProviderKeys) {
+          const dirPath = `${embeddingsBaseDir}/${key}`;
+          try {
+            await ssAdapter.remove(`${dirPath}/embeddings.bin`);
+            await ssAdapter.remove(`${dirPath}/embeddings.index.json`);
+            await ssAdapter
+              .remove(`${dirPath}/embeddings.index.json.writing`)
+              .catch(() => {});
+          } catch (err) {
+            logger.warn(
+              "semantic-search: failed to wipe stale index directory",
+              {
+                dir: dirPath,
+                error: err instanceof Error ? err.message : String(err),
+              },
+            );
+          }
+        }
+      }
 
       const registry = createEmbeddingStoreRegistry(
         ssAdapter,

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -39,7 +39,10 @@ import {
   ALL_PROVIDER_KEYS,
   type ProviderKey,
 } from "./features/semantic-search/services/providerFactory";
-import { createNativeEmbeddingProvider } from "./features/semantic-search/services/nativeEmbeddingProvider";
+import {
+  createNativeEmbeddingProvider,
+  MAX_INPUT_TOKENS as NATIVE_MAX_INPUT_TOKENS,
+} from "./features/semantic-search/services/nativeEmbeddingProvider";
 import {
   createEmbeddingStoreRegistry,
   migrateV1FlatStore,
@@ -457,6 +460,7 @@ export default class McpToolsPlugin extends Plugin {
       });
       const embedder = createEmbedder({
         pipelineFactory: nativeDownloader.factory,
+        maxInputTokens: NATIVE_MAX_INPUT_TOKENS,
       });
       const nativeEp = createNativeEmbeddingProvider(embedder);
       const nativeStore = registry.storeFor("native-minilm-l6-v2", 384);
@@ -589,6 +593,28 @@ export default class McpToolsPlugin extends Plugin {
               _rebuildingProviders.delete(providerKey);
             });
         };
+
+        // B3: Trigger rebuild for the active provider's store that was just
+        // wiped by the migration modal. The modal's "Rebuild now" button only
+        // wipes; this makes the rebuild actually happen automatically.
+        const settingToRegistryKey: Partial<Record<string, ProviderKey>> = {
+          native: "native-minilm-l6-v2",
+          auto: "native-minilm-l6-v2",
+          "embedding-gemma": "embedding-gemma-300m",
+          "multilingual-e5-base": "multilingual-e5-base",
+          // "smart-connections" has no local store — no rebuild needed.
+        };
+        const activeRegistryKey = settingToRegistryKey[state.settings.provider];
+        if (
+          activeRegistryKey &&
+          staleProviderKeys.includes(activeRegistryKey)
+        ) {
+          if (activeRegistryKey === "native-minilm-l6-v2") {
+            state.startIndexerIfNeeded();
+          } else {
+            state.startRebuildFor(activeRegistryKey);
+          }
+        }
 
         state.teardown = async () => {
           if (indexerStarted) {

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -101,9 +101,45 @@ void mock.module("obsidian", () => {
    * `close()` triggering `onClose()` exactly once even when called
    * multiple times, so we track that with a flag.
    */
+  /**
+   * Minimal stub for an Obsidian DOM element created by `contentEl.createEl`.
+   * Records the tag, text, and every event listener attached via
+   * `addEventListener` so tests can inspect what was rendered and
+   * simulate clicks without a real browser DOM.
+   */
+  class MockEl {
+    readonly tag: string;
+    readonly text: string;
+    readonly listeners: Map<string, () => void> = new Map();
+    constructor(tag: string, opts?: { text?: string }) {
+      this.tag = tag;
+      this.text = opts?.text ?? "";
+    }
+    addEventListener(event: string, handler: () => void) {
+      this.listeners.set(event, handler);
+    }
+  }
+
+  /**
+   * Stub of Obsidian's `contentEl` container. Supports `createEl` (which
+   * Obsidian injects on every HTMLElement at runtime) and `empty`. Created
+   * elements accumulate in `_created` so tests can query them by tag.
+   */
+  class MockContentEl {
+    readonly _created: MockEl[] = [];
+    createEl(tag: string, opts?: { text?: string }): MockEl {
+      const el = new MockEl(tag, opts);
+      this._created.push(el);
+      return el;
+    }
+    empty() {
+      this._created.length = 0;
+    }
+  }
+
   class Modal {
     app: unknown;
-    contentEl: { empty: () => void } = { empty: () => {} };
+    contentEl: MockContentEl = new MockContentEl();
     private _closed = false;
     constructor(app: unknown) {
       this.app = app;


### PR DESCRIPTION
## Summary

- **Dependency swap:** `@xenova/transformers@2.17.2` → `@huggingface/transformers@4.2.0`; pin `onnxruntime-web` to `1.26.0-dev.20260416-b7804b056c` (first build with ONNX IR v10 support)
- **FORMAT_VERSION 2 → 3:** indexes built with the Xenova runtime are incompatible with the HuggingFace v4 runtime; bump forces a rebuild on upgrade
- **IndexWipeMigrationModal:** prompts the user before wiping stale indexes; Escape/overlay-dismiss unblocks startup (no hanging promise)
- **onnxEnv.ts:** CDN WASM URL updated; `simd` left undefined for ort-web auto-detection (avoids Electron < 22 breakage); `logger.warn` added when WASM backend shape is absent
- **providerFactory.ts:** export `ALL_PROVIDER_KEYS` as single source of truth; remove hard-coded duplicate from `main.ts`
- **Wipe loop:** also deletes `.writing` sentinel to avoid spurious rebuild warnings after wipe

### Fixes from folotp validation (added 2026-05-28)

- **B1 — `import.meta` patterns survive the bundle:** Bun's `define` does literal token-replacement and does not intercept `Object(import.meta).url` or `typeof import.meta` (emitted by @huggingface/transformers v4) because `import.meta` is used as a function argument, not a member-access target. This caused `SyntaxError: Cannot use 'import.meta' outside a module` on plugin load. Fixed with a post-build step in `bun.config.ts` that replaces both patterns and asserts ≥1 occurrence each (loud build failure if upstream changes emit).
- **B2 — OrtRun SafeInt overflow on large vaults:** Whitespace-based chunking underestimates BPE token count for code, URLs, camelCase, and non-ASCII text. Chunks within the 512-word limit can exceed `max_position_embeddings` in real tokens, causing an integer overflow in OrtRun. Fixed by passing `truncation: true, max_length: <model-limit>` at every pipeline call site (Gemma 2048, E5 512, MiniLM 256) — the tokenizer hard-caps input before inference.
- **B3 — "Rebuild now" button only wipes, never rebuilds:** `IndexWipeMigrationModal` called `onConfirm` which wiped the stale index, but nothing triggered the actual download + reindex. Users had to go to Settings → "Rebuild index from scratch" manually. Fixed by auto-calling `startRebuildFor` (DLC providers) or `startIndexerIfNeeded` (native MiniLM) for the active provider's wiped store immediately after the state wiring is complete.

### Round 4 soak validation complete (folotp, 2026-05-30)

Merged via PR #206. Three additional fixes:

- WebGPU EP registration: redirect `onnxruntime-web` and `onnxruntime-node` to `onnxruntime-web/all` in `bun.config.ts`; split `onnxEnv.ts` into CPU and WebGPU configurators; `embedder.ts` probes `navigator.gpu.requestAdapter()` once and selects the device atomically. Both EmbeddingGemma 300M and MultilinguaE5-base run on WebGPU (Apple Silicon Metal). The SafeInt overflow is bypassed because WebGPU inference skips the WASM runtime path entirely.
- OOM fix: `dtype: "q8"` for both DLC downloaders in `main.ts`; `multilingualE5Provider.modelSizeBytes` corrected 100 MB → 60 MB.
- DLC UX: `startIndexerIfNeeded()` guarded with `!usingDlcProvider`; settings UI reads chunk count from `registry.storeFor(key, 768).size()` for DLC providers.

All B1–B4 confirmed fixed with no regressions. 6,000+ chunk count survives restart. `search_vault_smart` returns results.

## What's NOT in this PR (follow-ups)

- Atomic table chunking: low-priority — separate follow-up issue after merge
- `bun.config.ts` indentation cleanup: cosmetic, separate commit
- CPU path SafeInt overflow (no WebGPU): upstream bug filed at microsoft/onnxruntime#28726; WebGPU is the effective fix on Apple Silicon

## Test plan

```sh
git pull origin feat/transformersjs-v4-onnx-ir10
cd obsidian-mcp-tools/packages/obsidian-plugin
bun install && bun run build && bun run link /path/to/vault/.obsidian
```

- [x] `bun test` → 1072 pass, 0 fail
- [x] `bun run build` → log shows `B1 post-build replace: Object(import.meta).url ×1, typeof import.meta ×1`
- [x] `bun run check` → 0 TypeScript errors
- [x] Plugin loads in Obsidian without `import.meta.url` or `onnxruntime-web` errors (B1)
- [x] `IndexWipeMigrationModal` appears when a v2 index exists; "Rebuild now" starts download + indexing automatically (B3)
- [x] No `Unsupported model IR version: 10` in developer console
- [x] No `SafeInt` / `OrtRun` integer overflow errors on large vaults (B2)
- [x] `search_vault_smart` returns results after indexing
- [x] Chunk count survives an Obsidian restart (FORMAT_VERSION 3 persisted correctly)
- [x] Native MiniLM indexing confirmed working
- [x] EmbeddingGemma 300M — WebGPU indexing completes
- [x] MultilinguaE5-base — WebGPU indexing completes, no OOM
- [x] Settings UI shows correct chunk count for DLC providers
- [x] folotp confirmation on 1,022+ file vault (round 4, 2026-05-30)