### PR TITLE
feat(execute-template): add core Templates fallback when Templater is absent

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.test.ts
@@ -3,7 +3,13 @@ import {
   executeTemplateHandler,
   executeTemplateSchema,
 } from "./executeTemplate";
-import { mockApp, mockPlugin, resetMockVault, setMockFile } from "$/test-setup";
+import {
+  mockApp,
+  mockPlugin,
+  resetMockVault,
+  setMockFile,
+  setMockCoreTemplatesState,
+} from "$/test-setup";
 
 beforeEach(() => resetMockVault());
 
@@ -354,5 +360,170 @@ describe("execute_template tool", () => {
       undefined,
     );
     expect((restored as Record<string, unknown>).mcpTools).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Core Templates fallback (issue #228)
+// ---------------------------------------------------------------------------
+
+// Build a plugin where Templater is absent (plugin key missing) but
+// internalPlugins is backed by the mock state seeded via
+// setMockCoreTemplatesState(). The mockApp() already wires the templates slot.
+function mockPluginWithoutTemplater() {
+  const app = mockApp();
+  (
+    app as unknown as {
+      plugins: { plugins: Record<string, unknown> };
+    }
+  ).plugins = { plugins: {} };
+  return mockPlugin({ app } as never);
+}
+
+describe("execute_template — core Templates fallback", () => {
+  test("returns templater_not_installed when both Templater and core Templates are absent", async () => {
+    // core Templates disabled by default (resetMockVault already called it)
+    const plugin = mockPluginWithoutTemplater();
+
+    const result = await executeTemplateHandler({
+      arguments: { templatePath: "Templates/foo.md" },
+      app: plugin.app,
+      plugin,
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.errorCode).toBe("templater_not_installed");
+    expect(payload.error).toMatch(/no template engine/i);
+  });
+
+  test("renders via core Templates when Templater absent and core Templates enabled", async () => {
+    setMockCoreTemplatesState({ enabled: true });
+    setMockFile("Templates/foo.md", "Hello {{title}}");
+    const plugin = mockPluginWithoutTemplater();
+
+    const result = await executeTemplateHandler({
+      arguments: { templatePath: "Templates/foo.md" },
+      app: plugin.app,
+      plugin,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.content).toContain("Hello");
+    expect(parsed.message).toMatch(/without creating/i);
+  });
+
+  test("creates file via core Templates when createFile='true' and targetPath given", async () => {
+    setMockCoreTemplatesState({ enabled: true });
+    setMockFile("Templates/foo.md", "content");
+    const plugin = mockPluginWithoutTemplater();
+
+    const result = await executeTemplateHandler({
+      arguments: {
+        templatePath: "Templates/foo.md",
+        targetPath: "Output/note.md",
+        createFile: "true",
+      },
+      app: plugin.app,
+      plugin,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.message).toMatch(/created successfully/i);
+    expect(parsed.path).toBe("Output/note.md");
+    expect(
+      plugin.app.vault.getAbstractFileByPath("Output/note.md"),
+    ).not.toBeNull();
+  });
+
+  test("{{title}} uses targetPath basename when targetPath provided", async () => {
+    setMockCoreTemplatesState({ enabled: true });
+    setMockFile("Templates/foo.md", "# {{title}}");
+    const plugin = mockPluginWithoutTemplater();
+
+    const result = await executeTemplateHandler({
+      arguments: {
+        templatePath: "Templates/foo.md",
+        targetPath: "Notes/My Note.md",
+      },
+      app: plugin.app,
+      plugin,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.content).toBe("# My Note");
+  });
+
+  test("{{title}} uses template basename when no targetPath", async () => {
+    setMockCoreTemplatesState({ enabled: true });
+    setMockFile("Templates/weekly-review.md", "# {{title}}");
+    const plugin = mockPluginWithoutTemplater();
+
+    const result = await executeTemplateHandler({
+      arguments: { templatePath: "Templates/weekly-review.md" },
+      app: plugin.app,
+      plugin,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.content).toBe("# weekly-review");
+  });
+
+  test("{{date}} and {{time}} use formats from core Templates settings", async () => {
+    setMockCoreTemplatesState({
+      enabled: true,
+      dateFormat: "DD/MM/YYYY",
+      timeFormat: "HH:mm:ss",
+    });
+    setMockFile("t.md", "date={{date}} time={{time}}");
+    const plugin = mockPluginWithoutTemplater();
+
+    const result = await executeTemplateHandler({
+      arguments: { templatePath: "t.md" },
+      app: plugin.app,
+      plugin,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    // DD/MM/YYYY → matches \d{2}/\d{2}/\d{4}
+    expect(parsed.content).toMatch(/date=\d{2}\/\d{2}\/\d{4}/);
+    // HH:mm:ss → matches \d{2}:\d{2}:\d{2}
+    expect(parsed.content).toMatch(/time=\d{2}:\d{2}:\d{2}/);
+  });
+
+  test("ignores arguments map and includes warning in response", async () => {
+    setMockCoreTemplatesState({ enabled: true });
+    setMockFile("t.md", "{{title}}");
+    const plugin = mockPluginWithoutTemplater();
+
+    const result = await executeTemplateHandler({
+      arguments: {
+        templatePath: "t.md",
+        arguments: { name: "ignored" },
+      },
+      app: plugin.app,
+      plugin,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.warning).toMatch(/arguments map is ignored/i);
+  });
+
+  test("returns template_not_found via core Templates path when file missing", async () => {
+    setMockCoreTemplatesState({ enabled: true });
+    const plugin = mockPluginWithoutTemplater();
+
+    const result = await executeTemplateHandler({
+      arguments: { templatePath: "Templates/missing.md" },
+      app: plugin.app,
+      plugin,
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.errorCode).toBe("template_not_found");
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
@@ -1,9 +1,25 @@
 import { type } from "arktype";
 import type { App, TFile } from "obsidian";
+import { moment } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import { Templater, type PromptArgAccessor } from "shared";
 import { ensureParentFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
 import { createMutex } from "$/features/command-permissions";
+
+// Runtime shape of the core Templates internal plugin. `app.internalPlugins`
+// is not typed in obsidian.d.ts — same cast pattern as AppWithPlugins above.
+interface AppWithInternalPlugins {
+  internalPlugins?: {
+    plugins?: {
+      templates?: {
+        enabled?: boolean;
+        instance?: {
+          options?: { dateFormat?: string; timeFormat?: string };
+        };
+      };
+    };
+  };
+}
 
 // Serializes the global monkey-patch of `generate_object`: concurrent
 // execute_template calls would otherwise restore each other's patch
@@ -30,7 +46,7 @@ export const executeTemplateSchema = type({
     ),
   },
 }).describe(
-  'Renders a Templater template. If targetPath is given and createFile="true", creates a new note at that path and returns the rendered content. Requires the Templater community plugin: `errorCode: "templater_not_installed"` if absent, `template_not_found` if the template file does not exist in the vault, `template_execution_failed` if Templater throws during rendering (the underlying error is surfaced verbatim).',
+  'Renders a template. If targetPath is given and createFile="true", creates a new note at that path and returns the rendered content. Two-tier template engine: Templater (community plugin) when installed; falls back to the core Templates plugin for basic {{title}}/{{date}}/{{time}} substitution. `errorCode: "templater_not_installed"` when neither engine is available, `template_not_found` if the template file is missing, `template_execution_failed` on a Templater render error, `core_templates_execution_failed` on a core-Templates read error. The `arguments` map is Templater-specific and is ignored (with a warning) on the core-Templates path.',
 );
 
 export type ExecuteTemplateContext = {
@@ -65,8 +81,14 @@ export async function executeTemplateHandler(
   ).plugins.plugins["templater-obsidian"]?.templater;
 
   if (!templater) {
+    // Fallback to core Templates when Templater is absent.
+    const coreTemplates = (ctx.app as unknown as AppWithInternalPlugins)
+      .internalPlugins?.plugins?.templates;
+    if (coreTemplates?.enabled) {
+      return runCoreTemplates(ctx, coreTemplates.instance?.options);
+    }
     return errorPayload(
-      "Templater plugin is not installed or not yet loaded. Install Templater from Obsidian community plugins, restart Obsidian, then retry.",
+      "No template engine found. Install Templater for dynamic templates, or enable the core Templates plugin for basic {{title}}/{{date}}/{{time}} substitution.",
       "templater_not_installed",
       { templatePath: ctx.arguments.templatePath },
     );
@@ -194,6 +216,99 @@ export async function executeTemplateHandler(
       templater.functions_generator.generate_object = oldGenerateObject;
     }
   });
+}
+
+async function runCoreTemplates(
+  ctx: ExecuteTemplateContext,
+  options: { dateFormat?: string; timeFormat?: string } | undefined,
+): Promise<ToolResult> {
+  const {
+    templatePath,
+    targetPath,
+    createFile: createFileArg,
+    arguments: argMap,
+  } = ctx.arguments;
+
+  const templateFile = ctx.app.vault.getAbstractFileByPath(templatePath);
+  if (!templateFile) {
+    return errorPayload(
+      `Template not found: ${templatePath}`,
+      "template_not_found",
+      { templatePath },
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = await ctx.app.vault.read(templateFile as TFile);
+  } catch (err) {
+    return errorPayload(
+      `Core Templates could not read template file: ${err instanceof Error ? err.message : String(err)}`,
+      "core_templates_execution_failed",
+      { templatePath },
+    );
+  }
+
+  // Compute the three substitution values core Templates supports.
+  const dateFormat = options?.dateFormat ?? "YYYY-MM-DD";
+  const timeFormat = options?.timeFormat ?? "HH:mm";
+
+  // {{title}}: targetPath basename without extension when provided, else template basename.
+  const baseName = (p: string) => {
+    const name = p.split("/").pop() ?? p;
+    return name.replace(/\.[^.]+$/, "");
+  };
+  const title = targetPath ? baseName(targetPath) : baseName(templatePath);
+
+  const processed = raw
+    .replace(/\{\{title\}\}/g, title)
+    .replace(/\{\{date\}\}/g, moment().format(dateFormat))
+    .replace(/\{\{time\}\}/g, moment().format(timeFormat));
+
+  const createFile = createFileArg === "true";
+  const hasArgs = argMap && Object.keys(argMap).length > 0;
+  const warning = hasArgs
+    ? "arguments map is ignored by the core Templates engine (Templater-specific)"
+    : undefined;
+
+  if (createFile && targetPath) {
+    await ensureParentFolderExists(ctx.app, targetPath);
+    await ctx.app.vault.create(targetPath, processed);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              message: "Template executed and file created successfully",
+              content: processed,
+              path: targetPath,
+              ...(warning ? { warning } : {}),
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            message: "Template executed without creating a file",
+            content: processed,
+            ...(warning ? { warning } : {}),
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
 }
 
 function errorPayload(

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -511,6 +511,33 @@ export function resetMockBookmarks(): void {
   _mockBookmarks.items = [];
 }
 
+// === Mock for Obsidian core Templates plugin (issue #228) =================
+// execute_template reads app.internalPlugins.plugins["templates"] when
+// Templater is absent. Tests seed via setMockCoreTemplatesState(...).
+// Default: disabled (matches a vault without the core plugin enabled).
+
+const _mockCoreTemplates = {
+  enabled: false,
+  dateFormat: "YYYY-MM-DD",
+  timeFormat: "HH:mm",
+};
+
+export function setMockCoreTemplatesState(state: {
+  enabled: boolean;
+  dateFormat?: string;
+  timeFormat?: string;
+}): void {
+  _mockCoreTemplates.enabled = state.enabled;
+  _mockCoreTemplates.dateFormat = state.dateFormat ?? "YYYY-MM-DD";
+  _mockCoreTemplates.timeFormat = state.timeFormat ?? "HH:mm";
+}
+
+export function resetMockCoreTemplates(): void {
+  _mockCoreTemplates.enabled = false;
+  _mockCoreTemplates.dateFormat = "YYYY-MM-DD";
+  _mockCoreTemplates.timeFormat = "HH:mm";
+}
+
 // === Phase 2 mock vault state for tool tests ===
 
 type MockVaultState = {
@@ -651,6 +678,7 @@ export function resetMockVault(): void {
   resetMockPeriodicNotes();
   resetMockDataview();
   resetMockBookmarks();
+  resetMockCoreTemplates();
 }
 
 /**
@@ -1236,6 +1264,21 @@ export function mockApp(): App {
         get instance() {
           return _mockBookmarks.enabled
             ? { items: _mockBookmarks.items }
+            : undefined;
+        },
+      },
+      templates: {
+        get enabled() {
+          return _mockCoreTemplates.enabled;
+        },
+        get instance() {
+          return _mockCoreTemplates.enabled
+            ? {
+                options: {
+                  dateFormat: _mockCoreTemplates.dateFormat,
+                  timeFormat: _mockCoreTemplates.timeFormat,
+                },
+              }
             : undefined;
         },
       },


### PR DESCRIPTION
## Summary

`execute_template` hard-failed when Templater was not installed, even though many vaults use Obsidian's built-in Templates core plugin for basic variable substitution.

- Two-tier engine check: Templater (community) when installed; falls back to `app.internalPlugins.plugins["templates"]` otherwise.
- Core Templates path substitutes `{{title}}`, `{{date}}`, and `{{time}}` using the formats configured in Templates settings (`dateFormat` / `timeFormat`). `{{title}}` resolves to the `targetPath` basename (no extension) when provided, or the template file basename otherwise.
- The `arguments` map is Templater-specific; the core path ignores it and includes a `warning` field in the response.
- When neither engine is available, the error code remains `templater_not_installed` with an updated message: "No template engine found."
- Adds `setMockCoreTemplatesState()` to `test-setup.ts` and 8 new tests covering the fallback path.

Closes #228.

> **Merge order:** this branch is stacked on #232 (`refactor/execute-template-error-codes`). Merge #232 first so the diff here only shows the core Templates additions.