### PR TITLE
fix(semantic-search): live DLC index updates — debounced flush + persistent indexer subscribe

### DIFF
--- a/packages/obsidian-plugin/src/features/semantic-search/index.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/index.test.ts
@@ -470,7 +470,8 @@ describe("applySettings — UI swap path (T12)", () => {
     const fakeGemmaEp = {
       providerKey: "embedding-gemma-300m" as const,
       dimensions: 768,
-      maxInputTokens: 2048,
+      maxInputTokens: 512,
+      getMaxInputTokens: async () => 2048,
       embed: async (texts: string[]) => texts.map(() => new Float32Array(768)),
       isAvailable: async () => true,
       getModelSizeBytes: () => 0,

--- a/packages/obsidian-plugin/src/features/semantic-search/index.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/index.ts
@@ -120,8 +120,21 @@ export type SemanticSearchState = {
    * Trigger a download + full index build for a specific providerKey.
    * Wired by production setup (Task 8); absent in tests and early lifecycle.
    * The settings UI calls this from the rebuild banner's "Rebuild now" button.
+   *
+   * Implementation detail: the first call for a providerKey creates a
+   * persistent `LiveIndexer` (stored in `dlcIndexers`) and calls `start()`
+   * so vault create/modify/delete events flow into the matching store from
+   * that point on. Subsequent calls reuse the already-subscribed indexer
+   * and run a fresh `rebuildAll()` against it.
    */
   startRebuildFor?: ((providerKey: string) => void) | null;
+  /**
+   * Persistent DLC indexers keyed by providerKey. Populated lazily by
+   * `startRebuildFor` and by the plugin-load auto-subscribe for the
+   * active DLC provider. Used by `teardown` to stop and flush every
+   * subscribed indexer on plugin unload.
+   */
+  dlcIndexers?: Map<string, SemanticIndexer> | null;
   teardown: () => Promise<void>;
 };
 

--- a/packages/obsidian-plugin/src/features/semantic-search/services/chunker.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/chunker.test.ts
@@ -3,8 +3,10 @@ import {
   chunk,
   countTokens,
   hashChunk,
+  makeChunkerForProvider,
   wrapChunkerWithOverlap,
 } from "./chunker";
+import type { EmbeddingProvider } from "../types";
 
 const lorem = (words: number): string => {
   const base = "lorem ipsum dolor sit amet consectetur adipiscing elit ";
@@ -284,5 +286,49 @@ describe("chunker", () => {
     expect(chunks[0]?.id).toBe("#frontmatter");
     // Body chunk should NOT have frontmatter overlap prepended.
     expect(chunks[1]?.text.startsWith("# Body")).toBe(true);
+  });
+});
+
+function stubProvider(maxInputTokens: number): EmbeddingProvider {
+  return {
+    providerKey: "stub",
+    dimensions: 1,
+    maxInputTokens,
+    getMaxInputTokens: async () => maxInputTokens,
+    embed: async () => [],
+    isAvailable: async () => true,
+    getModelSizeBytes: () => 0,
+  };
+}
+
+describe("makeChunkerForProvider", () => {
+  test("subtracts 16-token task-prompt headroom from provider max", async () => {
+    // 2048 → 2032 effective. Use a single long section that exceeds the
+    // chunker default (512) — proves the override actually raises the cap.
+    const content = `# Body\n\n${lorem(800)}`;
+    const chunkerDefault = await chunk(content);
+    const chunkerLargeBudget = await makeChunkerForProvider(
+      stubProvider(2048),
+    )(content);
+    // Default config splits an 800-token section; the larger budget keeps
+    // it as one chunk because 800 < 2032.
+    expect(chunkerDefault.length).toBeGreaterThan(1);
+    expect(chunkerLargeBudget).toHaveLength(1);
+  });
+
+  test("MIN_CHUNK_MAX_TOKENS floor protects against pathological caps", async () => {
+    // Provider cap below the 64-token floor → chunker still uses 64.
+    const content = `# Body\n\n${lorem(80)}`;
+    const chunks = await makeChunkerForProvider(stubProvider(32))(content);
+    // 80 tokens at 64 maxTokens should produce ≥2 chunks; not crash.
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("native-sized provider (256) yields ~240 effective max", async () => {
+    // A 300-token section: 240 effective max → splits; 256 raw would keep
+    // it close to one. The 16-token headroom is the asserted behavior.
+    const content = `# Body\n\n${lorem(300)}`;
+    const chunks = await makeChunkerForProvider(stubProvider(256))(content);
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/chunker.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/chunker.ts
@@ -21,6 +21,7 @@
  */
 
 import { logger } from "$/shared/logger";
+import type { EmbeddingProvider } from "../types";
 
 export type ChunkOpts = {
   maxTokens?: number;
@@ -415,4 +416,48 @@ export async function chunk(
   }
 
   return fmChunk ? [fmChunk, ...bodyChunks] : bodyChunks;
+}
+
+/**
+ * Headroom subtracted from `provider.getMaxInputTokens()` so the longest
+ * task-prompt prefix can be prepended at embed time without exceeding
+ * the model's hard cap. Gemma's `"task: search result | query: "` is ≈8
+ * BPE tokens; 16 gives ample slack for prompt variants while keeping
+ * chunks near the model's effective context.
+ */
+const TASK_PROMPT_HEADROOM = 16;
+
+/**
+ * Absolute floor for chunk size. Guards against pathological provider
+ * caps (e.g. a misconfigured small-context model) producing chunks too
+ * tiny for `chunk()`'s `minTokens` heuristic to make sense.
+ */
+const MIN_CHUNK_MAX_TOKENS = 64;
+
+/**
+ * Build a `ChunkerFn` whose token budget tracks the provider's effective
+ * `getMaxInputTokens()` (backend-resolved). The headroom subtraction
+ * accounts for the task-prompt prefix prepended at embed time, so the
+ * rendered prompted text stays within the model's hard cap.
+ */
+export function makeChunkerForProvider(
+  provider: EmbeddingProvider,
+): ChunkerFn {
+  let logged = false;
+  return async (content: string): Promise<Chunk[]> => {
+    const maxInputTokens = await provider.getMaxInputTokens();
+    const maxTokens = Math.max(
+      MIN_CHUNK_MAX_TOKENS,
+      maxInputTokens - TASK_PROMPT_HEADROOM,
+    );
+    if (!logged) {
+      logged = true;
+      logger.info("semantic-search: chunker bound to provider", {
+        providerKey: provider.providerKey,
+        maxInputTokens,
+        chunkMaxTokens: maxTokens,
+      });
+    }
+    return chunk(content, { maxTokens });
+  };
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
+  __resetBackendForTesting,
   createEmbedder,
+  resolveBackend,
   type PipelineFactory,
   type PipelineFn,
 } from "./embedder";
@@ -199,5 +201,57 @@ describe("embedder", () => {
     });
     await embedder.embed("hello");
     expect(pipeOpts[0]).toMatchObject({ truncation: true, max_length: 128 });
+  });
+});
+
+describe("resolveBackend", () => {
+  afterEach(() => {
+    __resetBackendForTesting();
+  });
+
+  test("returns 'wasm' when navigator is undefined (test environment)", async () => {
+    expect(await resolveBackend(undefined)).toBe("wasm");
+  });
+
+  test("returns 'wasm' when navigator.gpu is missing", async () => {
+    expect(await resolveBackend({})).toBe("wasm");
+  });
+
+  test("returns 'wasm' when requestAdapter resolves null", async () => {
+    expect(
+      await resolveBackend({
+        gpu: { requestAdapter: async () => null },
+      }),
+    ).toBe("wasm");
+  });
+
+  test("returns 'wasm' when requestAdapter throws", async () => {
+    expect(
+      await resolveBackend({
+        gpu: {
+          requestAdapter: async () => {
+            throw new Error("adapter denied");
+          },
+        },
+      }),
+    ).toBe("wasm");
+  });
+
+  test("returns 'webgpu' when requestAdapter resolves a non-null adapter", async () => {
+    expect(
+      await resolveBackend({
+        gpu: { requestAdapter: async () => ({}) },
+      }),
+    ).toBe("webgpu");
+  });
+
+  test("cached after first call — second call ignores changed navigator", async () => {
+    expect(
+      await resolveBackend({
+        gpu: { requestAdapter: async () => ({}) },
+      }),
+    ).toBe("webgpu");
+    // No reset between calls; the cached result wins.
+    expect(await resolveBackend(undefined)).toBe("webgpu");
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
@@ -219,39 +219,74 @@ export function createEmbedder(opts: EmbedderOpts): Embedder {
 // override) and use "webgpu"; on failure we configure CPU env (numThreads:1)
 // and use "cpu". Valid v4.2.0 devices: "coreml" | "webgpu" | "cpu".
 import { pipeline as _hfPipeline } from "@huggingface/transformers";
+import type { BackendKind } from "../types";
 import { configureEnv, configureEnvForWebGpu } from "./onnxEnv";
 import { logger } from "$/shared/logger";
 
-// Resolved once: "webgpu" if requestAdapter() returns a non-null adapter,
-// "cpu" otherwise. Cached so all subsequent factory calls share the same
-// device and env configuration without re-probing.
-let _deviceConfig: Promise<"webgpu" | "cpu"> | null = null;
+export type { BackendKind } from "../types";
 
-function resolveDevice(): Promise<"webgpu" | "cpu"> {
-  if (!_deviceConfig) {
-    _deviceConfig = (async (): Promise<"webgpu" | "cpu"> => {
-      if (typeof navigator === "undefined" || !("gpu" in navigator)) {
-        configureEnv();
-        return "cpu";
-      }
-      try {
-        const adapter = await (
-          navigator as { gpu: { requestAdapter(): Promise<unknown> } }
-        ).gpu.requestAdapter();
-        if (adapter !== null) {
-          // JSEP WASM path: omit numThreads so onnxruntime-web selects
-          // ort-wasm-simd.jsep.wasm, which registers the WebGPU EP.
-          configureEnvForWebGpu();
-          return "webgpu";
-        }
-      } catch {
-        // adapter probe failed — fall through to cpu
-      }
-      configureEnv();
-      return "cpu";
+/**
+ * Optional navigator-shape parameter used by tests to inject a mock
+ * `navigator.gpu` without touching the global. Production callers pass
+ * nothing and the function reads the real `navigator`.
+ */
+export type NavigatorLike = {
+  gpu?: { requestAdapter(): Promise<unknown> };
+};
+
+// Resolved once: "webgpu" if requestAdapter() returns a non-null adapter,
+// "wasm" otherwise. Cached so all subsequent factory calls share the same
+// backend and env configuration without re-probing.
+let _backendConfig: Promise<BackendKind> | null = null;
+
+/**
+ * Probe the active inference backend. Calls the matching env configurator
+ * (`configureEnvForWebGpu` on success, `configureEnv` otherwise) so the
+ * one-shot env state is consistent with the resolved backend.
+ *
+ * Cached after first call. Tests should call `__resetBackendForTesting()`
+ * in `afterEach` to clear the cache.
+ */
+export function resolveBackend(
+  navigatorRef: NavigatorLike | undefined = typeof navigator !== "undefined"
+    ? (navigator as unknown as NavigatorLike)
+    : undefined,
+): Promise<BackendKind> {
+  if (!_backendConfig) {
+    _backendConfig = (async (): Promise<BackendKind> => {
+      const backend = await resolveBackendInner(navigatorRef);
+      logger.info("semantic-search: backend resolved", { backend });
+      return backend;
     })();
   }
-  return _deviceConfig;
+  return _backendConfig;
+}
+
+async function resolveBackendInner(
+  navigatorRef: NavigatorLike | undefined,
+): Promise<BackendKind> {
+  if (!navigatorRef?.gpu) {
+    configureEnv();
+    return "wasm";
+  }
+  try {
+    const adapter = await navigatorRef.gpu.requestAdapter();
+    if (adapter !== null) {
+      // JSEP WASM path: omit numThreads so onnxruntime-web selects
+      // ort-wasm-simd.jsep.wasm, which registers the WebGPU EP.
+      configureEnvForWebGpu();
+      return "webgpu";
+    }
+  } catch {
+    // adapter probe failed — fall through to wasm
+  }
+  configureEnv();
+  return "wasm";
+}
+
+/** Test-only: reset the cached backend resolution. */
+export function __resetBackendForTesting(): void {
+  _backendConfig = null;
 }
 
 export async function realPipelineFactory(
@@ -259,9 +294,9 @@ export async function realPipelineFactory(
   onProgress?: ProgressCallback,
   opts?: { dtype?: string },
 ): Promise<PipelineFn> {
-  const device = await resolveDevice();
+  const backend = await resolveBackend();
 
-  if (device === "webgpu") {
+  if (backend === "webgpu") {
     // No CPU fallback: a failed WebGPU attempt corrupts onnxruntime-web's
     // internal session state — subsequent cpu calls also get "webgpu backend
     // not found". Let the error propagate so the caller can surface it cleanly.

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
@@ -10,8 +10,10 @@ export function createEmbeddingGemmaProvider(
     modelId: "onnx-community/embeddinggemma-300m-ONNX",
     providerKey: "embedding-gemma-300m",
     dimensions: 768,
-    // Capped at 512 — onnxruntime-web@1.26.0-dev SafeInt overflow at 2048 (#202)
-    maxInputTokens: 512,
+    // WASM capped at 512 — onnxruntime-web@1.26.0 SafeInt overflow at 2048
+    // (#202, upstream microsoft/onnxruntime#28726). WebGPU EP bypasses the
+    // WASM int math path and unlocks the model's full 2K context.
+    maxInputTokensByBackend: { wasm: 512, webgpu: 2048 },
     modelSizeBytes: 190_000_000,
     taskPrompt: (text, role) =>
       role === "query"

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
@@ -683,6 +683,88 @@ describe("live indexer — flush debounce", () => {
   });
 });
 
+describe("live indexer — start({ initialRebuild: false })", () => {
+  let rawStore: Awaited<ReturnType<typeof makeStore>>;
+
+  beforeEach(async () => {
+    rawStore = await makeStore();
+  });
+
+  test("subscribes without running rebuildAll", async () => {
+    const { vault } = makeVault({
+      "a.md": "alpha",
+      "b.md": "bravo",
+    });
+    const { embedder, embeds } = fakeEmbeddingProvider();
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store: rawStore,
+      debounceMs: 10,
+      flushDebounceMs: 10,
+    });
+
+    await indexer.start({ initialRebuild: false });
+
+    // No embeds because rebuildAll was skipped.
+    expect(embeds()).toEqual([]);
+    expect(rawStore.size()).toBe(0);
+
+    await indexer.stop();
+  });
+
+  test("subscribes so a subsequent vault create event triggers processFile + flush", async () => {
+    const { vault, files, emit } = makeVault({});
+    const { embedder, embeds } = fakeEmbeddingProvider();
+    const { store, flushCalls } = wrapStoreWithFlushSpy(rawStore);
+
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 10,
+      flushDebounceMs: 20,
+    });
+    await indexer.start({ initialRebuild: false });
+    expect(embeds()).toEqual([]);
+
+    // The whole point of an auto-subscribed DLC indexer: future events
+    // flow into the store + persist to disk without an explicit rebuild.
+    files.set("new.md", "fresh content");
+    emit("create", "new.md");
+    await new Promise((r) => setTimeout(r, 80));
+
+    expect(embeds()).toContain("fresh content");
+    expect(store.size()).toBeGreaterThan(0);
+    expect(flushCalls()).toBeGreaterThanOrEqual(1);
+
+    await indexer.stop();
+  });
+
+  test("explicit rebuildAll() after subscribe-only start still indexes the vault", async () => {
+    const { vault } = makeVault({ "a.md": "alpha" });
+    const { embedder, embeds } = fakeEmbeddingProvider();
+
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store: rawStore,
+      debounceMs: 5,
+      flushDebounceMs: 5,
+    });
+    await indexer.start({ initialRebuild: false });
+    expect(embeds()).toEqual([]);
+
+    await indexer.rebuildAll();
+    expect(embeds()).toContain("alpha");
+
+    await indexer.stop();
+  });
+});
+
 /** mtime-aware in-memory vault for the low-power tests. */
 function makeMtimeVault(
   initial: Record<string, { content: string; mtime: number }>,

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
@@ -119,6 +119,7 @@ function fakeEmbeddingProvider(): {
     providerKey: "test-provider",
     dimensions: DIM,
     maxInputTokens: 512,
+    getMaxInputTokens: async () => 512,
     embed: async (texts, _role) => {
       for (const text of texts) calls.push(text);
       return texts.map((text) => {
@@ -410,6 +411,7 @@ describe("live indexer", () => {
       providerKey: "unavailable",
       dimensions: DIM,
       maxInputTokens: 512,
+      getMaxInputTokens: async () => 512,
       embed: async (texts, _role) => {
         for (const t of texts) embeds.push(t);
         return texts.map(() => new Float32Array(DIM));

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
@@ -480,6 +480,209 @@ describe("live indexer", () => {
   });
 });
 
+/**
+ * Wrap an `EmbeddingStore` so its `flush()` call count can be observed by
+ * tests. The wrapper proxies every method to the wrapped store; only
+ * `flush` is instrumented.
+ */
+function wrapStoreWithFlushSpy(store: Awaited<ReturnType<typeof makeStore>>): {
+  store: typeof store;
+  flushCalls: () => number;
+} {
+  let calls = 0;
+  // Class methods on `store` are not enumerable own properties, so a
+  // spread would lose them. Delegate explicitly.
+  const wrapped: typeof store = {
+    init: () => store.init(),
+    size: () => store.size(),
+    scan: () => store.scan(),
+    upsert: (records) => store.upsert(records),
+    delete: (path) => store.delete(path),
+    close: () => store.close(),
+    flush: async () => {
+      calls++;
+      await store.flush();
+    },
+  };
+  return { store: wrapped, flushCalls: () => calls };
+}
+
+describe("live indexer — flush debounce", () => {
+  let rawStore: Awaited<ReturnType<typeof makeStore>>;
+
+  beforeEach(async () => {
+    rawStore = await makeStore();
+  });
+
+  test("create event flushes store after flushDebounceMs of idle", async () => {
+    const { vault, files, emit } = makeVault({});
+    const { embedder } = fakeEmbeddingProvider();
+    const { store, flushCalls } = wrapStoreWithFlushSpy(rawStore);
+
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 10,
+      flushDebounceMs: 20,
+    });
+    await indexer.start();
+    expect(flushCalls()).toBe(0);
+
+    files.set("new.md", "fresh content");
+    emit("create", "new.md");
+
+    // Wait for processFile debounce + flush debounce + slack.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(flushCalls()).toBeGreaterThanOrEqual(1);
+
+    await indexer.stop();
+  });
+
+  test("modify event flushes store after flushDebounceMs", async () => {
+    const { vault, files, emit } = makeVault({ "a.md": "v1" });
+    const { embedder } = fakeEmbeddingProvider();
+    const { store, flushCalls } = wrapStoreWithFlushSpy(rawStore);
+
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 10,
+      flushDebounceMs: 20,
+    });
+    await indexer.start();
+    const startCalls = flushCalls();
+
+    files.set("a.md", "v2");
+    emit("modify", "a.md");
+    await new Promise((r) => setTimeout(r, 80));
+
+    expect(flushCalls()).toBeGreaterThan(startCalls);
+
+    await indexer.stop();
+  });
+
+  test("delete event flushes store after flushDebounceMs", async () => {
+    const { vault, files, emit } = makeVault({ "a.md": "v1" });
+    const { embedder } = fakeEmbeddingProvider();
+    const { store, flushCalls } = wrapStoreWithFlushSpy(rawStore);
+
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 10,
+      flushDebounceMs: 20,
+    });
+    await indexer.start();
+    const startCalls = flushCalls();
+
+    files.delete("a.md");
+    emit("delete", "a.md");
+    await new Promise((r) => setTimeout(r, 80));
+
+    expect(flushCalls()).toBeGreaterThan(startCalls);
+
+    await indexer.stop();
+  });
+
+  test("rapid burst of edits coalesces to a single debounced flush", async () => {
+    const { vault, files, emit } = makeVault({ "a.md": "v1" });
+    const { embedder } = fakeEmbeddingProvider();
+    const { store, flushCalls } = wrapStoreWithFlushSpy(rawStore);
+
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 10,
+      flushDebounceMs: 50,
+    });
+    await indexer.start();
+    const startCalls = flushCalls();
+
+    // Three edits, each within the flush debounce window.
+    files.set("a.md", "v2");
+    emit("modify", "a.md");
+    await new Promise((r) => setTimeout(r, 20));
+    files.set("a.md", "v3");
+    emit("modify", "a.md");
+    await new Promise((r) => setTimeout(r, 20));
+    files.set("a.md", "v4");
+    emit("modify", "a.md");
+
+    // Wait for the final debounce cycle to settle.
+    await new Promise((r) => setTimeout(r, 120));
+
+    // Exactly one flush for the whole burst.
+    expect(flushCalls() - startCalls).toBe(1);
+
+    await indexer.stop();
+  });
+
+  test("stop() forces pending debounced flush to run", async () => {
+    const { vault, files, emit } = makeVault({});
+    const { embedder } = fakeEmbeddingProvider();
+    const { store, flushCalls } = wrapStoreWithFlushSpy(rawStore);
+
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 5,
+      // Long enough that the timer would not fire before stop() does.
+      flushDebounceMs: 10_000,
+    });
+    await indexer.start();
+    const startCalls = flushCalls();
+
+    files.set("new.md", "fresh");
+    emit("create", "new.md");
+    // Wait only long enough for processFile to complete and schedule the
+    // flush timer — not long enough for the 10-second timer to fire.
+    await new Promise((r) => setTimeout(r, 40));
+
+    await indexer.stop();
+
+    // stop() must have drained the pending flush.
+    expect(flushCalls() - startCalls).toBe(1);
+  });
+
+  test("public flush() drains pending debounced flush", async () => {
+    const { vault, files, emit } = makeVault({});
+    const { embedder } = fakeEmbeddingProvider();
+    const { store, flushCalls } = wrapStoreWithFlushSpy(rawStore);
+
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 5,
+      flushDebounceMs: 10_000,
+    });
+    await indexer.start();
+    const startCalls = flushCalls();
+
+    files.set("new.md", "fresh");
+    emit("create", "new.md");
+
+    // flush() drains both the pending processFile timer AND the pending
+    // flush timer, so the caller observes "fully persisted" synchronously.
+    await indexer.flush();
+
+    expect(flushCalls() - startCalls).toBeGreaterThanOrEqual(1);
+
+    await indexer.stop();
+  });
+});
+
 /** mtime-aware in-memory vault for the low-power tests. */
 function makeMtimeVault(
   initial: Record<string, { content: string; mtime: number }>,

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -62,8 +62,19 @@ export type LiveIndexerOpts = {
   flushDebounceMs?: number;
 };
 
+export type StartOpts = {
+  /**
+   * Whether to run a full `rebuildAll()` immediately as part of `start()`.
+   * Default `true` (existing behavior). Set to `false` when an existing
+   * on-disk store is already current and you only need to subscribe to
+   * future vault events — e.g. a DLC indexer auto-started at plugin load
+   * for a provider whose store survived from a prior session.
+   */
+  initialRebuild?: boolean;
+};
+
 export interface SemanticIndexer {
-  start(): Promise<void>;
+  start(opts?: StartOpts): Promise<void>;
   stop(): Promise<void>;
   /** Force a full re-build over all markdown files. */
   rebuildAll(): Promise<void>;
@@ -97,7 +108,7 @@ class LiveIndexerImpl implements SemanticIndexer {
     this.opts = { ...opts, chunker: wrapChunkerWithOverlap(opts.chunker) };
   }
 
-  async start(): Promise<void> {
+  async start(opts: StartOpts = {}): Promise<void> {
     if (this.running) return;
     this.running = true;
 
@@ -107,7 +118,9 @@ class LiveIndexerImpl implements SemanticIndexer {
       this.opts.vault.on("delete", (p) => this.schedule(p)),
     );
 
-    await this.rebuildAll();
+    if (opts.initialRebuild !== false) {
+      await this.rebuildAll();
+    }
   }
 
   async stop(): Promise<void> {
@@ -306,13 +319,15 @@ class LowPowerIndexerImpl implements SemanticIndexer {
     this.opts = { ...opts, chunker: wrapChunkerWithOverlap(opts.chunker) };
   }
 
-  async start(): Promise<void> {
+  async start(opts: StartOpts = {}): Promise<void> {
     if (this.running) return;
     this.running = true;
     // Run the first scan immediately so the user doesn't wait
-    // `intervalMs` for indexing to begin. Subsequent scans tick on
-    // the interval.
-    await this.runCycle();
+    // `intervalMs` for indexing to begin (unless explicitly opted out).
+    // Subsequent scans tick on the interval regardless.
+    if (opts.initialRebuild !== false) {
+      await this.runCycle();
+    }
     this.timer = setInterval(() => {
       // Skip if a cycle is still in flight to avoid stacking.
       if (this.cycleInFlight) return;

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -53,6 +53,13 @@ export type LiveIndexerOpts = {
   store: EmbeddingStore;
   /** Per-file inactivity window before re-processing. Default 2000ms. */
   debounceMs?: number;
+  /**
+   * Idle window after the last `processOnePath` completes before the
+   * in-memory store is flushed to disk. Coalesces a burst of edits into
+   * a single `writeBinary` call. Default 5000ms. `stop()` and the public
+   * `flush()` method both drain any pending flush before returning.
+   */
+  flushDebounceMs?: number;
 };
 
 export interface SemanticIndexer {
@@ -71,17 +78,22 @@ export interface SemanticIndexer {
 }
 
 const DEFAULT_DEBOUNCE_MS = 2000;
+const DEFAULT_FLUSH_DEBOUNCE_MS = 5000;
 
 class LiveIndexerImpl implements SemanticIndexer {
   private timers = new Map<string, ReturnType<typeof setTimeout>>();
   private inFlight = new Map<string, Promise<void>>();
   private unsubs: Array<() => void> = [];
   private running = false;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private flushInFlight: Promise<void> | null = null;
   private readonly debounceMs: number;
+  private readonly flushDebounceMs: number;
   private readonly opts: LiveIndexerOpts;
 
   constructor(opts: LiveIndexerOpts) {
     this.debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.flushDebounceMs = opts.flushDebounceMs ?? DEFAULT_FLUSH_DEBOUNCE_MS;
     this.opts = { ...opts, chunker: wrapChunkerWithOverlap(opts.chunker) };
   }
 
@@ -107,6 +119,9 @@ class LiveIndexerImpl implements SemanticIndexer {
     // Wait for any in-flight processing to finish so the store is
     // not mid-mutation when the caller drops it.
     await Promise.all(this.inFlight.values());
+    // Drain any pending debounced flush + await an in-flight one so the
+    // on-disk store reflects every event processed before stop().
+    await this.drainFlush();
   }
 
   async rebuildAll(): Promise<void> {
@@ -142,6 +157,10 @@ class LiveIndexerImpl implements SemanticIndexer {
       }),
     );
     await Promise.all(this.inFlight.values());
+    // Persist whatever the processing produced so callers (tests and
+    // production teardown alike) see a synchronous "everything settled,
+    // including disk" boundary.
+    await this.drainFlush();
   }
 
   pending(): number {
@@ -175,6 +194,9 @@ class LiveIndexerImpl implements SemanticIndexer {
     this.inFlight.set(path, next);
     try {
       await next;
+      // Schedule a debounced flush so the upsert/delete the file just
+      // produced eventually reaches disk. Coalesces bursts.
+      this.scheduleFlush();
     } finally {
       // Only clear inFlight if our promise is still the current one
       // (a later schedule may have queued behind).
@@ -184,6 +206,52 @@ class LiveIndexerImpl implements SemanticIndexer {
 
   private async doProcessFile(path: string): Promise<void> {
     await processOnePath(this.opts, path);
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) clearTimeout(this.flushTimer);
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.flushInFlight = this.runFlush();
+    }, this.flushDebounceMs);
+  }
+
+  private async runFlush(): Promise<void> {
+    const startedAt = Date.now();
+    try {
+      await this.opts.store.flush();
+      logger.info("live indexer: flush completed", {
+        providerKey: this.opts.embedder.providerKey,
+        durationMs: Date.now() - startedAt,
+      });
+    } catch (err) {
+      // Do not let a transient flush failure crash future processing —
+      // the store still has `dirty = true` (or the next upsert will set
+      // it), so the next debounced flush self-heals by rewriting both
+      // bin and index from current in-memory state.
+      logger.error("live indexer: flush failed", {
+        providerKey: this.opts.embedder.providerKey,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.flushInFlight = null;
+    }
+  }
+
+  /**
+   * Force any pending debounced flush to run now, then await the
+   * in-flight flush (if any) so the caller observes a synchronous
+   * "store persisted" boundary. Used by `stop()` and `flush()`.
+   */
+  private async drainFlush(): Promise<void> {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+      this.flushInFlight = this.runFlush();
+    }
+    if (this.flushInFlight) {
+      await this.flushInFlight;
+    }
   }
 }
 

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -117,9 +117,17 @@ class LiveIndexerImpl implements SemanticIndexer {
       return;
     }
     const files = this.opts.vault.getMarkdownFiles();
+    logger.info("live indexer: rebuildAll starting", {
+      providerKey: this.opts.embedder.providerKey,
+      fileCount: files.length,
+    });
     for (const f of files) {
       await this.processFile(f.path);
     }
+    logger.info("live indexer: rebuildAll finished", {
+      providerKey: this.opts.embedder.providerKey,
+      fileCount: files.length,
+    });
   }
 
   async flush(): Promise<void> {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/multilingualE5Provider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/multilingualE5Provider.ts
@@ -9,7 +9,8 @@ export function createMultilingualE5Provider(
     modelId: "Xenova/multilingual-e5-base",
     providerKey: "multilingual-e5-base",
     dimensions: 768,
-    maxInputTokens: 512,
+    // Model intrinsic 512-token cap; no benefit from WebGPU's larger context.
+    maxInputTokensByBackend: { wasm: 512, webgpu: 512 },
     modelSizeBytes: 60_000_000,
     taskPrompt: (text, role) =>
       (role === "query" ? "query: " : "passage: ") + text,

--- a/packages/obsidian-plugin/src/features/semantic-search/services/nativeEmbeddingProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/nativeEmbeddingProvider.ts
@@ -22,6 +22,12 @@ class NativeEmbeddingProviderImpl implements EmbeddingProvider {
 
   constructor(private embedder: Embedder) {}
 
+  // MiniLM's 256-token cap is a model-intrinsic limit; identical on
+  // both WASM and WebGPU paths. No backend probe required.
+  getMaxInputTokens(): Promise<number> {
+    return Promise.resolve(MAX_INPUT_TOKENS);
+  }
+
   getModelSizeBytes(): number {
     return MODEL_SIZE_BYTES;
   }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/providerFactory.test.ts
@@ -112,6 +112,7 @@ function fakeEmbeddingProvider(dim: number): EmbeddingProvider {
     providerKey: `fake-${dim}d`,
     dimensions: dim,
     maxInputTokens: 512,
+    getMaxInputTokens: async () => 512,
     embed: async (texts, _role) => texts.map(() => new Float32Array(dim)),
     isAvailable: async () => true,
     getModelSizeBytes: () => 0,

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
@@ -315,7 +315,7 @@ describe("embedding store", () => {
     expect(written.records).toHaveLength(0);
   });
 
-  test("FORMAT_VERSION 3 round-trip: flushed index carries version 3", async () => {
+  test("FORMAT_VERSION round-trip: flushed index carries current FORMAT_VERSION", async () => {
     const opts = {
       adapter: mem.adapter,
       binPath: "/p/embeddings.bin",
@@ -330,7 +330,7 @@ describe("embedding store", () => {
       mem.files.get("/p/embeddings.index.json") ?? "{}",
     );
     expect(written.version).toBe(FORMAT_VERSION);
-    expect(FORMAT_VERSION).toBe(3);
+    expect(FORMAT_VERSION).toBe(4);
   });
 
   test("v1 index treated as stale (version mismatch); re-init from scratch", async () => {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
@@ -65,7 +65,10 @@ export type EmbeddingStoreOpts = {
   vectorDim?: number;
 };
 
-export const FORMAT_VERSION = 3;
+// v4: chunk size now derived from provider.getMaxInputTokens() (WebGPU lets
+// EmbeddingGemma use its full 2K context). Stored hashes from v3 differ from
+// v4 for the same source files, so the index is wiped on upgrade.
+export const FORMAT_VERSION = 4;
 const DEFAULT_VECTOR_DIM = 384;
 
 type IndexRecord = {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createTransformersProvider } from "./transformersProvider";
 import { createEmbeddingGemmaProvider } from "./embeddingGemmaProvider";
 import { createMultilingualE5Provider } from "./multilingualE5Provider";
 import { createNativeEmbeddingProvider } from "./nativeEmbeddingProvider";
-import type { Embedder } from "./embedder";
+import {
+  __resetBackendForTesting,
+  resolveBackend,
+  type Embedder,
+} from "./embedder";
 
 type MockPipelineFn = (
   input: string | string[],
@@ -48,6 +52,15 @@ function makeMockEmbedder(loaded = true): Embedder {
   };
 }
 
+// Reset the cached backend resolution between tests so the wasm/webgpu
+// dispatch tests below don't bleed cached state into each other.
+beforeEach(() => {
+  __resetBackendForTesting();
+});
+afterEach(() => {
+  __resetBackendForTesting();
+});
+
 describe("TransformersProviderImpl", () => {
   test("applies task prompt before calling pipeline", async () => {
     const { factory, calls } = makeMockFactory(768);
@@ -55,7 +68,7 @@ describe("TransformersProviderImpl", () => {
       modelId: "test-model",
       providerKey: "test",
       dimensions: 768,
-      maxInputTokens: 512,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 512 },
       modelSizeBytes: 1_000_000,
       taskPrompt: (text, role) => `${role}: ${text}`,
       pipelineFactory: factory,
@@ -74,7 +87,7 @@ describe("TransformersProviderImpl", () => {
       modelId: "test-model",
       providerKey: "test",
       dimensions: 768,
-      maxInputTokens: 512,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 512 },
       modelSizeBytes: 1_000_000,
       taskPrompt: (t) => t,
       pipelineFactory: factory,
@@ -91,7 +104,7 @@ describe("TransformersProviderImpl", () => {
       modelId: "test-model",
       providerKey: "test",
       dimensions: 768,
-      maxInputTokens: 512,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 512 },
       modelSizeBytes: 1_000_000,
       taskPrompt: (t) => t,
       pipelineFactory: factory,
@@ -109,7 +122,7 @@ describe("TransformersProviderImpl", () => {
       modelId: "test-model",
       providerKey: "test",
       dimensions: 768,
-      maxInputTokens: 512,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 512 },
       modelSizeBytes: 42_000_000,
       taskPrompt: (t) => t,
       pipelineFactory: factory,
@@ -129,7 +142,7 @@ describe("TransformersProviderImpl", () => {
       modelId: "test-model",
       providerKey: "test",
       dimensions: 768,
-      maxInputTokens: 512,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 512 },
       modelSizeBytes: 1_000_000,
       taskPrompt: (t) => t,
       pipelineFactory: factory,
@@ -143,14 +156,84 @@ describe("TransformersProviderImpl", () => {
   });
 });
 
-describe("TransformersProviderImpl — truncation opts", () => {
-  test("passes truncation: true and max_length to pipeline", async () => {
+describe("TransformersProviderImpl — backend-resolved maxInputTokens", () => {
+  test("synchronous maxInputTokens always returns the wasm value", () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 2048 },
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (t) => t,
+      pipelineFactory: factory,
+    });
+    expect(provider.maxInputTokens).toBe(512);
+  });
+
+  test("getMaxInputTokens returns wasm value when navigator.gpu absent", async () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 2048 },
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (t) => t,
+      pipelineFactory: factory,
+    });
+    // Pre-resolve the backend with an explicit "no gpu" navigator.
+    expect(await resolveBackend(undefined)).toBe("wasm");
+    expect(await provider.getMaxInputTokens()).toBe(512);
+  });
+
+  test("getMaxInputTokens returns webgpu value when adapter available", async () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 2048 },
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (t) => t,
+      pipelineFactory: factory,
+    });
+    expect(
+      await resolveBackend({
+        gpu: { requestAdapter: async () => ({}) },
+      }),
+    ).toBe("webgpu");
+    expect(await provider.getMaxInputTokens()).toBe(2048);
+  });
+
+  test("embed forwards backend-resolved max_length to pipeline", async () => {
     const { factory, optsLog } = makeMockFactoryWithOpts(768);
     const provider = createTransformersProvider({
       modelId: "test-model",
       providerKey: "test",
       dimensions: 768,
-      maxInputTokens: 512,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 2048 },
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (t) => t,
+      pipelineFactory: factory,
+    });
+    // Force webgpu resolution.
+    await resolveBackend({
+      gpu: { requestAdapter: async () => ({}) },
+    });
+    await provider.embed(["hello"], "document");
+    expect(optsLog[0]).toMatchObject({ truncation: true, max_length: 2048 });
+  });
+});
+
+describe("TransformersProviderImpl — truncation opts", () => {
+  test("passes truncation: true and max_length to pipeline (wasm path)", async () => {
+    const { factory, optsLog } = makeMockFactoryWithOpts(768);
+    const provider = createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 768,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 512 },
       modelSizeBytes: 1_000_000,
       taskPrompt: (t) => t,
       pipelineFactory: factory,
@@ -162,12 +245,21 @@ describe("TransformersProviderImpl — truncation opts", () => {
 });
 
 describe("EmbeddingGemmaProvider", () => {
-  test("providerKey, dimensions, maxInputTokens", () => {
+  test("providerKey, dimensions, sync maxInputTokens (wasm cap)", () => {
     const { factory } = makeMockFactory(768);
     const provider = createEmbeddingGemmaProvider(factory);
     expect(provider.providerKey).toBe("embedding-gemma-300m");
     expect(provider.dimensions).toBe(768);
     expect(provider.maxInputTokens).toBe(512);
+  });
+
+  test("getMaxInputTokens unlocks 2048 on webgpu", async () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createEmbeddingGemmaProvider(factory);
+    await resolveBackend({
+      gpu: { requestAdapter: async () => ({}) },
+    });
+    expect(await provider.getMaxInputTokens()).toBe(2048);
   });
 
   test("getModelSizeBytes returns 190 MB", () => {
@@ -194,13 +286,23 @@ describe("EmbeddingGemmaProvider", () => {
 });
 
 describe("MultilingualE5Provider", () => {
-  test("providerKey, dimensions, maxInputTokens", () => {
+  test("providerKey, dimensions, sync maxInputTokens", () => {
     const { factory } = makeMockFactory(768);
     const provider = createMultilingualE5Provider(factory);
     expect(provider.providerKey).toBe("multilingual-e5-base");
     expect(provider.dimensions).toBe(768);
     expect(provider.maxInputTokens).toBe(512);
   });
+
+  test("getMaxInputTokens returns 512 on both backends (model intrinsic cap)", async () => {
+    const { factory } = makeMockFactory(768);
+    const provider = createMultilingualE5Provider(factory);
+    await resolveBackend({
+      gpu: { requestAdapter: async () => ({}) },
+    });
+    expect(await provider.getMaxInputTokens()).toBe(512);
+  });
+
 
   test("getModelSizeBytes returns 60 MB", () => {
     const { factory } = makeMockFactory(768);
@@ -231,6 +333,14 @@ describe("NativeEmbeddingProvider", () => {
     expect(provider.providerKey).toBe("native-minilm-l6-v2");
     expect(provider.dimensions).toBe(384);
     expect(provider.maxInputTokens).toBe(256);
+  });
+
+  test("getMaxInputTokens returns 256 regardless of backend", async () => {
+    const provider = createNativeEmbeddingProvider(makeMockEmbedder());
+    await resolveBackend({
+      gpu: { requestAdapter: async () => ({}) },
+    });
+    expect(await provider.getMaxInputTokens()).toBe(256);
   });
 
   test("getModelSizeBytes returns 25 MB", () => {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
@@ -11,7 +11,8 @@
  * the model is constructed exactly once.
  */
 
-import type { EmbeddingProvider } from "../types";
+import type { BackendKind, EmbeddingProvider } from "../types";
+import { resolveBackend } from "./embedder";
 import type { EmbedTensor, PipelineFactory, PipelineFn } from "./embedder";
 
 export type TaskPromptFn = (text: string, role: "document" | "query") => string;
@@ -20,7 +21,18 @@ export type TransformersProviderOpts = {
   modelId: string;
   providerKey: string;
   dimensions: number;
-  maxInputTokens: number;
+  /**
+   * Per-backend input-token cap. The conservative `wasm` value is also
+   * the synchronous `maxInputTokens` fallback for callers that run
+   * before the backend has been resolved.
+   *
+   * Note: vectors produced under different backends are not bit-identical
+   * (FP16 reductions on WebGPU vs FP32 on WASM). The `FORMAT_VERSION`
+   * bump on upgrades makes this a non-issue for new installs; mid-session
+   * hardware swap is rare enough that we accept the small re-rank drift
+   * over doubling on-disk footprint with a per-backend `providerKey`.
+   */
+  maxInputTokensByBackend: Record<BackendKind, number>;
   modelSizeBytes: number;
   taskPrompt: TaskPromptFn;
   pipelineFactory: PipelineFactory;
@@ -33,11 +45,21 @@ class TransformersProviderImpl implements EmbeddingProvider {
 
   private pipeline: PipelineFn | null = null;
   private loadPromise: Promise<PipelineFn> | null = null;
+  private resolvedMaxTokens: Promise<number> | null = null;
 
   constructor(private opts: TransformersProviderOpts) {
     this.providerKey = opts.providerKey;
     this.dimensions = opts.dimensions;
-    this.maxInputTokens = opts.maxInputTokens;
+    this.maxInputTokens = opts.maxInputTokensByBackend.wasm;
+  }
+
+  getMaxInputTokens(): Promise<number> {
+    if (!this.resolvedMaxTokens) {
+      this.resolvedMaxTokens = resolveBackend().then(
+        (b) => this.opts.maxInputTokensByBackend[b],
+      );
+    }
+    return this.resolvedMaxTokens;
   }
 
   getModelSizeBytes(): number {
@@ -53,6 +75,7 @@ class TransformersProviderImpl implements EmbeddingProvider {
     role: "document" | "query",
   ): Promise<Float32Array[]> {
     const pipe = await this.ensurePipeline();
+    const maxLen = await this.getMaxInputTokens();
     return Promise.all(
       texts.map(async (text) => {
         const prompted = this.opts.taskPrompt(text, role);
@@ -60,7 +83,7 @@ class TransformersProviderImpl implements EmbeddingProvider {
           pooling: "mean",
           normalize: true,
           truncation: true,
-          max_length: this.opts.maxInputTokens,
+          max_length: maxLen,
         });
         return new Float32Array((result as EmbedTensor).data);
       }),

--- a/packages/obsidian-plugin/src/features/semantic-search/types.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/types.ts
@@ -1,6 +1,17 @@
 import { type } from "arktype";
 
 /**
+ * Active inference runtime. Resolved once per process by
+ * `resolveBackend()` in `services/embedder.ts`.
+ *
+ * - `wasm`: onnxruntime-web CPU EP (non-JSEP WASM). Fallback path for
+ *   hardware without `navigator.gpu` or after a failed adapter probe.
+ * - `webgpu`: onnxruntime-web WebGPU EP via JSEP WASM. Faster, larger
+ *   effective context windows for models that intrinsically support them.
+ */
+export type BackendKind = "wasm" | "webgpu";
+
+/**
  * Embedding layer abstraction. One `EmbeddingProvider` per model;
  * the store registry and indexer are keyed on `providerKey`.
  *
@@ -11,7 +22,18 @@ import { type } from "arktype";
 export interface EmbeddingProvider {
   readonly providerKey: string;
   readonly dimensions: number;
+  /**
+   * Conservative (WASM) cap. Synchronous getter for pre-resolution
+   * callers (settings UI, status displays). Use `getMaxInputTokens()`
+   * for the backend-resolved value.
+   */
   readonly maxInputTokens: number;
+  /**
+   * Resolves the backend-dependent input-token cap. WebGPU providers
+   * may expose a larger context here than `maxInputTokens` advertises.
+   * Cached after the first call.
+   */
+  getMaxInputTokens(): Promise<number>;
   embed(texts: string[], role: "document" | "query"): Promise<Float32Array[]>;
   isAvailable(): Promise<boolean>;
   getModelSizeBytes(): number;

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -55,6 +55,7 @@ import { FORMAT_VERSION } from "./features/semantic-search/services/store";
 import {
   createLiveIndexer,
   createLowPowerIndexer,
+  type SemanticIndexer,
   type VaultLike,
 } from "./features/semantic-search/services/indexer";
 import { makeChunkerForProvider } from "./features/semantic-search/services/chunker";
@@ -564,27 +565,73 @@ export default class McpToolsPlugin extends Plugin {
             // best-effort — non-ASCII sampling failure must not affect startup
           });
 
-        // DLC rebuild hook — download + full index for one provider.
-        const _rebuildingProviders = new Set<string>();
-        state.startRebuildFor = (providerKey: string) => {
-          if (_rebuildingProviders.has(providerKey)) return;
-          _rebuildingProviders.add(providerKey);
-          const ep =
-            embeddingProviders[providerKey as keyof typeof embeddingProviders];
-          if (!ep) {
-            _rebuildingProviders.delete(providerKey);
-            return;
-          }
+        // Map from `SemanticSearchSettings.provider` string to the
+        // registry providerKey. Declared once here and reused by both the
+        // auto-subscribe block below and the post-migration auto-rebuild
+        // trigger further down.
+        const settingToRegistryKey: Partial<Record<string, ProviderKey>> = {
+          native: "native-minilm-l6-v2",
+          auto: "native-minilm-l6-v2",
+          "embedding-gemma": "embedding-gemma-300m",
+          "multilingual-e5-base": "multilingual-e5-base",
+          // "smart-connections" has no local store — no rebuild needed.
+        };
+
+        // Persistent DLC indexers — created on first rebuild or at
+        // plugin-load auto-subscribe for the active provider. Each one
+        // subscribes to vault create/modify/delete events so live edits
+        // update the matching store without requiring a full rebuild.
+        state.dlcIndexers = new Map<string, SemanticIndexer>();
+
+        // Helper: build a fresh DLC indexer for a providerKey. Pure
+        // construction — does not start / subscribe. Caller decides.
+        const buildDlcIndexer = (
+          providerKey: keyof typeof embeddingProviders,
+        ): SemanticIndexer | null => {
+          const ep = embeddingProviders[providerKey];
+          if (!ep) return null;
           const dlcStore = registry.storeFor(providerKey, ep.dimensions);
-          const dlcIndexer = createLiveIndexer({
+          return createLiveIndexer({
             vault: ssVault,
             chunker: makeChunkerForProvider(ep),
             embedder: ep,
             store: dlcStore,
           });
-          dlcIndexer
-            .rebuildAll()
+        };
+
+        // DLC rebuild hook — download + full index for one provider.
+        // First call creates the indexer and `start()`s it (subscribes +
+        // initial rebuild). Subsequent calls reuse the live indexer and
+        // run a fresh `rebuildAll()` against it; the subscription stays
+        // intact so post-rebuild edits keep flowing.
+        const _rebuildingProviders = new Set<string>();
+        state.startRebuildFor = (providerKey: string) => {
+          if (_rebuildingProviders.has(providerKey)) return;
+          _rebuildingProviders.add(providerKey);
+          const epKey = providerKey as keyof typeof embeddingProviders;
+          const ep = embeddingProviders[epKey];
+          if (!ep) {
+            _rebuildingProviders.delete(providerKey);
+            return;
+          }
+
+          const existing = state.dlcIndexers?.get(providerKey);
+          const dlcIndexer = existing ?? buildDlcIndexer(epKey);
+          if (!dlcIndexer) {
+            _rebuildingProviders.delete(providerKey);
+            return;
+          }
+          if (!existing) {
+            state.dlcIndexers?.set(providerKey, dlcIndexer);
+          }
+
+          const work = existing
+            ? dlcIndexer.rebuildAll()
+            : dlcIndexer.start();
+
+          work
             .then(async () => {
+              const dlcStore = registry.storeFor(providerKey, ep.dimensions);
               await dlcStore.flush();
               registry.markReady(providerKey);
               if (state.pendingProvider === providerKey)
@@ -604,19 +651,53 @@ export default class McpToolsPlugin extends Plugin {
             });
         };
 
+        // Auto-subscribe active DLC provider at plugin load when its
+        // store already has content. Skips the initial rebuild (existing
+        // store is current) and only wires up vault event subscriptions
+        // so future create/modify/delete events update the index live.
+        // Deferred to onLayoutReady to match the same vault-scan-ready
+        // guarantee as the migration auto-trigger below.
+        const _autoSubscribeDlc = (
+          providerKey: keyof typeof embeddingProviders,
+        ): void => {
+          if (state.dlcIndexers?.has(providerKey)) return;
+          const dlcIndexer = buildDlcIndexer(providerKey);
+          if (!dlcIndexer) return;
+          state.dlcIndexers?.set(providerKey, dlcIndexer);
+          this.app.workspace.onLayoutReady(() => {
+            dlcIndexer.start({ initialRebuild: false }).catch((err) => {
+              logger.error("semantic-search: DLC auto-subscribe failed", {
+                providerKey,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            });
+          });
+        };
+
+        for (const key of [
+          "embedding-gemma-300m",
+          "multilingual-e5-base",
+        ] as const) {
+          const dim = 768;
+          const dlcStore = registry.storeFor(key, dim);
+          // Auto-subscribe only when the provider is currently active AND
+          // its store is ready (size > 0 was set by the earlier init loop
+          // via registry.markReady). Inactive providers stay dormant —
+          // the user can switch into them, which routes through
+          // startRebuildFor and lazily starts the indexer at that point.
+          const isActive =
+            settingToRegistryKey[state.settings.provider] === key;
+          if (isActive && dlcStore.size() > 0) {
+            _autoSubscribeDlc(key);
+          }
+        }
+
         // B3: Trigger rebuild for the active provider's store that was just
         // wiped by the migration. Deferred to onLayoutReady because
         // vault.getMarkdownFiles() can return an empty/partial snapshot
         // during onload() — Obsidian's vault scan is still in flight.
         // Firing earlier silently produces a 0-chunk rebuild and the .then()
         // flush writes an empty store.
-        const settingToRegistryKey: Partial<Record<string, ProviderKey>> = {
-          native: "native-minilm-l6-v2",
-          auto: "native-minilm-l6-v2",
-          "embedding-gemma": "embedding-gemma-300m",
-          "multilingual-e5-base": "multilingual-e5-base",
-          // "smart-connections" has no local store — no rebuild needed.
-        };
         const activeRegistryKey = settingToRegistryKey[state.settings.provider];
         if (
           activeRegistryKey &&
@@ -638,6 +719,21 @@ export default class McpToolsPlugin extends Plugin {
             } catch {
               // best-effort
             }
+          }
+          // Stop every persistent DLC indexer so its debounced flush
+          // drains to disk before the plugin unloads.
+          if (state.dlcIndexers) {
+            for (const [providerKey, dlcIndexer] of state.dlcIndexers) {
+              try {
+                await dlcIndexer.stop();
+              } catch (err) {
+                logger.warn("semantic-search: DLC indexer stop failed", {
+                  providerKey,
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              }
+            }
+            state.dlcIndexers.clear();
           }
           try {
             await embedder.unload();

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -52,13 +52,12 @@ import { createMultilingualE5Provider } from "./features/semantic-search/service
 import { detectNonAsciiRatio } from "./features/semantic-search/services/langDetect";
 import type { VaultAdapter } from "./features/semantic-search/services/store";
 import { FORMAT_VERSION } from "./features/semantic-search/services/store";
-import { IndexWipeMigrationModal } from "./features/semantic-search/services/indexWipeMigrationModal";
 import {
   createLiveIndexer,
   createLowPowerIndexer,
   type VaultLike,
 } from "./features/semantic-search/services/indexer";
-import { chunk as semanticChunk } from "./features/semantic-search/services/chunker";
+import { makeChunkerForProvider } from "./features/semantic-search/services/chunker";
 import type { ExcerptResolver } from "./features/semantic-search/services/nativeProvider";
 import {
   loadLocalRestAPI,
@@ -421,14 +420,12 @@ export default class McpToolsPlugin extends Plugin {
       }
 
       if (staleProviderKeys.length > 0) {
-        await new Promise<void>((resolve) => {
-          const modal = new IndexWipeMigrationModal({
-            app: this.app,
-            onConfirm: resolve,
-            onCancel: resolve,
-          });
-          modal.open();
-        });
+        // Silent wipe: the previous IndexWipeMigrationModal flow blocked
+        // onload() indefinitely on Obsidian's "Loading plugins..." splash,
+        // which suppresses modal interaction during plugin load. Embedding
+        // data is fully derivable from vault notes (no original content
+        // lost), so user confirmation buys nothing — wipe immediately and
+        // surface a Notice after the workspace becomes interactive.
         for (const key of staleProviderKeys) {
           const dirPath = `${embeddingsBaseDir}/${key}`;
           try {
@@ -447,6 +444,13 @@ export default class McpToolsPlugin extends Plugin {
             );
           }
         }
+        const wipedCount = staleProviderKeys.length;
+        this.app.workspace.onLayoutReady(() => {
+          new Notice(
+            `MCP Tools: Semantic search index format upgraded (${wipedCount} provider${wipedCount > 1 ? "s" : ""} migrated). Rebuilding automatically.`,
+            8000,
+          );
+        });
       }
 
       const registry = createEmbeddingStoreRegistry(
@@ -514,17 +518,21 @@ export default class McpToolsPlugin extends Plugin {
         }
 
         // Native indexer — lazy start on first search tool call.
+        // The chunker tracks the provider's effective max-input-tokens
+        // (backend-resolved via getMaxInputTokens()), with a small safety
+        // margin for the task-prompt prefix prepended at embed time.
+        const nativeChunker = makeChunkerForProvider(nativeEp);
         const indexer =
           state.settings.indexingMode === "low-power"
             ? createLowPowerIndexer({
                 vault: ssVault,
-                chunker: semanticChunk,
+                chunker: nativeChunker,
                 embedder: nativeEp,
                 store: nativeStore,
               })
             : createLiveIndexer({
                 vault: ssVault,
-                chunker: semanticChunk,
+                chunker: nativeChunker,
                 embedder: nativeEp,
                 store: nativeStore,
               });
@@ -570,7 +578,7 @@ export default class McpToolsPlugin extends Plugin {
           const dlcStore = registry.storeFor(providerKey, ep.dimensions);
           const dlcIndexer = createLiveIndexer({
             vault: ssVault,
-            chunker: semanticChunk,
+            chunker: makeChunkerForProvider(ep),
             embedder: ep,
             store: dlcStore,
           });

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -605,8 +605,11 @@ export default class McpToolsPlugin extends Plugin {
         };
 
         // B3: Trigger rebuild for the active provider's store that was just
-        // wiped by the migration modal. The modal's "Rebuild now" button only
-        // wipes; this makes the rebuild actually happen automatically.
+        // wiped by the migration. Deferred to onLayoutReady because
+        // vault.getMarkdownFiles() can return an empty/partial snapshot
+        // during onload() — Obsidian's vault scan is still in flight.
+        // Firing earlier silently produces a 0-chunk rebuild and the .then()
+        // flush writes an empty store.
         const settingToRegistryKey: Partial<Record<string, ProviderKey>> = {
           native: "native-minilm-l6-v2",
           auto: "native-minilm-l6-v2",
@@ -619,11 +622,13 @@ export default class McpToolsPlugin extends Plugin {
           activeRegistryKey &&
           staleProviderKeys.includes(activeRegistryKey)
         ) {
-          if (activeRegistryKey === "native-minilm-l6-v2") {
-            state.startIndexerIfNeeded();
-          } else {
-            state.startRebuildFor(activeRegistryKey);
-          }
+          this.app.workspace.onLayoutReady(() => {
+            if (activeRegistryKey === "native-minilm-l6-v2") {
+              state.startIndexerIfNeeded?.();
+            } else {
+              state.startRebuildFor?.(activeRegistryKey);
+            }
+          });
         }
 
         state.teardown = async () => {


### PR DESCRIPTION
## Summary

Stacks on #208 (same base: `feat/transformersjs-v4-onnx-ir10`). Can be reviewed independently; must merge after #208.

Two correctness fixes for the live indexing path on DLC providers (EmbeddingGemma 300M, Multilingual E5):

- **`LiveIndexerImpl` never persisted incremental updates** — `store.delete()` + `store.upsert()` mutated in-memory state and set `dirty = true`, but `store.flush()` was never called. Every live edit was lost on Obsidian restart.
- **DLC indexers were never subscribed to vault events** — `startRebuildFor` created a `LiveIndexer`, ran `rebuildAll()`, and dropped the reference. No `start()` call, no event subscription. Live edits between manual rebuilds were silently dropped.

### Commit 1 — `aa12990` debounced flush

Extends `LiveIndexerImpl` with a debounced flush timer (default 5 s, coalesces edit bursts):

- `scheduleFlush()` called at end of each `processFile` cycle
- `runFlush()` calls `store.flush()`, logs `live indexer: flush completed { providerKey, durationMs }`, swallows + logs errors
- `stop()` and `flush()` drain any pending timer via `drainFlush()` — teardown always persists
- Constructor option `flushDebounceMs?: number` for test injection
- 6 new unit tests in `describe("live indexer — flush debounce")`

### Commit 2 — `edae506` persistent indexer + auto-subscribe

- `SemanticSearchState.dlcIndexers: Map<string, SemanticIndexer>` — persists DLC indexers across the plugin lifecycle
- `startRebuildFor`: first call for a `providerKey` builds + stores + `start()`s the indexer; subsequent calls reuse the live indexer and call `rebuildAll()` only
- `_autoSubscribeDlc(key)` at `onLayoutReady`: when the active provider is a DLC type and its store has content, calls `dlcIndexer.start({ initialRebuild: false })` — subscribes to vault events without triggering a redundant full re-embed
- `SemanticIndexer.start()` accepts `StartOpts { initialRebuild?: boolean }` (default `true`); `LowPowerIndexerImpl` updated for parity
- `state.teardown` iterates `dlcIndexers` and stops each (drains flush before unload)
- 3 new unit tests in `describe("live indexer — start({ initialRebuild: false })")`

## Test plan

- [x] `bun run check` — clean across all packages
- [x] `bun test` (1097/1097) — all existing + new tests pass
- [x] `bun run build` — bundle green
- [x] E2E Scenario 1: create note with unique marker → `flush completed` log → disk mtime advances → `search_vault_smart` returns new note ✓
- [x] E2E Scenario 2: append section to existing note → flush → disk update → MCP search returns new heading ✓
- [x] E2E Scenario 3: quit + restart Obsidian → both marker phrases still searchable (persistence confirmed) ✓
- [x] E2E Scenario 4: delete note → flush → 0 chunks on disk → MCP search returns zero hits ✓

Tested on vault (~1100 files, EmbeddingGemma 300M, WebGPU backend, macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)