### PR TITLE
refactor(execute-template): add structured error codes aligned with Dataview pattern

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.test.ts
@@ -95,9 +95,10 @@ describe("execute_template tool", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(
-      /templater|not available|not installed/i,
-    );
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.errorCode).toBe("templater_not_installed");
+    expect(payload.templatePath).toBe("Templates/foo.md");
+    expect(payload.error).toMatch(/templater|not installed/i);
   });
 
   test("returns error when template file not found in vault", async () => {
@@ -112,7 +113,9 @@ describe("execute_template tool", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Templates/missing.md");
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.errorCode).toBe("template_not_found");
+    expect(payload.templatePath).toBe("Templates/missing.md");
   });
 
   test("renders template and returns content without creating a file", async () => {
@@ -336,11 +339,14 @@ describe("execute_template tool", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Templater internal error");
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.errorCode).toBe("template_execution_failed");
+    expect(payload.error).toContain("Templater internal error");
+    expect(payload.templatePath).toBe("a.md");
     // The handler must NOT wrap the message in `MCP error -<code>:` itself —
     // the registry would then wrap again, producing the double prefix folotp
     // reported.
-    expect(result.content[0].text).not.toMatch(/MCP error -?\d+:.*MCP error/);
+    expect(payload.error).not.toMatch(/MCP error -?\d+:.*MCP error/);
 
     // generate_object must be restored to the non-injecting version
     const restored = await fakeTemplater.functions_generator.generate_object(

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
@@ -30,7 +30,7 @@ export const executeTemplateSchema = type({
     ),
   },
 }).describe(
-  'Renders a Templater template. If targetPath is given and createFile="true", creates a new note at that path and returns the rendered content.',
+  'Renders a Templater template. If targetPath is given and createFile="true", creates a new note at that path and returns the rendered content. Requires the Templater community plugin: `errorCode: "templater_not_installed"` if absent, `template_not_found` if the template file does not exist in the vault, `template_execution_failed` if Templater throws during rendering (the underlying error is surfaced verbatim).',
 );
 
 export type ExecuteTemplateContext = {
@@ -65,15 +65,11 @@ export async function executeTemplateHandler(
   ).plugins.plugins["templater-obsidian"]?.templater;
 
   if (!templater) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Templater plugin is not installed or not yet loaded. Install Templater from Obsidian community plugins, restart Obsidian, then retry.",
-        },
-      ],
-      isError: true,
-    };
+    return errorPayload(
+      "Templater plugin is not installed or not yet loaded. Install Templater from Obsidian community plugins, restart Obsidian, then retry.",
+      "templater_not_installed",
+      { templatePath: ctx.arguments.templatePath },
+    );
   }
 
   // Resolve template file from vault
@@ -81,15 +77,11 @@ export async function executeTemplateHandler(
     ctx.arguments.templatePath,
   );
   if (!templateFile) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Template not found: ${ctx.arguments.templatePath}`,
-        },
-      ],
-      isError: true,
-    };
+    return errorPayload(
+      `Template not found: ${ctx.arguments.templatePath}`,
+      "template_not_found",
+      { templatePath: ctx.arguments.templatePath },
+    );
   }
 
   // createFile coercion — belt-and-suspenders: accept both boolean string "true" and missing
@@ -189,19 +181,36 @@ export async function executeTemplateHandler(
       // <text>`. Returning `isError: true` keeps the message clean and matches
       // the convention used by the other vault tools.
       const message = error instanceof Error ? error.message : String(error);
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Template execution failed: ${message}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorPayload(
+        `Template execution failed: ${message}`,
+        "template_execution_failed",
+        {
+          templatePath: ctx.arguments.templatePath,
+        },
+      );
     } finally {
       // Always restore generate_object — even when an error is thrown — to
       // avoid leaking the mcpTools injection into subsequent template runs.
       templater.functions_generator.generate_object = oldGenerateObject;
     }
   });
+}
+
+function errorPayload(
+  message: string,
+  errorCode: string,
+  extras: Record<string, unknown>,
+): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
+      },
+    ],
+    isError: true,
+  };
 }


### PR DESCRIPTION
## Summary

`execute_template` was returning `isError: true` with plain-text messages. MCP clients and LLM agents had to parse the string to distinguish "plugin missing" from "file not found" from "render error." `execute_dataview_query` already has structured `errorCode` fields for exactly this reason.

- Adds `errorPayload()` helper at the bottom of `executeTemplate.ts`, identical in signature to the one in `executeDataviewQuery.ts`.
- Replaces all three plain-text error returns with structured JSON payloads: `templater_not_installed`, `template_not_found`, `template_execution_failed`.
- Updates `describe()` to document the error codes (mirrors Dataview's tool description).
- Updates tests to assert `errorCode` fields via `JSON.parse`.

No functional change to the success path.

Closes #229.

> **Note:** `templater_not_ready` is deferred. Templater has no `index-ready` equivalent, so the absent/not-ready states are indistinguishable at the API level.