### PR TITLE
fix(semantic-search): improve excerpt quality in search_vault_smart

### DIFF
--- a/packages/obsidian-plugin/src/features/semantic-search/services/nativeProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/nativeProvider.test.ts
@@ -188,7 +188,7 @@ describe("native provider", () => {
     expect(out.map((r) => r.filePath)).toEqual(["1.md", "2.md"]);
   });
 
-  test("excerpt is bounded to 200 chars", async () => {
+  test("excerpt is bounded to 500 chars", async () => {
     const longBody = "x".repeat(1000);
     const store = await makeStore([
       rec({
@@ -211,8 +211,8 @@ describe("native provider", () => {
 
     const out = await provider.search("q", {});
     expect(out).toHaveLength(1);
-    expect(out[0]!.excerpt.length).toBeLessThanOrEqual(200);
-    expect(out[0]!.excerpt.startsWith("H: ")).toBe(true);
+    expect(out[0]!.excerpt.length).toBeLessThanOrEqual(500);
+    expect(out[0]!.excerpt.startsWith("H: ")).toBe(false);
   });
 
   test("excerpt without resolver falls back to heading + sentinel or sentinel only", async () => {
@@ -235,7 +235,7 @@ describe("native provider", () => {
 
     const out = await provider.search("q", { limit: 2 });
     const byPath = Object.fromEntries(out.map((r) => [r.filePath, r]));
-    expect(byPath["h.md"]?.excerpt.startsWith("Heading: ")).toBe(true);
+    expect(byPath["h.md"]?.excerpt).toBe("(no preview)");
     expect(byPath["n.md"]?.excerpt).toBe("(no preview)");
   });
 
@@ -272,8 +272,6 @@ describe("native provider", () => {
 
     const out = await provider.search("q", {});
     expect(out).toHaveLength(1);
-    // Falls back to heading-only excerpt (with empty body) — does
-    // not throw.
-    expect(out[0]!.excerpt.startsWith("H: ")).toBe(true);
+    expect(out[0]!.excerpt).toBe("(no preview)");
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/nativeProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/nativeProvider.ts
@@ -30,7 +30,7 @@ import type {
 } from "$/features/semantic-search";
 
 const DEFAULT_LIMIT = 10;
-const EXCERPT_MAX_LENGTH = 200;
+const EXCERPT_MAX_LENGTH = 500;
 
 export type ExcerptResolver = (
   filePath: string,
@@ -92,26 +92,10 @@ class NativeProviderImpl implements SemanticSearchProvider {
           EXCERPT_MAX_LENGTH,
         );
       } catch {
-        // Failure to read the file should not fail the whole search;
-        // the excerpt degrades to heading-only.
         body = "";
       }
     }
-
-    if (record.heading) {
-      const prefix = `${record.heading}: `;
-      const remaining = Math.max(0, EXCERPT_MAX_LENGTH - prefix.length);
-      const tail = body.slice(0, remaining);
-      const out = prefix + tail;
-      return out.length > EXCERPT_MAX_LENGTH
-        ? out.slice(0, EXCERPT_MAX_LENGTH)
-        : out;
-    }
-
-    if (body.length === 0) return "(no preview)";
-    return body.length > EXCERPT_MAX_LENGTH
-      ? body.slice(0, EXCERPT_MAX_LENGTH)
-      : body;
+    return truncateExcerpt(body);
   }
 }
 
@@ -161,6 +145,15 @@ export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
   }
   const denom = Math.sqrt(normA) * Math.sqrt(normB);
   return denom === 0 ? 0 : dot / denom;
+}
+
+function truncateExcerpt(body: string): string {
+  if (body.length === 0) return "(no preview)";
+  if (body.length <= EXCERPT_MAX_LENGTH) return body;
+  const cut = body.lastIndexOf(" ", EXCERPT_MAX_LENGTH);
+  return (
+    (cut > 0 ? body.slice(0, cut) : body.slice(0, EXCERPT_MAX_LENGTH)) + "..."
+  );
 }
 
 export function createNativeProvider(

--- a/packages/obsidian-plugin/src/features/semantic-search/services/smartConnectionsProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/smartConnectionsProvider.test.ts
@@ -148,7 +148,7 @@ describe("SmartConnectionsProvider", () => {
     expect(results[0]).toEqual({
       filePath: "Zettelkasten/idea.md",
       heading: "Zettelkasten > idea",
-      excerpt: "Zettelkasten > idea: Body content of the idea note.",
+      excerpt: "Body content of the idea note.",
       score: 0.95,
     });
 
@@ -158,7 +158,7 @@ describe("SmartConnectionsProvider", () => {
     expect(results[1]?.score).toBe(0.42);
   });
 
-  test("excerpt is bounded to 200 chars (with heading prefix counted)", async () => {
+  test("excerpt is bounded to 500 chars", async () => {
     const longBody = "x".repeat(500);
     const fakeSC: FakeSmartSearch = {
       search: async () => [
@@ -184,9 +184,9 @@ describe("SmartConnectionsProvider", () => {
     const results = await provider.search("q", {});
 
     for (const r of results) {
-      expect(r.excerpt.length).toBeLessThanOrEqual(200);
+      expect(r.excerpt.length).toBeLessThanOrEqual(500);
     }
-    expect(results[0]?.excerpt.startsWith("Long: ")).toBe(true);
+    expect(results[0]?.excerpt.startsWith("Long: ")).toBe(false);
   });
 
   test("empty body without heading falls back to (no preview)", async () => {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/smartConnectionsProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/smartConnectionsProvider.ts
@@ -27,7 +27,7 @@ import type {
   SemanticSearchProvider,
 } from "$/features/semantic-search";
 
-const EXCERPT_MAX_LENGTH = 200;
+const EXCERPT_MAX_LENGTH = 500;
 
 /**
  * Pure helper: convert the user-facing `SearchOpts` shape into the
@@ -105,7 +105,7 @@ class SmartConnectionsProviderImpl implements SemanticSearchProvider {
         return {
           filePath: r.item.path,
           heading,
-          excerpt: makeExcerpt(heading, body),
+          excerpt: makeExcerpt(body),
           score: r.score,
         };
       }),
@@ -113,20 +113,13 @@ class SmartConnectionsProviderImpl implements SemanticSearchProvider {
   }
 }
 
-function makeExcerpt(heading: string | null, body: string): string {
-  if (heading) {
-    const prefix = `${heading}: `;
-    const remaining = Math.max(0, EXCERPT_MAX_LENGTH - prefix.length);
-    const tail = body.slice(0, remaining);
-    const out = prefix + tail;
-    return out.length > EXCERPT_MAX_LENGTH
-      ? out.slice(0, EXCERPT_MAX_LENGTH)
-      : out;
-  }
+function makeExcerpt(body: string): string {
   if (body.length === 0) return "(no preview)";
-  return body.length > EXCERPT_MAX_LENGTH
-    ? body.slice(0, EXCERPT_MAX_LENGTH)
-    : body;
+  if (body.length <= EXCERPT_MAX_LENGTH) return body;
+  const cut = body.lastIndexOf(" ", EXCERPT_MAX_LENGTH);
+  return (
+    (cut > 0 ? body.slice(0, cut) : body.slice(0, EXCERPT_MAX_LENGTH)) + "..."
+  );
 }
 
 export function createSmartConnectionsProvider(


### PR DESCRIPTION
Closes #223.

Proposed and fully spec'd by @folotp — implementing as agreed.

## Changes

**`nativeProvider.ts` and `smartConnectionsProvider.ts`:**
- `EXCERPT_MAX_LENGTH` 200 → 500
- Removed heading prefix from `excerpt` (`heading` is already a separate field in `SearchResult`)
- Word-boundary truncation with `...` suffix instead of hard character cut

**Tests (4 assertions updated):**
- Limit checks updated to 500
- `startsWith("H: ")` / `startsWith("Long: ")` assertions replaced to reflect the new shape
- Resolver-failure and no-resolver fallbacks now expect `"(no preview)"` (no heading bleed)