### PR TITLE
feat(adaptive-loading): show Notice when activate_tool promotes a tool

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
@@ -25,11 +25,13 @@ export async function activateToolHandler({
   registry,
   plugin,
   server,
+  onActivated,
 }: {
   arguments: { name: string };
   registry: RegistryLike;
   plugin: PluginLike;
   server: McpServer;
+  onActivated?: (toolName: string) => void;
 }): Promise<{
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
@@ -63,6 +65,7 @@ export async function activateToolHandler({
   const allNames = allEntries.map((e) => e.name);
   const mgr = new ToolLoadingManager();
   await mgr.activateTool(args.name, allNames, plugin);
+  onActivated?.(args.name);
 
   try {
     await server.server.notification({

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -7,7 +7,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { App } from "obsidian";
+import { Notice, type App } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import { logger } from "$/shared";
 import { ToolRegistryClass } from "./toolRegistry";
@@ -88,6 +88,8 @@ export async function createMcpService(
       registry,
       plugin: config.plugin,
       server,
+      onActivated: (name) =>
+        new Notice(`MCP Connector: "${name}" promoted to active`),
     }),
   );
 


### PR DESCRIPTION
## Summary

- Adds optional `onActivated` callback to `activateToolHandler` — keeps the handler testable without Obsidian globals
- `mcpServer` passes a `Notice` call so the user gets a real-time Obsidian notification when the model promotes a tool mid-session
- Message format: `MCP Connector: "<tool_name>" promoted to active`

Closes #247 Fix 2.

## Test plan

- [ ] `bun test` — 1142/1142 pass
- [ ] In Obsidian with adaptive profile: trigger `activate_tool` via MCP and verify the Notice appears
- [ ] Verify the Notice does not appear when the tool is already active (early return path)