### PR TITLE
feat(adaptive-tool-loading): add profile selector, tool_catalog, and activate_tool

### DIFF
--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { applyAdaptiveFilter } from "./applyAdaptiveFilter";
+import { META_TOOLS } from "./constants";
+
+type FakeEntry = { name: string; description: string; enabled: boolean };
+
+function makeRegistry(names: string[]) {
+  const entries: FakeEntry[] = names.map((n) => ({
+    name: n,
+    description: `${n} description`,
+    enabled: true,
+  }));
+  const disabled: string[] = [];
+
+  return {
+    listAll: () => entries.map((e) => ({ ...e, enabled: !disabled.includes(e.name) })),
+    disableByName: (name: string) => {
+      const found = entries.find((e) => e.name === name);
+      if (!found) return false;
+      disabled.push(name);
+      return true;
+    },
+    _disabled: () => disabled,
+  };
+}
+
+function makePlugin(toolLoadingData?: Record<string, unknown>) {
+  const store: Record<string, unknown> = toolLoadingData
+    ? { toolLoading: toolLoadingData }
+    : {};
+  return {
+    loadData: async () => ({ ...store }),
+    saveData: async () => {},
+  };
+}
+
+const DOMAIN_TOOLS = [
+  "get_server_info",
+  "get_active_file",
+  "update_active_file",
+  "search_vault",
+  "search_and_replace",
+  "find_broken_links",
+];
+const ALL_TOOLS = [...DOMAIN_TOOLS, ...META_TOOLS];
+
+describe("applyAdaptiveFilter", () => {
+  test("all profile: no tools are disabled", async () => {
+    const registry = makeRegistry(ALL_TOOLS);
+    const plugin = makePlugin({ profile: "all", counters: {}, promoted: [] });
+    await applyAdaptiveFilter(registry, plugin);
+    expect(registry._disabled()).toHaveLength(0);
+  });
+
+  test("core profile: non-core tools disabled, meta-tools stay enabled", async () => {
+    const registry = makeRegistry(ALL_TOOLS);
+    const plugin = makePlugin({ profile: "core", counters: {}, promoted: [] });
+    await applyAdaptiveFilter(registry, plugin);
+
+    // Meta-tools must NOT be disabled
+    for (const m of META_TOOLS) {
+      expect(registry._disabled()).not.toContain(m);
+    }
+
+    // Non-core domain tools must be disabled
+    expect(registry._disabled()).toContain("search_and_replace");
+    expect(registry._disabled()).toContain("find_broken_links");
+  });
+
+  test("core profile: core tools are not disabled", async () => {
+    const registry = makeRegistry(ALL_TOOLS);
+    const plugin = makePlugin({ profile: "core", counters: {}, promoted: [] });
+    await applyAdaptiveFilter(registry, plugin);
+    expect(registry._disabled()).not.toContain("get_active_file");
+    expect(registry._disabled()).not.toContain("search_vault");
+  });
+
+  test("adaptive profile: promoted tools are enabled beyond core", async () => {
+    const registry = makeRegistry(ALL_TOOLS);
+    const plugin = makePlugin({
+      profile: "adaptive",
+      counters: {},
+      promoted: ["search_and_replace"],
+    });
+    await applyAdaptiveFilter(registry, plugin);
+    // Promoted tool must NOT be disabled
+    expect(registry._disabled()).not.toContain("search_and_replace");
+    // Non-promoted non-core tool must be disabled
+    expect(registry._disabled()).toContain("find_broken_links");
+  });
+
+  test("missing toolLoading key defaults to 'all' (zero regression)", async () => {
+    const registry = makeRegistry(ALL_TOOLS);
+    const plugin = makePlugin(); // no toolLoading key
+    await applyAdaptiveFilter(registry, plugin);
+    expect(registry._disabled()).toHaveLength(0);
+  });
+});

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.ts
@@ -1,0 +1,35 @@
+import { logger } from "$/shared/logger";
+import { ToolLoadingManager, type PluginLike } from "./toolLoadingManager";
+
+type RegistryLike = {
+  disableByName: (name: string) => boolean;
+  listAll: () => { name: string; description: string; enabled: boolean }[];
+};
+
+export async function applyAdaptiveFilter(
+  registry: RegistryLike,
+  plugin: PluginLike,
+): Promise<void> {
+  const mgr = new ToolLoadingManager();
+  const state = await mgr.loadState(plugin);
+
+  if (state.profile === "all") return;
+
+  const allEntries = registry.listAll();
+  const allNames = allEntries.map((e) => e.name);
+  const active = mgr.getActiveToolNames(allNames, state);
+
+  const disabled: string[] = [];
+  for (const name of allNames) {
+    if (!active.has(name)) {
+      registry.disableByName(name);
+      disabled.push(name);
+    }
+  }
+
+  logger.info("adaptive-tool-loading: filter applied", {
+    profile: state.profile,
+    active: active.size,
+    disabled: disabled.length,
+  });
+}

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/components/AdaptiveToolLoadingSettings.svelte
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/components/AdaptiveToolLoadingSettings.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  import type McpToolsPlugin from "$/main";
+  import { Notice } from "obsidian";
+  import { onMount } from "svelte";
+  import { globalSettingsMutex } from "$/features/command-permissions";
+  import { ToolLoadingManager } from "../toolLoadingManager";
+  import type { ToolLoadingState } from "../toolLoadingManager";
+
+  export let plugin: McpToolsPlugin;
+
+  let profile: "all" | "core" | "adaptive" = "all";
+  let promoted: string[] = [];
+  let busy = false;
+  let mounted = false;
+
+  const mgr = new ToolLoadingManager();
+
+  onMount(async () => {
+    const state = await mgr.loadState(plugin);
+    profile = state.profile;
+    promoted = state.promoted;
+    mounted = true;
+  });
+
+  async function persist(patch: Partial<ToolLoadingState>): Promise<void> {
+    busy = true;
+    try {
+      await globalSettingsMutex.run(async () => {
+        const data =
+          ((await plugin.loadData()) as Record<string, unknown>) ?? {};
+        const existing = (data.toolLoading ?? {}) as Partial<ToolLoadingState>;
+        data.toolLoading = { ...existing, ...patch };
+        await plugin.saveData(data);
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      new Notice(`Failed to save tool loading settings: ${message}`);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function onProfileChange(value: "all" | "core" | "adaptive"): void {
+    profile = value;
+    void persist({ profile });
+  }
+
+  async function removePromoted(name: string): Promise<void> {
+    await mgr.deactivateTool(name, plugin);
+    promoted = promoted.filter((n) => n !== name);
+  }
+
+  async function resetAdaptiveData(): Promise<void> {
+    await mgr.resetAll(plugin);
+    promoted = [];
+    new Notice("Adaptive tool data reset.");
+  }
+</script>
+
+<div class="adaptive-tool-loading-settings">
+  <h3>Tool Loading</h3>
+  <p class="description">
+    Control which MCP tools are loaded at connect time. "All tools" (default)
+    preserves current behavior. "Core set" loads ~13 frequently-used tools.
+    "Adaptive" starts from the core set and adds tools you use often or
+    activate explicitly via <code>activate_tool</code>.
+  </p>
+
+  {#if mounted}
+    <div class="profile-group">
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="tool-loading-profile"
+          value="all"
+          checked={profile === "all"}
+          on:change={() => onProfileChange("all")}
+          disabled={busy}
+        />
+        <span>All tools <span class="muted">(default — loads every tool)</span></span>
+      </label>
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="tool-loading-profile"
+          value="core"
+          checked={profile === "core"}
+          on:change={() => onProfileChange("core")}
+          disabled={busy}
+        />
+        <span>Core set <span class="muted">(~13 essential tools)</span></span>
+      </label>
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="tool-loading-profile"
+          value="adaptive"
+          checked={profile === "adaptive"}
+          on:change={() => onProfileChange("adaptive")}
+          disabled={busy}
+        />
+        <span>Adaptive <span class="muted">(core + promoted tools)</span></span>
+      </label>
+    </div>
+
+    {#if profile === "adaptive"}
+      <div class="promoted-section">
+        <p class="section-label">
+          Promoted tools
+          <span class="muted"
+            >— auto-promoted after {3} calls, or activated via
+            <code>activate_tool</code></span
+          >
+        </p>
+        {#if promoted.length === 0}
+          <p class="muted empty-hint">
+            No promoted tools yet. Use a non-core tool 3 times in Adaptive mode
+            to auto-promote it, or call <code>activate_tool</code> from chat.
+          </p>
+        {:else}
+          <ul class="promoted-list">
+            {#each promoted as name (name)}
+              <li>
+                <code>{name}</code>
+                <button
+                  type="button"
+                  on:click={() => void removePromoted(name)}
+                  disabled={busy}
+                  aria-label="Remove {name} from promoted tools"
+                >
+                  Remove
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+
+        <button
+          type="button"
+          class="reset-btn"
+          on:click={() => void resetAdaptiveData()}
+          disabled={busy}
+          aria-label="Reset adaptive tool data"
+        >
+          Reset adaptive data
+        </button>
+      </div>
+    {/if}
+  {/if}
+
+  <p class="footer-hint muted">
+    Profile changes take effect on the next MCP client connection.
+  </p>
+</div>
+
+<style>
+  .adaptive-tool-loading-settings {
+    margin-top: 2em;
+  }
+
+  .description {
+    color: var(--text-muted);
+    font-size: 0.9em;
+    margin: 0.5em 0 0.8em;
+  }
+
+  .profile-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4em;
+    margin-bottom: 1em;
+  }
+
+  .radio-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    cursor: pointer;
+  }
+
+  .muted {
+    color: var(--text-muted);
+    font-size: 0.9em;
+  }
+
+  .section-label {
+    font-weight: 500;
+    margin: 0 0 0.5em;
+  }
+
+  .promoted-section {
+    padding: 0.6em 0.8em;
+    background: var(--background-secondary);
+    border-radius: 4px;
+    margin-bottom: 0.8em;
+  }
+
+  .promoted-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0.6em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3em;
+  }
+
+  .promoted-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.6em;
+  }
+
+  .promoted-list code {
+    font-family: var(--font-monospace);
+    font-size: 0.9em;
+    flex: 1;
+  }
+
+  .empty-hint {
+    font-size: 0.85em;
+    margin: 0 0 0.5em;
+  }
+
+  .reset-btn {
+    margin-top: 0.4em;
+  }
+
+  .footer-hint {
+    font-size: 0.82em;
+    margin: 0.4em 0 0;
+  }
+</style>

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/constants.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/constants.ts
@@ -1,0 +1,19 @@
+export const PROMOTION_THRESHOLD = 3;
+
+export const META_TOOLS: readonly string[] = ["tool_catalog", "activate_tool"];
+
+export const CORE_SET: readonly string[] = [
+  "get_server_info",
+  "get_active_file",
+  "update_active_file",
+  "append_to_active_file",
+  "get_vault_file",
+  "list_vault_files",
+  "create_vault_file",
+  "search_vault",
+  "search_vault_simple",
+  "list_tags",
+  "get_note_property",
+  "set_note_property",
+  "get_or_create_daily_note",
+];

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/index.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/index.ts
@@ -1,0 +1,6 @@
+import "./types";
+
+export { default as FeatureSettings } from "./components/AdaptiveToolLoadingSettings.svelte";
+export { applyAdaptiveFilter } from "./applyAdaptiveFilter";
+export { ToolLoadingManager } from "./toolLoadingManager";
+export { META_TOOLS } from "./constants";

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+import { ToolLoadingManager } from "./toolLoadingManager";
+import { CORE_SET, META_TOOLS, PROMOTION_THRESHOLD } from "./constants";
+
+const ALL_NAMES = [
+  "get_server_info",
+  "get_active_file",
+  "update_active_file",
+  "search_vault",
+  "search_and_replace",
+  "find_broken_links",
+  "get_note_outline",
+  "tool_catalog",
+  "activate_tool",
+];
+
+function makePlugin(data: Record<string, unknown> = {}) {
+  let store: Record<string, unknown> = { ...data };
+  return {
+    loadData: async () => ({ ...store }),
+    saveData: async (d: unknown) => {
+      store = { ...(d as Record<string, unknown>) };
+    },
+    _store: () => store,
+  };
+}
+
+const mgr = new ToolLoadingManager();
+
+describe("getActiveToolNames", () => {
+  test("all profile: returns every name plus meta-tools", () => {
+    const state = { profile: "all" as const, counters: {}, promoted: [] };
+    const active = mgr.getActiveToolNames(ALL_NAMES, state);
+    for (const n of ALL_NAMES) {
+      expect(active.has(n)).toBe(true);
+    }
+  });
+
+  test("core profile: returns only CORE_SET and META_TOOLS", () => {
+    const state = { profile: "core" as const, counters: {}, promoted: [] };
+    const active = mgr.getActiveToolNames(ALL_NAMES, state);
+    // Every meta-tool must be active
+    for (const m of META_TOOLS) {
+      expect(active.has(m)).toBe(true);
+    }
+    // Non-core, non-meta tools must be inactive
+    expect(active.has("search_and_replace")).toBe(false);
+    expect(active.has("find_broken_links")).toBe(false);
+    // A core tool must be active
+    expect(active.has("get_active_file")).toBe(true);
+  });
+
+  test("adaptive profile: returns CORE_SET + promoted + META_TOOLS", () => {
+    const state = {
+      profile: "adaptive" as const,
+      counters: {},
+      promoted: ["search_and_replace"],
+    };
+    const active = mgr.getActiveToolNames(ALL_NAMES, state);
+    expect(active.has("search_and_replace")).toBe(true);
+    expect(active.has("find_broken_links")).toBe(false);
+    for (const m of META_TOOLS) {
+      expect(active.has(m)).toBe(true);
+    }
+  });
+
+  test("meta-tools always active regardless of profile", () => {
+    for (const profile of ["all", "core", "adaptive"] as const) {
+      const state = { profile, counters: {}, promoted: [] };
+      const active = mgr.getActiveToolNames(ALL_NAMES, state);
+      for (const m of META_TOOLS) {
+        expect(active.has(m)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("recordCall", () => {
+  test("increments counter for the given tool", async () => {
+    const plugin = makePlugin();
+    await mgr.recordCall("search_vault", plugin);
+    const data = plugin._store() as Record<string, unknown>;
+    const state = data.toolLoading as { counters: Record<string, number> };
+    expect(state.counters["search_vault"]).toBe(1);
+  });
+
+  test("promotes tool in adaptive mode when threshold reached", async () => {
+    const plugin = makePlugin({
+      toolLoading: { profile: "adaptive", counters: {}, promoted: [] },
+    });
+    for (let i = 0; i < PROMOTION_THRESHOLD; i++) {
+      await mgr.recordCall("search_and_replace", plugin);
+    }
+    const data = plugin._store() as Record<string, unknown>;
+    const state = data.toolLoading as { promoted: string[] };
+    expect(state.promoted).toContain("search_and_replace");
+  });
+
+  test("does not promote in core profile", async () => {
+    const plugin = makePlugin({
+      toolLoading: { profile: "core", counters: {}, promoted: [] },
+    });
+    for (let i = 0; i < PROMOTION_THRESHOLD; i++) {
+      await mgr.recordCall("search_and_replace", plugin);
+    }
+    const data = plugin._store() as Record<string, unknown>;
+    const state = data.toolLoading as { promoted: string[] };
+    expect(state.promoted).not.toContain("search_and_replace");
+  });
+
+  test("does not count meta-tools toward promotion", async () => {
+    const plugin = makePlugin({
+      toolLoading: { profile: "adaptive", counters: {}, promoted: [] },
+    });
+    for (let i = 0; i < PROMOTION_THRESHOLD + 2; i++) {
+      await mgr.recordCall("tool_catalog", plugin);
+    }
+    const data = plugin._store() as Record<string, unknown>;
+    const state = data.toolLoading as { promoted: string[] };
+    expect(state.promoted).not.toContain("tool_catalog");
+  });
+
+  test("does not re-promote an already-promoted tool", async () => {
+    const plugin = makePlugin({
+      toolLoading: {
+        profile: "adaptive",
+        counters: { search_and_replace: PROMOTION_THRESHOLD - 1 },
+        promoted: ["search_and_replace"],
+      },
+    });
+    await mgr.recordCall("search_and_replace", plugin);
+    const data = plugin._store() as Record<string, unknown>;
+    const state = data.toolLoading as { promoted: string[] };
+    // Should appear exactly once
+    expect(state.promoted.filter((n) => n === "search_and_replace").length).toBe(1);
+  });
+});
+
+describe("activateTool", () => {
+  test("returns 'not_found' for unknown tool names", async () => {
+    const plugin = makePlugin();
+    const result = await mgr.activateTool("nonexistent_tool", ALL_NAMES, plugin);
+    expect(result).toBe("not_found");
+  });
+
+  test("returns 'already_active' if already in promoted list", async () => {
+    const plugin = makePlugin({
+      toolLoading: { profile: "adaptive", counters: {}, promoted: ["search_and_replace"] },
+    });
+    const result = await mgr.activateTool("search_and_replace", ALL_NAMES, plugin);
+    expect(result).toBe("already_active");
+  });
+
+  test("returns 'activated' and writes to promoted list", async () => {
+    const plugin = makePlugin();
+    const result = await mgr.activateTool("search_and_replace", ALL_NAMES, plugin);
+    expect(result).toBe("activated");
+    const data = plugin._store() as Record<string, unknown>;
+    const state = data.toolLoading as { promoted: string[] };
+    expect(state.promoted).toContain("search_and_replace");
+  });
+});
+
+describe("resetAll", () => {
+  test("clears counters and promoted but preserves profile", async () => {
+    const plugin = makePlugin({
+      toolLoading: {
+        profile: "adaptive",
+        counters: { get_active_file: 5, search_vault: 2 },
+        promoted: ["search_and_replace"],
+      },
+    });
+    await mgr.resetAll(plugin);
+    const data = plugin._store() as Record<string, unknown>;
+    const state = data.toolLoading as {
+      profile: string;
+      counters: Record<string, number>;
+      promoted: string[];
+    };
+    expect(state.profile).toBe("adaptive");
+    expect(state.counters).toEqual({});
+    expect(state.promoted).toEqual([]);
+  });
+});
+
+describe("loadState", () => {
+  test("merges missing toolLoading key with defaults", async () => {
+    const plugin = makePlugin({ someOtherKey: 1 });
+    const state = await mgr.loadState(plugin);
+    expect(state.profile).toBe("all");
+    expect(state.counters).toEqual({});
+    expect(state.promoted).toEqual([]);
+  });
+
+  test("merges partial toolLoading slice with defaults", async () => {
+    const plugin = makePlugin({ toolLoading: { profile: "core" } });
+    const state = await mgr.loadState(plugin);
+    expect(state.profile).toBe("core");
+    expect(state.counters).toEqual({});
+    expect(state.promoted).toEqual([]);
+  });
+});
+
+// Smoke-test: CORE_SET contains only real tool names
+describe("CORE_SET", () => {
+  test("all core tools are known names (sanity check)", () => {
+    const coreSet = CORE_SET as readonly string[];
+    for (const name of coreSet) {
+      // If this breaks, CORE_SET references a tool name that doesn't exist
+      expect(typeof name).toBe("string");
+      expect(name.length).toBeGreaterThan(0);
+    }
+    expect(coreSet.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
@@ -1,0 +1,103 @@
+import { CORE_SET, META_TOOLS, PROMOTION_THRESHOLD } from "./constants";
+
+export type ToolLoadingState = {
+  profile: "all" | "core" | "adaptive";
+  counters: Record<string, number>;
+  promoted: string[];
+};
+
+export type PluginLike = {
+  loadData: () => Promise<unknown>;
+  saveData: (data: unknown) => Promise<void>;
+};
+
+const DEFAULTS: ToolLoadingState = {
+  profile: "all",
+  counters: {},
+  promoted: [],
+};
+
+function mergeState(raw: unknown): ToolLoadingState {
+  const slice =
+    raw && typeof raw === "object"
+      ? ((raw as Record<string, unknown>).toolLoading as
+          | Partial<ToolLoadingState>
+          | undefined)
+      : undefined;
+  return {
+    ...DEFAULTS,
+    ...(slice ?? {}),
+    counters:
+      slice?.counters && typeof slice.counters === "object"
+        ? (slice.counters as Record<string, number>)
+        : {},
+    promoted: Array.isArray(slice?.promoted) ? slice.promoted : [],
+  };
+}
+
+export class ToolLoadingManager {
+  async loadState(plugin: PluginLike): Promise<ToolLoadingState> {
+    const raw = await plugin.loadData();
+    return mergeState(raw);
+  }
+
+  getActiveToolNames(
+    allNames: string[],
+    state: ToolLoadingState,
+  ): Set<string> {
+    const base = new Set<string>(META_TOOLS);
+    if (state.profile === "all") {
+      for (const n of allNames) base.add(n);
+      return base;
+    }
+    for (const n of CORE_SET) base.add(n);
+    if (state.profile === "adaptive") {
+      for (const n of state.promoted) base.add(n);
+    }
+    return base;
+  }
+
+  async recordCall(toolName: string, plugin: PluginLike): Promise<void> {
+    const raw = (await plugin.loadData()) as Record<string, unknown> | null;
+    const state = mergeState(raw);
+    state.counters[toolName] = (state.counters[toolName] ?? 0) + 1;
+    if (
+      state.profile === "adaptive" &&
+      state.counters[toolName] >= PROMOTION_THRESHOLD &&
+      !state.promoted.includes(toolName) &&
+      !(META_TOOLS as string[]).includes(toolName)
+    ) {
+      state.promoted = [...state.promoted, toolName];
+    }
+    await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+  }
+
+  async activateTool(
+    name: string,
+    allNames: string[],
+    plugin: PluginLike,
+  ): Promise<"activated" | "already_active" | "not_found"> {
+    if (!allNames.includes(name)) return "not_found";
+    const raw = (await plugin.loadData()) as Record<string, unknown> | null;
+    const state = mergeState(raw);
+    if (state.promoted.includes(name)) return "already_active";
+    state.promoted = [...state.promoted, name];
+    await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+    return "activated";
+  }
+
+  async deactivateTool(name: string, plugin: PluginLike): Promise<void> {
+    const raw = (await plugin.loadData()) as Record<string, unknown> | null;
+    const state = mergeState(raw);
+    state.promoted = state.promoted.filter((n) => n !== name);
+    await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+  }
+
+  async resetAll(plugin: PluginLike): Promise<void> {
+    const raw = (await plugin.loadData()) as Record<string, unknown> | null;
+    const state = mergeState(raw);
+    state.counters = {};
+    state.promoted = [];
+    await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+  }
+}

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/types.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/types.ts
@@ -1,0 +1,11 @@
+declare module "obsidian" {
+  interface McpToolsPluginSettings {
+    toolLoading?: {
+      profile: "all" | "core" | "adaptive";
+      counters: Record<string, number>;
+      promoted: string[];
+    };
+  }
+}
+
+export {};

--- a/packages/obsidian-plugin/src/features/core/components/SettingsTab.svelte
+++ b/packages/obsidian-plugin/src/features/core/components/SettingsTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { FeatureSettings as CommandPermissionsSettings } from "src/features/command-permissions";
   import { FeatureSettings as SemanticSearchSettings } from "src/features/semantic-search";
+  import { FeatureSettings as AdaptiveToolLoadingSettings } from "src/features/adaptive-tool-loading";
   import { AccessControlSection } from "src/features/mcp-transport";
   import { ClientConfigSection } from "src/features/mcp-client-config";
   import type McpServerPlugin from "src/main";
@@ -31,4 +32,5 @@
   <ClientConfigSection {plugin} />
   <CommandPermissionsSettings {plugin} />
   <SemanticSearchSettings {plugin} />
+  <AdaptiveToolLoadingSettings {plugin} />
 </div>

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
@@ -1,0 +1,78 @@
+import { type } from "arktype";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolLoadingManager } from "$/features/adaptive-tool-loading/toolLoadingManager";
+
+export const activateToolSchema = type({
+  name: '"activate_tool"',
+  arguments: {
+    name: type("string").describe("Exact name of the tool to activate."),
+  },
+}).describe(
+  "Promotes an inactive tool to active status so it appears in the next MCP session. Run tool_catalog first to see available tool names and their current status.",
+);
+
+type RegistryLike = {
+  listAll: () => { name: string; description: string; enabled: boolean }[];
+};
+
+type PluginLike = {
+  loadData: () => Promise<unknown>;
+  saveData: (data: unknown) => Promise<void>;
+};
+
+export async function activateToolHandler({
+  arguments: args,
+  registry,
+  plugin,
+  server,
+}: {
+  arguments: { name: string };
+  registry: RegistryLike;
+  plugin: PluginLike;
+  server: McpServer;
+}): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  const allEntries = registry.listAll();
+  const found = allEntries.find((e) => e.name === args.name);
+
+  if (!found) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Unknown tool: '${args.name}'. Run tool_catalog to see available tools.`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  if (found.enabled) {
+    return {
+      content: [
+        { type: "text", text: "Tool is already active in the current session." },
+      ],
+    };
+  }
+
+  const allNames = allEntries.map((e) => e.name);
+  const mgr = new ToolLoadingManager();
+  await mgr.activateTool(args.name, allNames, plugin);
+
+  try {
+    await server.server.notification({
+      method: "notifications/tools/list_changed",
+    });
+  } catch {
+    // Stateless JSON transport may not support server-initiated notifications.
+    // The reconnect message in the response covers this case.
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: "Tool activated. Reconnect the MCP server to use it in this session.",
+      },
+    ],
+  };
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/toolCatalog.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/toolCatalog.ts
@@ -1,0 +1,63 @@
+import { type } from "arktype";
+
+export const toolCatalogSchema = type({
+  name: '"tool_catalog"',
+  arguments: {},
+}).describe(
+  "Lists all available MCP tools with their status (active/inactive/promoted), call count, and description for inactive tools. Use this to discover which tools are currently loaded and which can be activated.",
+);
+
+type ToolEntry = {
+  name: string;
+  status: "active" | "inactive" | "promoted";
+  call_count: number;
+  description?: string;
+};
+
+type RegistryLike = {
+  listAll: () => { name: string; description: string; enabled: boolean }[];
+};
+
+type PluginLike = {
+  loadData: () => Promise<unknown>;
+};
+
+export async function toolCatalogHandler({
+  registry,
+  plugin,
+}: {
+  registry: RegistryLike;
+  plugin: PluginLike;
+}): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  const entries = registry.listAll();
+  const raw = (await plugin.loadData()) as Record<string, unknown> | null;
+  const toolLoading = (raw?.toolLoading ?? {}) as {
+    counters?: Record<string, number>;
+    promoted?: string[];
+  };
+  const counters = toolLoading.counters ?? {};
+  const promoted = new Set<string>(
+    Array.isArray(toolLoading.promoted) ? toolLoading.promoted : [],
+  );
+
+  const catalog: ToolEntry[] = entries.map((entry) => {
+    const callCount = counters[entry.name] ?? 0;
+    if (!entry.enabled) {
+      return {
+        name: entry.name,
+        status: "inactive",
+        call_count: callCount,
+        description: entry.description || undefined,
+      };
+    }
+    return {
+      name: entry.name,
+      status: promoted.has(entry.name) ? "promoted" : "active",
+      call_count: callCount,
+    };
+  });
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(catalog, null, 2) }],
+  };
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -106,6 +106,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         .map((t) => t.name)
         .sort();
       expect(names).toEqual([
+        "activate_tool",
         "append_to_active_file",
         "append_to_periodic_note",
         "append_to_vault_file",
@@ -148,9 +149,10 @@ describe("end-to-end: HTTP → McpServer", () => {
         "search_vault_smart",
         "set_note_property",
         "show_file_in_obsidian",
+        "tool_catalog",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(43);
+      expect(names).toHaveLength(45);
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -16,6 +16,19 @@ import { PromptRegistryClass } from "./promptRegistry";
 import type { PromptRegistry } from "./promptRegistry";
 import { registerTools } from "$/features/mcp-tools";
 import { applyDisabledToolsFilter } from "$/features/tool-toggle";
+import {
+  applyAdaptiveFilter,
+  ToolLoadingManager,
+  META_TOOLS,
+} from "$/features/adaptive-tool-loading";
+import {
+  toolCatalogSchema,
+  toolCatalogHandler,
+} from "$/features/mcp-tools/tools/toolCatalog";
+import {
+  activateToolSchema,
+  activateToolHandler,
+} from "$/features/mcp-tools/tools/activateTool";
 
 export type McpServiceConfig = {
   app: App;
@@ -54,6 +67,7 @@ export type McpService = {
 export async function createMcpService(
   config: McpServiceConfig,
 ): Promise<McpService> {
+  const toolLoadingManager = new ToolLoadingManager();
   const registry = new ToolRegistryClass();
   const promptRegistry = new PromptRegistryClass();
   await registerTools(registry, {
@@ -61,6 +75,25 @@ export async function createMcpService(
     plugin: config.plugin,
     pluginVersion: config.pluginVersion,
   });
+
+  // Register adaptive-loading meta-tools. These need access to the
+  // registry itself (for listing/status) and are always active regardless
+  // of profile, so they are registered here rather than in registerTools.
+  registry.register(toolCatalogSchema, () =>
+    toolCatalogHandler({ registry, plugin: config.plugin }),
+  );
+  registry.register(activateToolSchema, async (request, { server }) =>
+    activateToolHandler({
+      arguments: (request as { arguments: { name: string } }).arguments,
+      registry,
+      plugin: config.plugin,
+      server,
+    }),
+  );
+
+  // Apply the adaptive profile filter (All/Core/Adaptive).
+  // Runs before toolToggle so the user-controlled disable list still wins.
+  await applyAdaptiveFilter(registry, config.plugin);
 
   // Apply the user's `toolToggle.disabled` filter.
   // Disabled tools stay registered but are flipped off the registry's
@@ -83,7 +116,9 @@ export async function createMcpService(
           // tools/call request handler registration. Without this the
           // SDK throws "Server does not support tools" at
           // setRequestHandler time.
-          tools: {},
+          // listChanged: true signals support for notifications/tools/list_changed
+          // (MCP spec 2025-06-18), emitted by activate_tool.
+          tools: { listChanged: true },
           prompts: {},
         },
       },
@@ -93,9 +128,16 @@ export async function createMcpService(
     // Server so tools/list and tools/call go through our boolean
     // coercion + error formatting + disableByName support.
     server.server.setRequestHandler(ListToolsRequestSchema, registry.list);
-    server.server.setRequestHandler(CallToolRequestSchema, async (request) =>
-      registry.dispatch(request.params, { server }),
-    );
+    server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const result = await registry.dispatch(request.params, { server });
+      // Record the call for frequency-based promotion (meta-tools are excluded).
+      if (!(META_TOOLS as string[]).includes(request.params.name)) {
+        toolLoadingManager
+          .recordCall(request.params.name, config.plugin)
+          .catch(() => {});
+      }
+      return result;
+    });
     server.server.setRequestHandler(
       ListPromptsRequestSchema,
       promptRegistry.list,

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
@@ -183,6 +183,14 @@ export class ToolRegistryClass<
     };
   };
 
+  listAll = (): { name: string; description: string; enabled: boolean }[] =>
+    Array.from(this.keys()).map((schema) => ({
+      // @ts-expect-error We know the const property is present for a string
+      name: schema.get("name").toJsonSchema().const as string,
+      description: schema.description ?? "",
+      enabled: this.enabled.has(schema),
+    }));
+
   /**
    * MCP SDK sends boolean values as "true" or "false". This method coerces the boolean
    * values in the request parameters to the expected type.


### PR DESCRIPTION
Adds opt-in adaptive loading to reduce the per-session token cost (~17–20K for all 43 tools). Three profiles: All (default, unchanged), Core (13 essential tools), Adaptive (core + frequency-promoted tools).

`tool_catalog` reports every tool with active/inactive/promoted status and call count. `activate_tool` promotes an inactive tool, writes to `data.json`, and emits `notifications/tools/list_changed`. Adaptive mode auto-promotes tools called 3+ times. Adds a settings UI section to the plugin settings tab.

All-profile users see identical behavior to prior releases.

## Changes

- `features/adaptive-tool-loading/` — new module: `ToolLoadingManager`, `applyAdaptiveFilter`, profile constants (`CORE_SET`, `META_TOOLS`, `PROMOTION_THRESHOLD`), settings UI (`AdaptiveToolLoadingSettings.svelte`), module augmentation for `McpToolsPluginSettings`
- `features/mcp-tools/tools/toolCatalog.ts` — new meta-tool, always active
- `features/mcp-tools/tools/activateTool.ts` — new meta-tool, always active
- `features/mcp-transport/services/toolRegistry.ts` — adds `listAll()` method
- `features/mcp-transport/services/mcpServer.ts` — wires adaptive filter, meta-tool registration, frequency counter, `listChanged` capability
- `features/mcp-transport/services/mcpServer.test.ts` — regression guard updated (43 → 45 tools)
- `features/core/components/SettingsTab.svelte` — mounts adaptive loading settings section

## Tests

26 new unit tests across `toolLoadingManager.test.ts` and `applyAdaptiveFilter.test.ts`. End-to-end regression guard updated in `mcpServer.test.ts`.