### PR TITLE
chore: add root bunfig.toml so bun test from repo root loads obsidian mock

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,9 @@
+# Root-level Bun configuration.
+#
+# Mirrors the preload in packages/obsidian-plugin/bunfig.toml so that
+# `bun test` run from the repo root also registers the synthetic
+# "obsidian" module (the real package has only .d.ts files and cannot
+# be loaded at runtime outside Obsidian itself).
+
+[test]
+preload = ["./packages/obsidian-plugin/src/test-setup.ts"]


### PR DESCRIPTION
Running `bun test` from the repo root failed with "Cannot find package 'obsidian'" because bun does not pick up `bunfig.toml` in `packages/obsidian-plugin/` when invoked from root. The root config uses the same preload path; all 1115 tests now pass from either directory.