### PR TITLE
feat(adaptive-loading): add persist param to activate_tool

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
@@ -6,9 +6,12 @@ export const activateToolSchema = type({
   name: '"activate_tool"',
   arguments: {
     name: type("string").describe("Exact name of the tool to activate."),
+    "persist?": type("boolean").describe(
+      "If true, write the promotion to data.json so it survives the session. Defaults to false (session-only, no reconnect needed).",
+    ),
   },
 }).describe(
-  "Promotes an inactive tool to active status so it appears in the next MCP session. Run tool_catalog first to see available tool names and their current status.",
+  "Promotes an inactive tool to active status. With persist=false (default) the tool is available immediately in this session only. With persist=true the promotion is saved and survives reconnects. Run tool_catalog first to see available tool names.",
 );
 
 type RegistryLike = {
@@ -26,12 +29,14 @@ export async function activateToolHandler({
   plugin,
   server,
   onActivated,
+  enableInRegistry,
 }: {
-  arguments: { name: string };
+  arguments: { name: string; persist?: boolean };
   registry: RegistryLike;
   plugin: PluginLike;
   server: McpServer;
   onActivated?: (toolName: string) => void;
+  enableInRegistry?: (name: string) => boolean;
 }): Promise<{
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
@@ -62,10 +67,33 @@ export async function activateToolHandler({
     };
   }
 
-  const allNames = allEntries.map((e) => e.name);
-  const mgr = new ToolLoadingManager();
-  await mgr.activateTool(args.name, allNames, plugin);
   onActivated?.(args.name);
+
+  if (args.persist === true) {
+    const allNames = allEntries.map((e) => e.name);
+    const mgr = new ToolLoadingManager();
+    await mgr.activateTool(args.name, allNames, plugin);
+
+    try {
+      await server.server.notification({
+        method: "notifications/tools/list_changed",
+      });
+    } catch {
+      // Stateless JSON transport may not support server-initiated notifications.
+      // The reconnect message in the response covers this case.
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: "Tool activated and saved. Reconnect the MCP server to use it in this session.",
+        },
+      ],
+    };
+  }
+
+  enableInRegistry?.(args.name);
 
   try {
     await server.server.notification({
@@ -73,14 +101,13 @@ export async function activateToolHandler({
     });
   } catch {
     // Stateless JSON transport may not support server-initiated notifications.
-    // The reconnect message in the response covers this case.
   }
 
   return {
     content: [
       {
         type: "text",
-        text: "Tool activated. Reconnect the MCP server to use it in this session.",
+        text: "Tool activated for this session. Available immediately — no reconnect needed.",
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -84,12 +84,14 @@ export async function createMcpService(
   );
   registry.register(activateToolSchema, async (request, { server }) =>
     activateToolHandler({
-      arguments: (request as { arguments: { name: string } }).arguments,
+      arguments: (request as { arguments: { name: string; persist?: boolean } })
+        .arguments,
       registry,
       plugin: config.plugin,
       server,
       onActivated: (name) =>
         new Notice(`MCP Connector: "${name}" promoted to active`),
+      enableInRegistry: (name) => registry.enableByName(name),
     }),
   );
 

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
@@ -156,6 +156,18 @@ export class ToolRegistryClass<
    * Useful for applying user-controlled disable lists (e.g. from an
    * env var) after all features have registered their tools.
    */
+  enableByName = (name: string): boolean => {
+    for (const schema of this.keys()) {
+      // @ts-expect-error We know the const property is present for a string
+      const toolName = schema.get("name").toJsonSchema().const as string;
+      if (toolName === name) {
+        this.enable(schema);
+        return true;
+      }
+    }
+    return false;
+  };
+
   disableByName = (name: string): boolean => {
     for (const schema of this.keys()) {
       // @ts-expect-error We know the const property is present for a string


### PR DESCRIPTION
## Summary

- Adds optional `persist` boolean to `activate_tool` (default `false`)
- `persist=false`: enables the tool in the registry immediately for the current session only, no `data.json` write, no reconnect needed
- `persist=true`: saves the promotion to `data.json` and survives session reconnects (previous behavior, now opt-in)
- Adds `enableByName` to `ToolRegistryClass`, mirroring `disableByName`
- Passes `enableInRegistry` callback from `mcpServer` to `activateToolHandler`

Closes #247 Fix 3.

## Test plan

- [ ] `bun test` — 1142/1142 pass
- [ ] `activate_tool` with no `persist` (default): tool appears in `tools/list` immediately, not in `data.json` promoted list
- [ ] `activate_tool` with `persist=true`: tool written to `data.json`, survives reconnect
- [ ] `activate_tool` on already-active tool: returns "already active" in both cases