### PR TITLE
fix(adaptive-loading): exclude activate_tool from core profile

### DIFF
--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { applyAdaptiveFilter } from "./applyAdaptiveFilter";
-import { META_TOOLS } from "./constants";
+import {
+  ADAPTIVE_META_TOOLS,
+  ALWAYS_ACTIVE_TOOLS,
+  META_TOOLS,
+} from "./constants";
 
 type FakeEntry = { name: string; description: string; enabled: boolean };
 
@@ -53,16 +57,19 @@ describe("applyAdaptiveFilter", () => {
     expect(registry._disabled()).toHaveLength(0);
   });
 
-  test("core profile: non-core tools disabled, meta-tools stay enabled", async () => {
+  test("core profile: tool_catalog stays enabled, activate_tool is disabled", async () => {
     const registry = makeRegistry(ALL_TOOLS);
     const plugin = makePlugin({ profile: "core", counters: {}, promoted: [] });
     await applyAdaptiveFilter(registry, plugin);
 
-    // Meta-tools must NOT be disabled
-    for (const m of META_TOOLS) {
+    // tool_catalog always active
+    for (const m of ALWAYS_ACTIVE_TOOLS) {
       expect(registry._disabled()).not.toContain(m);
     }
-
+    // activate_tool must be disabled in core
+    for (const m of ADAPTIVE_META_TOOLS) {
+      expect(registry._disabled()).toContain(m);
+    }
     // Non-core domain tools must be disabled
     expect(registry._disabled()).toContain("search_and_replace");
     expect(registry._disabled()).toContain("find_broken_links");

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/constants.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/constants.ts
@@ -1,6 +1,16 @@
 export const PROMOTION_THRESHOLD = 3;
 
-export const META_TOOLS: readonly string[] = ["tool_catalog", "activate_tool"];
+/** Always active regardless of profile — informational, no side effects. */
+export const ALWAYS_ACTIVE_TOOLS: readonly string[] = ["tool_catalog"];
+
+/** Active only in adaptive and all profiles — can expand the tool surface. */
+export const ADAPTIVE_META_TOOLS: readonly string[] = ["activate_tool"];
+
+/** Combined set used for promotion-exclusion checks in recordCall. */
+export const META_TOOLS: readonly string[] = [
+  ...ALWAYS_ACTIVE_TOOLS,
+  ...ADAPTIVE_META_TOOLS,
+];
 
 export const CORE_SET: readonly string[] = [
   "get_server_info",

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { ToolLoadingManager } from "./toolLoadingManager";
-import { CORE_SET, META_TOOLS, PROMOTION_THRESHOLD } from "./constants";
+import {
+  ADAPTIVE_META_TOOLS,
+  ALWAYS_ACTIVE_TOOLS,
+  CORE_SET,
+  META_TOOLS,
+  PROMOTION_THRESHOLD,
+} from "./constants";
 
 const ALL_NAMES = [
   "get_server_info",
@@ -36,12 +42,16 @@ describe("getActiveToolNames", () => {
     }
   });
 
-  test("core profile: returns only CORE_SET and META_TOOLS", () => {
+  test("core profile: returns CORE_SET plus tool_catalog only", () => {
     const state = { profile: "core" as const, counters: {}, promoted: [] };
     const active = mgr.getActiveToolNames(ALL_NAMES, state);
-    // Every meta-tool must be active
-    for (const m of META_TOOLS) {
+    // tool_catalog always active
+    for (const m of ALWAYS_ACTIVE_TOOLS) {
       expect(active.has(m)).toBe(true);
+    }
+    // activate_tool must NOT be active in core
+    for (const m of ADAPTIVE_META_TOOLS) {
+      expect(active.has(m)).toBe(false);
     }
     // Non-core, non-meta tools must be inactive
     expect(active.has("search_and_replace")).toBe(false);
@@ -64,13 +74,28 @@ describe("getActiveToolNames", () => {
     }
   });
 
-  test("meta-tools always active regardless of profile", () => {
+  test("tool_catalog always active regardless of profile", () => {
     for (const profile of ["all", "core", "adaptive"] as const) {
       const state = { profile, counters: {}, promoted: [] };
       const active = mgr.getActiveToolNames(ALL_NAMES, state);
-      for (const m of META_TOOLS) {
+      for (const m of ALWAYS_ACTIVE_TOOLS) {
         expect(active.has(m)).toBe(true);
       }
+    }
+  });
+
+  test("activate_tool active for all and adaptive profiles, not core", () => {
+    for (const profile of ["all", "adaptive"] as const) {
+      const state = { profile, counters: {}, promoted: [] };
+      const active = mgr.getActiveToolNames(ALL_NAMES, state);
+      for (const m of ADAPTIVE_META_TOOLS) {
+        expect(active.has(m)).toBe(true);
+      }
+    }
+    const coreState = { profile: "core" as const, counters: {}, promoted: [] };
+    const coreActive = mgr.getActiveToolNames(ALL_NAMES, coreState);
+    for (const m of ADAPTIVE_META_TOOLS) {
+      expect(coreActive.has(m)).toBe(false);
     }
   });
 });

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
@@ -1,4 +1,10 @@
-import { CORE_SET, META_TOOLS, PROMOTION_THRESHOLD } from "./constants";
+import {
+  ADAPTIVE_META_TOOLS,
+  ALWAYS_ACTIVE_TOOLS,
+  CORE_SET,
+  META_TOOLS,
+  PROMOTION_THRESHOLD,
+} from "./constants";
 
 export type ToolLoadingState = {
   profile: "all" | "core" | "adaptive";
@@ -42,13 +48,13 @@ export class ToolLoadingManager {
   }
 
   getActiveToolNames(allNames: string[], state: ToolLoadingState): Set<string> {
-    const base = new Set<string>(META_TOOLS);
     if (state.profile === "all") {
-      for (const n of allNames) base.add(n);
-      return base;
+      return new Set<string>([...META_TOOLS, ...allNames]);
     }
+    const base = new Set<string>(ALWAYS_ACTIVE_TOOLS);
     for (const n of CORE_SET) base.add(n);
     if (state.profile === "adaptive") {
+      for (const n of ADAPTIVE_META_TOOLS) base.add(n);
       for (const n of state.promoted) base.add(n);
     }
     return base;


### PR DESCRIPTION
## Summary

- Splits `META_TOOLS` into `ALWAYS_ACTIVE_TOOLS` (`tool_catalog`) and `ADAPTIVE_META_TOOLS` (`activate_tool`)
- Core profile now exposes only `tool_catalog`; `activate_tool` is active only in adaptive and all profiles
- Updates `getActiveToolNames` in `ToolLoadingManager` to reflect the split
- Updates 4 tests to assert the new per-profile behavior

Closes #247 Fix 1.

## Test plan

- [ ] `bun test` — 22/22 pass
- [ ] Core profile: verify `activate_tool` is not in the active tool set
- [ ] Adaptive profile: verify `activate_tool` is still active
- [ ] All profile: verify all tools active as before