### PR TITLE
fix(adaptive-loading): serialize data.json writes through globalSettingsMutex

### DIFF
--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
@@ -145,6 +145,21 @@ describe("recordCall", () => {
     expect(state.promoted).not.toContain("tool_catalog");
   });
 
+  test("concurrent recordCalls do not lose counter updates", async () => {
+    const plugin = makePlugin();
+    // Fire two read-modify-write cycles concurrently. Without the
+    // settings mutex both read the same "before" snapshot and the
+    // last writer clobbers the first one's counter (lost update).
+    await Promise.all([
+      mgr.recordCall("search_vault", plugin),
+      mgr.recordCall("get_active_file", plugin),
+    ]);
+    const data = plugin._store() as Record<string, unknown>;
+    const state = data.toolLoading as { counters: Record<string, number> };
+    expect(state.counters["search_vault"]).toBe(1);
+    expect(state.counters["get_active_file"]).toBe(1);
+  });
+
   test("does not re-promote an already-promoted tool", async () => {
     const plugin = makePlugin({
       toolLoading: {

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
@@ -1,3 +1,4 @@
+import { globalSettingsMutex } from "$/features/command-permissions/services/settingsLock";
 import {
   ADAPTIVE_META_TOOLS,
   ALWAYS_ACTIVE_TOOLS,
@@ -60,19 +61,26 @@ export class ToolLoadingManager {
     return base;
   }
 
+  // All mutating methods serialize their load→modify→save cycle through
+  // globalSettingsMutex: data.json is shared with every other feature, so
+  // an unserialized read-modify-write here can clobber another feature's
+  // slice (or lose a concurrent counter increment). See settingsLock.ts.
+
   async recordCall(toolName: string, plugin: PluginLike): Promise<void> {
-    const raw = (await plugin.loadData()) as Record<string, unknown> | null;
-    const state = mergeState(raw);
-    state.counters[toolName] = (state.counters[toolName] ?? 0) + 1;
-    if (
-      state.profile === "adaptive" &&
-      state.counters[toolName] >= PROMOTION_THRESHOLD &&
-      !state.promoted.includes(toolName) &&
-      !(META_TOOLS as string[]).includes(toolName)
-    ) {
-      state.promoted = [...state.promoted, toolName];
-    }
-    await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+    await globalSettingsMutex.run(async () => {
+      const raw = (await plugin.loadData()) as Record<string, unknown> | null;
+      const state = mergeState(raw);
+      state.counters[toolName] = (state.counters[toolName] ?? 0) + 1;
+      if (
+        state.profile === "adaptive" &&
+        state.counters[toolName] >= PROMOTION_THRESHOLD &&
+        !state.promoted.includes(toolName) &&
+        !(META_TOOLS as string[]).includes(toolName)
+      ) {
+        state.promoted = [...state.promoted, toolName];
+      }
+      await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+    });
   }
 
   async activateTool(
@@ -81,26 +89,32 @@ export class ToolLoadingManager {
     plugin: PluginLike,
   ): Promise<"activated" | "already_active" | "not_found"> {
     if (!allNames.includes(name)) return "not_found";
-    const raw = (await plugin.loadData()) as Record<string, unknown> | null;
-    const state = mergeState(raw);
-    if (state.promoted.includes(name)) return "already_active";
-    state.promoted = [...state.promoted, name];
-    await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
-    return "activated";
+    return globalSettingsMutex.run(async () => {
+      const raw = (await plugin.loadData()) as Record<string, unknown> | null;
+      const state = mergeState(raw);
+      if (state.promoted.includes(name)) return "already_active" as const;
+      state.promoted = [...state.promoted, name];
+      await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+      return "activated" as const;
+    });
   }
 
   async deactivateTool(name: string, plugin: PluginLike): Promise<void> {
-    const raw = (await plugin.loadData()) as Record<string, unknown> | null;
-    const state = mergeState(raw);
-    state.promoted = state.promoted.filter((n) => n !== name);
-    await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+    await globalSettingsMutex.run(async () => {
+      const raw = (await plugin.loadData()) as Record<string, unknown> | null;
+      const state = mergeState(raw);
+      state.promoted = state.promoted.filter((n) => n !== name);
+      await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+    });
   }
 
   async resetAll(plugin: PluginLike): Promise<void> {
-    const raw = (await plugin.loadData()) as Record<string, unknown> | null;
-    const state = mergeState(raw);
-    state.counters = {};
-    state.promoted = [];
-    await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+    await globalSettingsMutex.run(async () => {
+      const raw = (await plugin.loadData()) as Record<string, unknown> | null;
+      const state = mergeState(raw);
+      state.counters = {};
+      state.promoted = [];
+      await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Wraps the load-modify-save body of recordCall/activateTool/deactivateTool/resetAll in globalSettingsMutex.run()
- Fixes the lost-update race documented in AUDIT.md Phase 4 Finding 1 (MAJOR)
- Adds a concurrency regression test: two interleaved recordCalls, both counters must persist (fails without the fix)

## Test plan

- [x] bun run check clean
- [x] bun test: 1143 pass / 0 fail (baseline 1142 + 1 new)
- [x] New test red before fix, green after