### PR TITLE
chore: fix prettier formatting drift (restore green format:check)

### DIFF
--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.test.ts
@@ -13,7 +13,8 @@ function makeRegistry(names: string[]) {
   const disabled: string[] = [];
 
   return {
-    listAll: () => entries.map((e) => ({ ...e, enabled: !disabled.includes(e.name) })),
+    listAll: () =>
+      entries.map((e) => ({ ...e, enabled: !disabled.includes(e.name) })),
     disableByName: (name: string) => {
       const found = entries.find((e) => e.name === name);
       if (!found) return false;

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
@@ -132,28 +132,46 @@ describe("recordCall", () => {
     const data = plugin._store() as Record<string, unknown>;
     const state = data.toolLoading as { promoted: string[] };
     // Should appear exactly once
-    expect(state.promoted.filter((n) => n === "search_and_replace").length).toBe(1);
+    expect(
+      state.promoted.filter((n) => n === "search_and_replace").length,
+    ).toBe(1);
   });
 });
 
 describe("activateTool", () => {
   test("returns 'not_found' for unknown tool names", async () => {
     const plugin = makePlugin();
-    const result = await mgr.activateTool("nonexistent_tool", ALL_NAMES, plugin);
+    const result = await mgr.activateTool(
+      "nonexistent_tool",
+      ALL_NAMES,
+      plugin,
+    );
     expect(result).toBe("not_found");
   });
 
   test("returns 'already_active' if already in promoted list", async () => {
     const plugin = makePlugin({
-      toolLoading: { profile: "adaptive", counters: {}, promoted: ["search_and_replace"] },
+      toolLoading: {
+        profile: "adaptive",
+        counters: {},
+        promoted: ["search_and_replace"],
+      },
     });
-    const result = await mgr.activateTool("search_and_replace", ALL_NAMES, plugin);
+    const result = await mgr.activateTool(
+      "search_and_replace",
+      ALL_NAMES,
+      plugin,
+    );
     expect(result).toBe("already_active");
   });
 
   test("returns 'activated' and writes to promoted list", async () => {
     const plugin = makePlugin();
-    const result = await mgr.activateTool("search_and_replace", ALL_NAMES, plugin);
+    const result = await mgr.activateTool(
+      "search_and_replace",
+      ALL_NAMES,
+      plugin,
+    );
     expect(result).toBe("activated");
     const data = plugin._store() as Record<string, unknown>;
     const state = data.toolLoading as { promoted: string[] };

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
@@ -41,10 +41,7 @@ export class ToolLoadingManager {
     return mergeState(raw);
   }
 
-  getActiveToolNames(
-    allNames: string[],
-    state: ToolLoadingState,
-  ): Set<string> {
+  getActiveToolNames(allNames: string[], state: ToolLoadingState): Set<string> {
     const base = new Set<string>(META_TOOLS);
     if (state.profile === "all") {
       for (const n of allNames) base.add(n);

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
@@ -30,7 +30,10 @@ export async function activateToolHandler({
   registry: RegistryLike;
   plugin: PluginLike;
   server: McpServer;
-}): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+}): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
   const allEntries = registry.listAll();
   const found = allEntries.find((e) => e.name === args.name);
 
@@ -49,7 +52,10 @@ export async function activateToolHandler({
   if (found.enabled) {
     return {
       content: [
-        { type: "text", text: "Tool is already active in the current session." },
+        {
+          type: "text",
+          text: "Tool is already active in the current session.",
+        },
       ],
     };
   }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/chunker.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/chunker.test.ts
@@ -307,9 +307,9 @@ describe("makeChunkerForProvider", () => {
     // chunker default (512) — proves the override actually raises the cap.
     const content = `# Body\n\n${lorem(800)}`;
     const chunkerDefault = await chunk(content);
-    const chunkerLargeBudget = await makeChunkerForProvider(
-      stubProvider(2048),
-    )(content);
+    const chunkerLargeBudget = await makeChunkerForProvider(stubProvider(2048))(
+      content,
+    );
     // Default config splits an 800-token section; the larger budget keeps
     // it as one chunk because 800 < 2032.
     expect(chunkerDefault.length).toBeGreaterThan(1);

--- a/packages/obsidian-plugin/src/features/semantic-search/services/chunker.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/chunker.ts
@@ -440,9 +440,7 @@ const MIN_CHUNK_MAX_TOKENS = 64;
  * accounts for the task-prompt prefix prepended at embed time, so the
  * rendered prompted text stays within the model's hard cap.
  */
-export function makeChunkerForProvider(
-  provider: EmbeddingProvider,
-): ChunkerFn {
+export function makeChunkerForProvider(provider: EmbeddingProvider): ChunkerFn {
   let logged = false;
   return async (content: string): Promise<Chunk[]> => {
     const maxInputTokens = await provider.getMaxInputTokens();

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
@@ -303,7 +303,6 @@ describe("MultilingualE5Provider", () => {
     expect(await provider.getMaxInputTokens()).toBe(512);
   });
 
-
   test("getModelSizeBytes returns 60 MB", () => {
     const { factory } = makeMockFactory(768);
     expect(createMultilingualE5Provider(factory).getModelSizeBytes()).toBe(


### PR DESCRIPTION
## What

Pure `prettier --write` pass over the 7 files that had drifted out of Prettier 3.8.3 compliance. Whitespace only — no logic change.

## Why

`bun run format:check` (the gate added in #162) is currently **failing on `main`**: the last several CI runs, including `dd5313a` / 0.14.1, are red because `prettier --check` flags these 7 files:

- `features/adaptive-tool-loading/applyAdaptiveFilter.test.ts`
- `features/adaptive-tool-loading/toolLoadingManager.ts`
- `features/adaptive-tool-loading/toolLoadingManager.test.ts`
- `features/mcp-tools/tools/activateTool.ts`
- `features/semantic-search/services/chunker.ts`
- `features/semantic-search/services/chunker.test.ts`
- `features/semantic-search/services/transformersProvider.test.ts`

The differences are formatting-only (single-param signature wrapping under the current print width), which suggests they were committed under a slightly different Prettier minor and not re-run through `format`. This restores a green `format:check`.

## Verification

- `bun run format:check` → all matched files clean
- `bun run check` → green (whitespace change cannot affect types, but confirmed)
- `git diff` is exclusively whitespace/line-wrapping

Spotted while preparing #244 (RFC #238) — kept separate so that PR stays scoped to the feature. Either can merge first.
