### PR TITLE
style: fix prettier formatting in two files

### DIFF
--- a/packages/obsidian-plugin/src/features/semantic-search/index.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/index.test.ts
@@ -365,9 +365,8 @@ describe("applySettings — UI swap path (T12)", () => {
   test("DLC: embedding-gemma with store not ready sets pendingProvider and keeps old provider", async () => {
     const { plugin } = makePluginStub();
     const { createEmbeddingStore } = await import("./services/store");
-    const { createEmbeddingStoreRegistry } = await import(
-      "./services/storeRegistry"
-    );
+    const { createEmbeddingStoreRegistry } =
+      await import("./services/storeRegistry");
     const adapter = {
       async exists() {
         return false;
@@ -424,9 +423,8 @@ describe("applySettings — UI swap path (T12)", () => {
   test("DLC: embedding-gemma with store ready swaps provider and clears pendingProvider", async () => {
     const { plugin } = makePluginStub();
     const { createEmbeddingStore } = await import("./services/store");
-    const { createEmbeddingStoreRegistry } = await import(
-      "./services/storeRegistry"
-    );
+    const { createEmbeddingStoreRegistry } =
+      await import("./services/storeRegistry");
     const adapter = {
       async exists() {
         return false;

--- a/packages/obsidian-plugin/src/features/semantic-search/services/modelDownloader.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/modelDownloader.ts
@@ -89,7 +89,9 @@ class ModelDownloaderImpl implements ModelDownloader {
         const pipe = await this.opts.innerFactory(
           model,
           (info) => this.onProgress(info),
-          this.opts.dtype !== undefined ? { dtype: this.opts.dtype } : undefined,
+          this.opts.dtype !== undefined
+            ? { dtype: this.opts.dtype }
+            : undefined,
         );
         this.setState({ kind: "ready" });
         return pipe;


### PR DESCRIPTION
Fixes `format:check` CI failure. Two files had formatting drift: `index.test.ts` and `modelDownloader.ts`. Applied `prettier --write`.