### PR TITLE
fix(ci): add prettier as explicit root dev dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,9 @@
       "dependencies": {
         "caniuse-lite": "^1.0.30001724",
       },
+      "devDependencies": {
+        "prettier": "^3.8.3",
+      },
     },
     "packages/obsidian-plugin": {
       "name": "@obsidian-mcp-tools/obsidian-plugin",
@@ -717,6 +720,8 @@
     "preact": ["preact@10.25.3", "", {}, "sha512-dzQmIFtM970z+fP9ziQ3yG4e3ULIbwZzJ734vaMVUTaKQ2+Ru1Ou/gjshOYVHCcd1rpAelC6ngjvjDXph98unQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   },
   "dependencies": {
     "caniuse-lite": "^1.0.30001724"
+  },
+  "devDependencies": {
+    "prettier": "^3.8.3"
   }
 }


### PR DESCRIPTION
Prettier was not declared in any `package.json` — it was only available as a transitive hoist from `packages/test-site`. Removing test-site dropped it from `bun.lock`, breaking the `format:check` CI step with `prettier: command not found`.

Adds `prettier@3.8.3` as an explicit `devDependency` in the root `package.json`.