### PR TITLE
chore(types): add obsidian-daily-notes-interface module augmentation

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.ts
@@ -85,81 +85,53 @@ export function resolvePeriodicNote(
 
 // ── Period <-> lib function dispatch ─────────────────────────────────────
 //
-// The shipped `obsidian-daily-notes-interface@0.9.4` .d.ts only declares
-// the daily surface (`appHasDailyNotesPluginLoaded`, `createDailyNote`,
-// etc.), but the runtime ships the full per-period set
-// (`appHasWeeklyNotesPluginLoaded`, `createWeeklyNote`, …). Cast the
-// import as a typed bag — same pattern CLAUDE.md prescribes for stale /
-// runtime-only Obsidian APIs (`listTags.ts:30` cast for `getTags`).
-
-interface PeriodicNoteSettings {
-  folder?: string;
-  format?: string;
-  template?: string;
-}
-
-interface PeriodicNotesLibRuntime {
-  appHasDailyNotesPluginLoaded: () => boolean;
-  appHasWeeklyNotesPluginLoaded: () => boolean;
-  appHasMonthlyNotesPluginLoaded: () => boolean;
-  appHasQuarterlyNotesPluginLoaded: () => boolean;
-  appHasYearlyNotesPluginLoaded: () => boolean;
-  getDailyNoteSettings: () => PeriodicNoteSettings;
-  getWeeklyNoteSettings: () => PeriodicNoteSettings;
-  getMonthlyNoteSettings: () => PeriodicNoteSettings;
-  getQuarterlyNoteSettings: () => PeriodicNoteSettings;
-  getYearlyNoteSettings: () => PeriodicNoteSettings;
-  createDailyNote: (date: Moment) => Promise<TFile>;
-  createWeeklyNote: (date: Moment) => Promise<TFile>;
-  createMonthlyNote: (date: Moment) => Promise<TFile>;
-  createQuarterlyNote: (date: Moment) => Promise<TFile>;
-  createYearlyNote: (date: Moment) => Promise<TFile>;
-}
-
-const lib = periodicNotesLib as unknown as PeriodicNotesLibRuntime;
+// Upstream `.d.ts` still only ships the daily surface; the full per-period
+// set is declared via augmentation in `src/types.ts`.
 
 function pluginLoadedFor(period: PeriodType): boolean {
   switch (period) {
     case "daily":
-      return lib.appHasDailyNotesPluginLoaded();
+      return periodicNotesLib.appHasDailyNotesPluginLoaded();
     case "weekly":
-      return lib.appHasWeeklyNotesPluginLoaded();
+      return periodicNotesLib.appHasWeeklyNotesPluginLoaded();
     case "monthly":
-      return lib.appHasMonthlyNotesPluginLoaded();
+      return periodicNotesLib.appHasMonthlyNotesPluginLoaded();
     case "quarterly":
-      return lib.appHasQuarterlyNotesPluginLoaded();
+      return periodicNotesLib.appHasQuarterlyNotesPluginLoaded();
     case "yearly":
-      return lib.appHasYearlyNotesPluginLoaded();
+      return periodicNotesLib.appHasYearlyNotesPluginLoaded();
   }
 }
 
-function settingsFor(period: PeriodType): PeriodicNoteSettings {
+function settingsFor(
+  period: PeriodType,
+): periodicNotesLib.PeriodicNoteSettings {
   switch (period) {
     case "daily":
-      return lib.getDailyNoteSettings();
+      return periodicNotesLib.getDailyNoteSettings();
     case "weekly":
-      return lib.getWeeklyNoteSettings();
+      return periodicNotesLib.getWeeklyNoteSettings();
     case "monthly":
-      return lib.getMonthlyNoteSettings();
+      return periodicNotesLib.getMonthlyNoteSettings();
     case "quarterly":
-      return lib.getQuarterlyNoteSettings();
+      return periodicNotesLib.getQuarterlyNoteSettings();
     case "yearly":
-      return lib.getYearlyNoteSettings();
+      return periodicNotesLib.getYearlyNoteSettings();
   }
 }
 
 function createForPeriod(period: PeriodType, m: Moment): Promise<TFile> {
   switch (period) {
     case "daily":
-      return lib.createDailyNote(m);
+      return periodicNotesLib.createDailyNote(m);
     case "weekly":
-      return lib.createWeeklyNote(m);
+      return periodicNotesLib.createWeeklyNote(m);
     case "monthly":
-      return lib.createMonthlyNote(m);
+      return periodicNotesLib.createMonthlyNote(m);
     case "quarterly":
-      return lib.createQuarterlyNote(m);
+      return periodicNotesLib.createQuarterlyNote(m);
     case "yearly":
-      return lib.createYearlyNote(m);
+      return periodicNotesLib.createYearlyNote(m);
   }
 }
 
@@ -255,7 +227,7 @@ function defaultIsoForPeriod(period: PeriodType): string {
 function computePath(
   period: PeriodType,
   m: Moment,
-  settings: PeriodicNoteSettings | null,
+  settings: periodicNotesLib.PeriodicNoteSettings | null,
 ): string {
   const format = settings?.format ?? DEFAULT_FORMAT_BY_PERIOD[period];
   // Trim leading/trailing slashes so a settings folder of `Daily/` or

--- a/packages/obsidian-plugin/src/types.ts
+++ b/packages/obsidian-plugin/src/types.ts
@@ -9,4 +9,44 @@ declare module "obsidian" {
   }
 }
 
+// Augmentation for obsidian-daily-notes-interface@0.9.4, whose .d.ts only
+// ships the daily surface. The weekly/monthly/quarterly/yearly functions exist
+// at runtime (shipped since the Periodic Notes plugin era) but are missing
+// from upstream declarations.
+declare module "obsidian-daily-notes-interface" {
+  export interface PeriodicNoteSettings {
+    folder?: string;
+    format?: string;
+    template?: string;
+  }
+
+  export function appHasDailyNotesPluginLoaded(): boolean;
+  export function appHasWeeklyNotesPluginLoaded(): boolean;
+  export function appHasMonthlyNotesPluginLoaded(): boolean;
+  export function appHasQuarterlyNotesPluginLoaded(): boolean;
+  export function appHasYearlyNotesPluginLoaded(): boolean;
+
+  export function getDailyNoteSettings(): PeriodicNoteSettings;
+  export function getWeeklyNoteSettings(): PeriodicNoteSettings;
+  export function getMonthlyNoteSettings(): PeriodicNoteSettings;
+  export function getQuarterlyNoteSettings(): PeriodicNoteSettings;
+  export function getYearlyNoteSettings(): PeriodicNoteSettings;
+
+  export function createDailyNote(
+    date: import("moment").Moment,
+  ): Promise<import("obsidian").TFile>;
+  export function createWeeklyNote(
+    date: import("moment").Moment,
+  ): Promise<import("obsidian").TFile>;
+  export function createMonthlyNote(
+    date: import("moment").Moment,
+  ): Promise<import("obsidian").TFile>;
+  export function createQuarterlyNote(
+    date: import("moment").Moment,
+  ): Promise<import("obsidian").TFile>;
+  export function createYearlyNote(
+    date: import("moment").Moment,
+  ): Promise<import("obsidian").TFile>;
+}
+
 export {};


### PR DESCRIPTION
## Summary

Upstream `obsidian-daily-notes-interface@0.9.4` ships only the daily surface in its `.d.ts`. The weekly, monthly, quarterly, and yearly functions exist at runtime but have no type declarations.

- Adds a `declare module "obsidian-daily-notes-interface"` block in `src/types.ts` (already in the tsconfig `include` glob) with the full per-period function set and the `PeriodicNoteSettings` interface.
- Removes the local `PeriodicNotesLibRuntime` interface and the `as unknown as PeriodicNotesLibRuntime` cast from `periodicNotesDetector.ts`. Callers now use the typed import directly.

No functional change. TypeScript compiles clean, 1107 tests pass.

Closes #230.