### PR TITLE
perf(semantic-search): fix O(N×M) indexer — add fileIndex to EmbeddingStore

### DIFF
--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -376,8 +376,8 @@ async function processOnePath(deps: ProcessDeps, path: string): Promise<void> {
   }
 
   const existingByHash = new Map<string, EmbeddingRecord>();
-  for await (const r of deps.store.scan()) {
-    if (r.filePath === path) existingByHash.set(r.contentHash, r);
+  for (const r of deps.store.recordsFor(path)) {
+    existingByHash.set(r.contentHash, r);
   }
 
   const records: EmbeddingRecord[] = [];

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
@@ -431,3 +431,72 @@ describe("embedding store", () => {
     }
   });
 });
+
+describe("EmbeddingStore — recordsFor", () => {
+  function makeOpts() {
+    const { adapter } = makeMemAdapter();
+    return {
+      adapter,
+      binPath: "/p/embeddings.bin",
+      indexPath: "/p/embeddings.index.json",
+      vectorDim: DIM,
+    };
+  }
+
+  test("returns empty iterable for unknown filePath", async () => {
+    const store = createEmbeddingStore(makeOpts());
+    await store.init();
+    const result = Array.from(store.recordsFor("Notes/missing.md"));
+    expect(result).toHaveLength(0);
+  });
+
+  test("returns only records for the requested filePath", async () => {
+    const store = createEmbeddingStore(makeOpts());
+    await store.init();
+    await store.upsert([
+      makeRecord({ chunkId: "a:0", filePath: "Notes/a.md" }),
+      makeRecord({ chunkId: "a:1", filePath: "Notes/a.md" }),
+      makeRecord({ chunkId: "b:0", filePath: "Notes/b.md" }),
+    ]);
+    const forA = Array.from(store.recordsFor("Notes/a.md"));
+    expect(forA).toHaveLength(2);
+    expect(forA.every((r) => r.filePath === "Notes/a.md")).toBe(true);
+    const forB = Array.from(store.recordsFor("Notes/b.md"));
+    expect(forB).toHaveLength(1);
+    expect(forB[0]?.chunkId).toBe("b:0");
+  });
+
+  test("returns empty iterable after delete for that filePath", async () => {
+    const store = createEmbeddingStore(makeOpts());
+    await store.init();
+    await store.upsert([
+      makeRecord({ chunkId: "a:0", filePath: "Notes/a.md" }),
+      makeRecord({ chunkId: "a:1", filePath: "Notes/a.md" }),
+    ]);
+    await store.delete("Notes/a.md");
+    const result = Array.from(store.recordsFor("Notes/a.md"));
+    expect(result).toHaveLength(0);
+    expect(store.size()).toBe(0);
+  });
+
+  test("recordsFor reflects records loaded from disk after flush+init", async () => {
+    const opts = makeOpts();
+    const store1 = createEmbeddingStore(opts);
+    await store1.init();
+    await store1.upsert([
+      makeRecord({ chunkId: "a:0", filePath: "Notes/a.md" }),
+      makeRecord({ chunkId: "b:0", filePath: "Notes/b.md" }),
+    ]);
+    await store1.flush();
+    await store1.close();
+
+    const store2 = createEmbeddingStore(opts);
+    await store2.init();
+    const forA = Array.from(store2.recordsFor("Notes/a.md"));
+    expect(forA).toHaveLength(1);
+    expect(forA[0]?.chunkId).toBe("a:0");
+    const forB = Array.from(store2.recordsFor("Notes/b.md"));
+    expect(forB).toHaveLength(1);
+    expect(forB[0]?.chunkId).toBe("b:0");
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
@@ -51,6 +51,8 @@ export interface EmbeddingStore {
   size(): number;
   upsert(records: EmbeddingRecord[]): Promise<void>;
   delete(filePath: string): Promise<void>;
+  /** O(chunks-in-file) lookup via secondary index. Use instead of scan()+filter for per-path access. */
+  recordsFor(filePath: string): Iterable<EmbeddingRecord>;
   scan(): AsyncIterable<EmbeddingRecord>;
   flush(): Promise<void>;
   close(): Promise<void>;
@@ -85,6 +87,7 @@ type IndexFile = {
 
 class EmbeddingStoreImpl implements EmbeddingStore {
   private records = new Map<string, EmbeddingRecord>();
+  private fileIndex = new Map<string, Set<string>>();
   private dirty = false;
   private initialized = false;
   private readonly vectorDim: number;
@@ -196,6 +199,12 @@ class EmbeddingStoreImpl implements EmbeddingStore {
         contentHash: idx.contentHash,
         vector,
       });
+      let fileSet = this.fileIndex.get(idx.filePath);
+      if (!fileSet) {
+        fileSet = new Set();
+        this.fileIndex.set(idx.filePath, fileSet);
+      }
+      fileSet.add(idx.chunkId);
     }
 
     this.initialized = true;
@@ -214,21 +223,47 @@ class EmbeddingStoreImpl implements EmbeddingStore {
           `embedding dim mismatch: chunkId=${r.chunkId} expected ${this.vectorDim} got ${r.vector.length}`,
         );
       }
+      // If the chunkId already exists under a different filePath, remove it
+      // from the old fileIndex entry before overwriting.
+      const existing = this.records.get(r.chunkId);
+      if (existing && existing.filePath !== r.filePath) {
+        const oldSet = this.fileIndex.get(existing.filePath);
+        if (oldSet) {
+          oldSet.delete(r.chunkId);
+          if (oldSet.size === 0) this.fileIndex.delete(existing.filePath);
+        }
+      }
       this.records.set(r.chunkId, r);
+      let fileSet = this.fileIndex.get(r.filePath);
+      if (!fileSet) {
+        fileSet = new Set();
+        this.fileIndex.set(r.filePath, fileSet);
+      }
+      fileSet.add(r.chunkId);
     }
     this.dirty = true;
   }
 
   async delete(filePath: string): Promise<void> {
     if (!this.initialized) await this.init();
-    let removed = 0;
-    for (const [chunkId, rec] of this.records) {
-      if (rec.filePath === filePath) {
-        this.records.delete(chunkId);
-        removed += 1;
-      }
+    const chunkIds = this.fileIndex.get(filePath);
+    if (!chunkIds || chunkIds.size === 0) return;
+    for (const chunkId of chunkIds) {
+      this.records.delete(chunkId);
     }
-    if (removed > 0) this.dirty = true;
+    this.fileIndex.delete(filePath);
+    this.dirty = true;
+  }
+
+  recordsFor(filePath: string): Iterable<EmbeddingRecord> {
+    const chunkIds = this.fileIndex.get(filePath);
+    if (!chunkIds) return [];
+    const out: EmbeddingRecord[] = [];
+    for (const chunkId of chunkIds) {
+      const r = this.records.get(chunkId);
+      if (r) out.push(r);
+    }
+    return out;
   }
 
   async *scan(): AsyncIterable<EmbeddingRecord> {
@@ -315,6 +350,7 @@ class EmbeddingStoreImpl implements EmbeddingStore {
   async close(): Promise<void> {
     await this.flush();
     this.records.clear();
+    this.fileIndex.clear();
     this.dirty = false;
     this.initialized = false;
   }


### PR DESCRIPTION
## Problem

`processOnePath` called `store.scan()` and filtered by `filePath` for every file processed. During `rebuildAll()` over N files with M total chunks this was **O(N×M)** — quadratic in vault size. `delete(filePath)` had the same linear scan.

## Fix

Add a `Map<filePath, Set<chunkId>>` secondary index (`fileIndex`) to `EmbeddingStoreImpl`:

- **`upsert()`** — maintains `fileIndex` per record inserted/overwritten
- **`delete(filePath)`** — looks up `fileIndex` to delete only that file's chunks: **O(chunks-in-file)** instead of O(store-size)
- **`init()`** — populates `fileIndex` from records loaded from disk
- **`close()`** — clears `fileIndex`

Add `recordsFor(filePath): Iterable<EmbeddingRecord>` to the `EmbeddingStore` interface, returning only records for that path via the secondary index.

`processOnePath` now calls `store.recordsFor(path)` instead of the full `scan()` + filter. `rebuildAll()` over N files is now **O(N × chunks-per-file)** — linear.

`scan()` is unchanged — `nativeProvider` still uses it for full-store cosine search.

## Tests

+4 tests in `store.test.ts` covering `recordsFor`: empty lookup, multi-file isolation, post-delete empty, and round-trip through flush+init.

**Baseline:** 1072 pass / 0 fail  
**Post-fix:** 1076 pass / 0 fail