### PR TITLE
fix(semantic-search): WebGPU EP + OOM + DLC UX fixes for transformersjs-v4 branch

### DIFF
--- a/packages/obsidian-plugin/bun.config.ts
+++ b/packages/obsidian-plugin/bun.config.ts
@@ -32,13 +32,30 @@ const isProd = args.includes("--prod");
 const stubEmptyModulesPlugin: BunPlugin = {
   name: "stub-empty-modules",
   setup(build) {
-    // Redirect onnxruntime-node → onnxruntime-web (re-export wrapper).
+    // Redirect onnxruntime-web → onnxruntime-web/all.
+    // `ort.min.js` (the default "." export) includes WASM/CPU EP only.
+    // `ort.all.min.js` adds WebGPU EP (via JSEP) + WebGL EP. Without this
+    // redirect, `device: "webgpu"` always fails with "backend not found"
+    // because the WebGPU EP is never registered at startup.
+    build.onResolve({ filter: /^onnxruntime-web$/ }, () => ({
+      path: "onnxruntime-web-all-shim",
+      namespace: "ort-all-redirect",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "ort-all-redirect" }, () => ({
+      contents: "module.exports = require('onnxruntime-web/all');",
+      loader: "js",
+    }));
+    // Redirect onnxruntime-node → onnxruntime-web/all (re-export wrapper).
+    // @huggingface/transformers v4 still imports onnxruntime-node at the
+    // backend level and chooses it whenever process?.release?.name === 'node'
+    // — which in Electron renderer is true. Using /all keeps WebGPU EP
+    // available on the node-shim path too.
     build.onResolve({ filter: /^onnxruntime-node$/ }, () => ({
       path: "onnxruntime-node-shim",
       namespace: "ort-node-redirect",
     }));
     build.onLoad({ filter: /.*/, namespace: "ort-node-redirect" }, () => ({
-      contents: "module.exports = require('onnxruntime-web');",
+      contents: "module.exports = require('onnxruntime-web/all');",
       loader: "js",
     }));
     // Stub sharp.

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
@@ -93,10 +93,14 @@ export async function searchVaultSmartHandler(
   // Lazy indexer kick (Q4 = lazy on first query). Fire-and-forget:
   // the indexer's start() runs the first full vault build in the
   // background and subscribes to vault events for incremental
-  // updates. Subsequent calls are no-ops. Skipped entirely under
-  // Smart Connections — kicking the native indexer there triggers a
-  // pointless embedding-model download (#99).
-  if (!usingSmartConnections) {
+  // updates. Subsequent calls are no-ops. Skipped under Smart
+  // Connections (#99) and DLC providers (embedding-gemma,
+  // multilingual-e5-base) — DLC providers use their own indexer
+  // started by startRebuildFor, not the native MiniLM indexer.
+  const usingDlcProvider =
+    settings?.provider === "embedding-gemma" ||
+    settings?.provider === "multilingual-e5-base";
+  if (!usingSmartConnections && !usingDlcProvider) {
     state.startIndexerIfNeeded?.();
   }
 

--- a/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
+++ b/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
@@ -46,15 +46,20 @@
   });
 
   function refreshStatus() {
-    const state = plugin.semanticSearchState as
-      | (typeof plugin.semanticSearchState & {
-          store?: { size?: () => number };
-        })
-      | undefined;
-    storeSize = state?.store?.size?.() ?? 0;
-    pendingProvider = plugin.semanticSearchState?.pendingProvider ?? null;
-    autoSuggestProvider =
-      plugin.semanticSearchState?.autoSuggestProvider ?? null;
+    const state = plugin.semanticSearchState;
+    const provider = state?.settings?.provider;
+    const registry = state?.registry;
+    // For DLC providers, read chunk count from their own store.
+    // state.store always points to the native MiniLM store.
+    if (provider === "embedding-gemma" && registry) {
+      storeSize = registry.storeFor("embedding-gemma-300m", 768).size();
+    } else if (provider === "multilingual-e5-base" && registry) {
+      storeSize = registry.storeFor("multilingual-e5-base", 768).size();
+    } else {
+      storeSize = state?.store?.size?.() ?? 0;
+    }
+    pendingProvider = state?.pendingProvider ?? null;
+    autoSuggestProvider = state?.autoSuggestProvider ?? null;
   }
 
   async function persist(next: SemanticSearchSettings) {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
@@ -66,6 +66,7 @@ export type ProgressCallback = (info: ProgressEvent) => void;
 export type PipelineFactoryWithProgress = (
   model: string,
   onProgress?: ProgressCallback,
+  opts?: { dtype?: string },
 ) => Promise<PipelineFn>;
 
 export interface Embedder {
@@ -211,16 +212,70 @@ export function createEmbedder(opts: EmbedderOpts): Embedder {
 // v2.17.2. Spike (2026-04-26) found import.meta.url failures; a later
 // re-spike confirmed v4 loads cleanly with the bun.config.ts define block
 // already in place (import.meta.url + __dirname/__filename neutralized).
+//
+// device must be explicit — Transformers.js v4 auto-selects WebGPU when
+// navigator.gpu is present (Electron exposes it). We probe once via
+// requestAdapter(); on success we configure JSEP WASM env (no numThreads
+// override) and use "webgpu"; on failure we configure CPU env (numThreads:1)
+// and use "cpu". Valid v4.2.0 devices: "coreml" | "webgpu" | "cpu".
 import { pipeline as _hfPipeline } from "@huggingface/transformers";
-import { configureEnv } from "./onnxEnv";
+import { configureEnv, configureEnvForWebGpu } from "./onnxEnv";
+import { logger } from "$/shared/logger";
+
+// Resolved once: "webgpu" if requestAdapter() returns a non-null adapter,
+// "cpu" otherwise. Cached so all subsequent factory calls share the same
+// device and env configuration without re-probing.
+let _deviceConfig: Promise<"webgpu" | "cpu"> | null = null;
+
+function resolveDevice(): Promise<"webgpu" | "cpu"> {
+  if (!_deviceConfig) {
+    _deviceConfig = (async (): Promise<"webgpu" | "cpu"> => {
+      if (typeof navigator === "undefined" || !("gpu" in navigator)) {
+        configureEnv();
+        return "cpu";
+      }
+      try {
+        const adapter = await (
+          navigator as { gpu: { requestAdapter(): Promise<unknown> } }
+        ).gpu.requestAdapter();
+        if (adapter !== null) {
+          // JSEP WASM path: omit numThreads so onnxruntime-web selects
+          // ort-wasm-simd.jsep.wasm, which registers the WebGPU EP.
+          configureEnvForWebGpu();
+          return "webgpu";
+        }
+      } catch {
+        // adapter probe failed — fall through to cpu
+      }
+      configureEnv();
+      return "cpu";
+    })();
+  }
+  return _deviceConfig;
+}
 
 export async function realPipelineFactory(
   model: string,
   onProgress?: ProgressCallback,
+  opts?: { dtype?: string },
 ): Promise<PipelineFn> {
-  configureEnv();
+  const device = await resolveDevice();
+
+  if (device === "webgpu") {
+    // No CPU fallback: a failed WebGPU attempt corrupts onnxruntime-web's
+    // internal session state — subsequent cpu calls also get "webgpu backend
+    // not found". Let the error propagate so the caller can surface it cleanly.
+    const pipe = await _hfPipeline("feature-extraction", model, {
+      device: "webgpu",
+      progress_callback: onProgress,
+    } as Parameters<typeof _hfPipeline>[2]);
+    return pipe as unknown as PipelineFn;
+  }
+
   const pipe = await _hfPipeline("feature-extraction", model, {
+    device: "cpu",
     progress_callback: onProgress,
+    ...(opts?.dtype !== undefined ? { dtype: opts.dtype } : {}),
   } as Parameters<typeof _hfPipeline>[2]);
   return pipe as unknown as PipelineFn;
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/modelDownloader.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/modelDownloader.ts
@@ -47,6 +47,8 @@ export interface ModelDownloader {
 
 export type ModelDownloaderOpts = {
   innerFactory: PipelineFactoryWithProgress;
+  /** Passed to the WASM fallback path. Unused when WebGPU succeeds. */
+  dtype?: string;
 };
 
 const IDLE: ModelState = { kind: "idle" };
@@ -84,8 +86,10 @@ class ModelDownloaderImpl implements ModelDownloader {
     this.setState({ kind: "downloading", progress: 0 });
     const promise = (async () => {
       try {
-        const pipe = await this.opts.innerFactory(model, (info) =>
-          this.onProgress(info),
+        const pipe = await this.opts.innerFactory(
+          model,
+          (info) => this.onProgress(info),
+          this.opts.dtype !== undefined ? { dtype: this.opts.dtype } : undefined,
         );
         this.setState({ kind: "ready" });
         return pipe;

--- a/packages/obsidian-plugin/src/features/semantic-search/services/multilingualE5Provider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/multilingualE5Provider.ts
@@ -10,7 +10,7 @@ export function createMultilingualE5Provider(
     providerKey: "multilingual-e5-base",
     dimensions: 768,
     maxInputTokens: 512,
-    modelSizeBytes: 100_000_000,
+    modelSizeBytes: 60_000_000,
     taskPrompt: (text, role) =>
       (role === "query" ? "query: " : "passage: ") + text,
     pipelineFactory,

--- a/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/onnxEnv.ts
@@ -1,9 +1,16 @@
 /**
  * One-shot ONNX / Transformers.js environment configuration.
  *
- * Shared by embedder.ts (MiniLM path) and transformersProvider.ts
- * (multilingual providers) so the call-once guard is a module-level
- * singleton and both importers see the same `_envConfigured` flag.
+ * Two exported functions cover the two execution paths:
+ *   - `configureEnv()` — CPU WASM path; sets numThreads:1 (no SharedArrayBuffer
+ *     in Electron renderer without COOP+COEP).
+ *   - `configureEnvForWebGpu()` — WebGPU path; wasmPaths only, no numThreads,
+ *     so onnxruntime-web selects the JSEP WASM build which registers WebGPU EP.
+ *
+ * Both functions are no-ops after first call (independent flags per path).
+ * `realPipelineFactory` in embedder.ts calls the appropriate one after probing
+ * `navigator.gpu.requestAdapter()`; `transformersProvider.ts` does NOT call
+ * either directly — env configuration is centralised in the factory.
  *
  * Why each setting:
  *
@@ -15,11 +22,17 @@
  *   the version bundled with @huggingface/transformers@4.2.0; updating
  *   the lib requires updating this URL or the WASM ABI may not match
  *   the JS glue.
- * * `env.backends.onnx.wasm.numThreads = 1`: Electron's renderer does
- *   not have COOP/COEP cross-origin isolation, so SharedArrayBuffer is
- *   restricted. Single-threaded WASM avoids the worker spin-up path.
+ * * `env.backends.onnx.wasm.numThreads = 1` (CPU only): Electron's renderer
+ *   does not have COOP/COEP cross-origin isolation, so SharedArrayBuffer is
+ *   restricted. Single-threaded non-JSEP WASM avoids the worker spin-up path.
+ *   Omitted on the WebGPU path so onnxruntime-web selects JSEP WASM instead.
  * * `env.useBrowserCache = true`: persist the downloaded model to the
  *   Cache API so subsequent loads are fast.
+ *
+ * Bundle prerequisite: `bun.config.ts` redirects `onnxruntime-web` →
+ * `onnxruntime-web/all` (ort.all.min.js). The default `ort.min.js` includes
+ * only WASM/CPU EP; WebGPU EP lives in the `all` bundle. Without this redirect,
+ * `device: "webgpu"` always fails with "backend not found".
  */
 
 // Static import required: Obsidian's eval-based plugin loader cannot
@@ -32,36 +45,58 @@ import { logger } from "$/shared/logger";
 const ORT_WASM_PATHS =
   "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/";
 
-let _envConfigured = false;
-
-export function configureEnv(): void {
-  if (_envConfigured) return;
-  _envConfigured = true;
-
-  const e = _hfEnv as unknown as {
-    backends?: {
-      onnx?: {
-        wasm?: { numThreads?: number; simd?: boolean; wasmPaths?: string };
-      };
+type HfEnv = {
+  backends?: {
+    onnx?: {
+      wasm?: { numThreads?: number; simd?: boolean; wasmPaths?: string };
     };
-    useBrowserCache?: boolean;
   };
+  useBrowserCache?: boolean;
+};
 
+// Two independent configured-flags: one per execution path.
+// CPU path sets numThreads:1 (non-JSEP WASM, required for Electron renderer
+// which lacks SharedArrayBuffer/COOP+COEP). WebGPU path omits numThreads so
+// onnxruntime-web selects ort-wasm-simd.jsep.wasm (JSEP WASM), which
+// registers the WebGPU execution provider — numThreads:1 would force the
+// non-JSEP build and silently drop WebGPU EP support.
+let _cpuEnvConfigured = false;
+let _webgpuEnvConfigured = false;
+
+function applyCommon(e: HfEnv): void {
   if (e.backends?.onnx?.wasm) {
     e.backends.onnx.wasm.wasmPaths = ORT_WASM_PATHS;
-    e.backends.onnx.wasm.numThreads = 1;
-    // simd: leave unset — onnxruntime-web auto-detects SIMD capability.
-    // Forcing true causes silent load failures on older Electron builds
-    // (pre-22) and in enterprise lockdown environments.
   } else {
     logger.warn(
       "onnxEnv: expected WASM backend shape not found — CDN paths not configured",
     );
   }
-  // Guard: `navigator` is undefined in bun test (no DOM); Cache API is a production-only concern.
   if (typeof navigator !== "undefined") {
     e.useBrowserCache = true;
   }
+}
 
-  // WebGPU: deferred — requires requestAdapter() + pipeline call wiring.
+export function configureEnv(): void {
+  if (_cpuEnvConfigured) return;
+  _cpuEnvConfigured = true;
+  const e = _hfEnv as unknown as HfEnv;
+  applyCommon(e);
+  if (e.backends?.onnx?.wasm) {
+    e.backends.onnx.wasm.numThreads = 1;
+  }
+}
+
+/**
+ * WebGPU variant: same CDN paths, but NO numThreads override.
+ * numThreads:1 forces ort-wasm-simd.wasm (non-JSEP); omitting it lets
+ * onnxruntime-web pick ort-wasm-simd.jsep.wasm, which registers the
+ * WebGPU execution provider. Call this only after confirming a WebGPU
+ * adapter is available (navigator.gpu.requestAdapter() returned non-null).
+ */
+export function configureEnvForWebGpu(): void {
+  if (_webgpuEnvConfigured) return;
+  _webgpuEnvConfigured = true;
+  const e = _hfEnv as unknown as HfEnv;
+  applyCommon(e);
+  // numThreads intentionally not set — JSEP WASM handles its own threading.
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
@@ -13,7 +13,6 @@
 
 import type { EmbeddingProvider } from "../types";
 import type { EmbedTensor, PipelineFactory, PipelineFn } from "./embedder";
-import { configureEnv } from "./onnxEnv";
 
 export type TaskPromptFn = (text: string, role: "document" | "query") => string;
 
@@ -71,7 +70,6 @@ class TransformersProviderImpl implements EmbeddingProvider {
   private async ensurePipeline(): Promise<PipelineFn> {
     if (this.pipeline) return this.pipeline;
     if (!this.loadPromise) {
-      configureEnv();
       this.loadPromise = this.opts
         .pipelineFactory(this.opts.modelId)
         .then((p) => {

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -470,12 +470,14 @@ export default class McpToolsPlugin extends Plugin {
       // DLC providers — pipeline loads lazily on first embed call.
       const gemmaDownloader = createModelDownloader({
         innerFactory: realPipelineFactory,
+        dtype: "q8",
       });
       const gemmaProvider = createEmbeddingGemmaProvider(
         gemmaDownloader.factory,
       );
       const e5Downloader = createModelDownloader({
         innerFactory: realPipelineFactory,
+        dtype: "q8",
       });
       const e5Provider = createMultilingualE5Provider(e5Downloader.factory);
 


### PR DESCRIPTION
Follow-up to round 4 soak testing on macOS 26.5, Obsidian latest, vault ~1 022+ markdown files. Three issues found during testing; three commits fixing them.

## Commits

### 1. `feat(semantic-search): enable WebGPU acceleration via ort.all + JSEP WASM`

**Root cause found:** `ort.min.js` (the default `onnxruntime-web` entry resolved by Bun under `conditions: ["browser"]`) only registers the WASM/CPU execution provider. The WebGPU EP lives in `ort.all.min.js`. Without it, `device: "webgpu"` always fails with `no available backend found. ERR: [webgpu] backend not found` — regardless of whether `navigator.gpu.requestAdapter()` returns a non-null adapter.

**Fixes:**
- `bun.config.ts`: redirect both `onnxruntime-web` and `onnxruntime-node` imports to `onnxruntime-web/all` so WebGPU EP is registered at startup
- `onnxEnv.ts`: split into `configureEnv()` (CPU — keeps `numThreads:1` to force non-JSEP WASM, required in Electron renderer without COOP+COEP) and `configureEnvForWebGpu()` (WebGPU — `wasmPaths` only, no `numThreads` override, lets onnxruntime-web select `ort-wasm-simd.jsep.wasm` which registers the WebGPU EP)
- `embedder.ts`: probe `navigator.gpu.requestAdapter()` once; call the correct env configurator atomically; drop the broken CPU fallback after a failed WebGPU attempt (onnxruntime-web internal state is corrupted by a failed WebGPU session — subsequent CPU calls also get "webgpu backend not found")
- `transformersProvider.ts`: remove the premature `configureEnv()` call from `ensurePipeline()` — env configuration is now solely owned by `realPipelineFactory`

**Result:** EmbeddingGemma 300M and MultilinguaE5-base both load and run inference on WebGPU (Apple Silicon Metal). The SafeInt overflow is bypassed entirely — WebGPU inference does not touch the WASM runtime path that has the overflow bug.

### 2. `fix(semantic-search): use q8 dtype for DLC providers to prevent WASM OOM`

MultilinguaE5-base fp32 (~268 MB) triggers `std::bad_alloc` in the onnxruntime-web WASM heap on the CPU path. Added `dtype: "q8"` to both EmbeddingGemma and MultilinguaE5 downloaders in `main.ts`. `ModelDownloader` gains an optional `dtype` field forwarded to `realPipelineFactory`'s WASM fallback path (unused when WebGPU succeeds). Also corrects `multilingualE5Provider.modelSizeBytes` from 100 MB → 60 MB (actual q8 artifact size).

### 3. `fix(semantic-search): correct DLC provider UX — indexer guard + chunk count`

Two independent UX bugs found during testing:

- `searchVaultSmart.ts`: `startIndexerIfNeeded()` was called for all non-Smart-Connections providers, including DLC providers. This unnecessarily started the native MiniLM indexer when EmbeddingGemma or MultilinguaE5 was active. Guarded with `!usingDlcProvider`.
- `SemanticSettingsSection.svelte`: `refreshStatus()` always read `state.store` (hardwired to the native MiniLM store), so the UI showed 0 chunks for DLC providers — even after a successful 6 000+ chunk rebuild. Now reads `registry.storeFor(key, 768).size()` for DLC providers.

## Test results (round 4+, this branch)

| | |
|---|---|
| ✅ B1 `import.meta` patch | confirmed fixed (no regression) |
| ✅ B3 migration banner "Rebuild now" | confirmed fixed (no regression) |
| ✅ B2 MiniLM truncation | confirmed fixed (no regression) |
| ✅ B4 "Rebuild from scratch" provider routing | confirmed fixed (no regression) |
| ✅ EmbeddingGemma 300M — WebGPU indexing | completes, no SafeInt overflow |
| ✅ MultilinguaE5-base — WebGPU indexing | completes, no OOM |
| ✅ MiniLM — indexing | confirmed working |
| ✅ `search_vault_smart` | returns ranked results |
| ✅ Chunk count survives Obsidian restart | confirmed (6 000+ chunks, EmbeddingGemma) |
| ✅ Settings UI shows correct chunk count | fixed by commit 3 |

## Notes

- **CPU path (no WebGPU):** the SafeInt overflow in `onnxruntime-web@1.26.0` WASM is unresolved for 768-dim models at sequence length > 512. WebGPU bypasses the WASM runtime entirely and is the effective fix. On machines without WebGPU, EmbeddingGemma and MultilinguaE5 will still hit the overflow on CPU. Upstream bug filed: [microsoft/onnxruntime#28726](https://github.com/microsoft/onnxruntime/issues/28726).
- **JSEP WASM files** are served from the existing CDN URL (`cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/`) — jsDelivr serves the full npm package, `ort-wasm-simd.jsep.wasm` is present.
- `ort.all.min.js` is larger than `ort.min.js` (adds WebGPU + WebGL EP code). Bundle size increase is acceptable given the existing Transformers.js payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)