### PR TITLE
fix(adaptive-loading): make activate_tool immediate on both persist paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to **MCP Connector** (formerly `obsidian-mcp-tools`) are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`activate_tool` activation is now immediate on both persist paths.** With `persist=true` the tool was written to `data.json` but not enabled in the live registry, and the response told the user to reconnect — which had no effect, since the registry is built once at plugin load. Both paths now enable the tool in the registry immediately; `persist` only controls whether the promotion also survives plugin reloads. Response and schema wording corrected accordingly ("until the plugin reloads" instead of "this session"). Dedicated test file added for the handler. (AUDIT.md Phase 4 Finding 2)
+- **Adaptive tool loading state writes serialize through the settings mutex.** Counter increments and promotions could be lost when two tool calls raced each other or another feature's settings write. (AUDIT.md Phase 4 Finding 1)
+
 ## [0.15.1] — 2026-06-09
 
 ### Fixed

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { activateToolHandler } from "./activateTool";
+
+function makeRegistry(
+  entries: { name: string; enabled: boolean }[],
+): Parameters<typeof activateToolHandler>[0]["registry"] {
+  return {
+    listAll: () =>
+      entries.map((e) => ({
+        name: e.name,
+        description: `${e.name} description`,
+        enabled: e.enabled,
+      })),
+  };
+}
+
+function makePlugin() {
+  let store: Record<string, unknown> = {};
+  return {
+    loadData: async () => ({ ...store }),
+    saveData: async (d: unknown) => {
+      store = { ...(d as Record<string, unknown>) };
+    },
+    _store: () => store,
+  };
+}
+
+function makeServer(): { server: McpServer; notifications: string[] } {
+  const notifications: string[] = [];
+  const server = {
+    server: {
+      notification: async (n: { method: string }) => {
+        notifications.push(n.method);
+      },
+    },
+  } as unknown as McpServer;
+  return { server, notifications };
+}
+
+const ENTRIES = [
+  { name: "search_vault", enabled: true },
+  { name: "find_broken_links", enabled: false },
+];
+
+describe("activateToolHandler", () => {
+  test("unknown tool returns isError without side effects", async () => {
+    const plugin = makePlugin();
+    const enabled: string[] = [];
+    const { server } = makeServer();
+    const result = await activateToolHandler({
+      arguments: { name: "nonexistent" },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: (n) => (enabled.push(n), true),
+    });
+    expect(result.isError).toBe(true);
+    expect(enabled).toHaveLength(0);
+    expect(plugin._store().toolLoading).toBeUndefined();
+  });
+
+  test("already-active tool returns early without side effects", async () => {
+    const plugin = makePlugin();
+    const enabled: string[] = [];
+    const { server } = makeServer();
+    const result = await activateToolHandler({
+      arguments: { name: "search_vault" },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: (n) => (enabled.push(n), true),
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("already active");
+    expect(enabled).toHaveLength(0);
+    expect(plugin._store().toolLoading).toBeUndefined();
+  });
+
+  test("persist=false enables in registry and does NOT write data.json", async () => {
+    const plugin = makePlugin();
+    const enabled: string[] = [];
+    const { server, notifications } = makeServer();
+    const result = await activateToolHandler({
+      arguments: { name: "find_broken_links" },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: (n) => (enabled.push(n), true),
+    });
+    expect(enabled).toEqual(["find_broken_links"]);
+    expect(plugin._store().toolLoading).toBeUndefined();
+    expect(notifications).toContain("notifications/tools/list_changed");
+    expect(result.content[0].text).toContain("until the plugin reloads");
+  });
+
+  test("persist=true enables in registry AND writes data.json", async () => {
+    const plugin = makePlugin();
+    const enabled: string[] = [];
+    const { server } = makeServer();
+    const result = await activateToolHandler({
+      arguments: { name: "find_broken_links", persist: true },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: (n) => (enabled.push(n), true),
+    });
+    expect(enabled).toEqual(["find_broken_links"]);
+    const state = plugin._store().toolLoading as { promoted: string[] };
+    expect(state.promoted).toContain("find_broken_links");
+    expect(result.content[0].text).toContain("survives plugin reloads");
+  });
+
+  test("onActivated fires on activation, not on early returns", async () => {
+    const plugin = makePlugin();
+    const activated: string[] = [];
+    const { server } = makeServer();
+    const opts = {
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      onActivated: (n: string) => activated.push(n),
+    };
+    await activateToolHandler({ arguments: { name: "nonexistent" }, ...opts });
+    await activateToolHandler({ arguments: { name: "search_vault" }, ...opts });
+    expect(activated).toHaveLength(0);
+    await activateToolHandler({
+      arguments: { name: "find_broken_links" },
+      ...opts,
+    });
+    expect(activated).toEqual(["find_broken_links"]);
+  });
+
+  test("notification failure is swallowed and activation still succeeds", async () => {
+    const plugin = makePlugin();
+    const server = {
+      server: {
+        notification: async () => {
+          throw new Error("stateless transport");
+        },
+      },
+    } as unknown as McpServer;
+    const result = await activateToolHandler({
+      arguments: { name: "find_broken_links" },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Tool activated");
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
@@ -7,11 +7,11 @@ export const activateToolSchema = type({
   arguments: {
     name: type("string").describe("Exact name of the tool to activate."),
     "persist?": type("boolean").describe(
-      "If true, write the promotion to data.json so it survives the session. Defaults to false (session-only, no reconnect needed).",
+      "If true, write the promotion to data.json so it survives plugin reloads. Defaults to false (in-memory until the plugin reloads, available immediately).",
     ),
   },
 }).describe(
-  "Promotes an inactive tool to active status. With persist=false (default) the tool is available immediately in this session only. With persist=true the promotion is saved and survives reconnects. Run tool_catalog first to see available tool names.",
+  "Promotes an inactive tool to active status. With persist=false (default) the tool is available immediately and stays active until the Obsidian plugin reloads. With persist=true the promotion is saved and survives plugin reloads. Run tool_catalog first to see available tool names.",
 );
 
 type RegistryLike = {
@@ -69,31 +69,17 @@ export async function activateToolHandler({
 
   onActivated?.(args.name);
 
+  // The registry lives for the whole plugin session, so flipping the tool
+  // on here makes it available immediately on either path. `persist` only
+  // controls whether the promotion is ALSO written to data.json so it
+  // survives plugin reloads.
+  enableInRegistry?.(args.name);
+
   if (args.persist === true) {
     const allNames = allEntries.map((e) => e.name);
     const mgr = new ToolLoadingManager();
     await mgr.activateTool(args.name, allNames, plugin);
-
-    try {
-      await server.server.notification({
-        method: "notifications/tools/list_changed",
-      });
-    } catch {
-      // Stateless JSON transport may not support server-initiated notifications.
-      // The reconnect message in the response covers this case.
-    }
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Tool activated and saved. Reconnect the MCP server to use it in this session.",
-        },
-      ],
-    };
   }
-
-  enableInRegistry?.(args.name);
 
   try {
     await server.server.notification({
@@ -101,13 +87,17 @@ export async function activateToolHandler({
     });
   } catch {
     // Stateless JSON transport may not support server-initiated notifications.
+    // Clients pick up the change on their next tools/list request.
   }
 
   return {
     content: [
       {
         type: "text",
-        text: "Tool activated for this session. Available immediately — no reconnect needed.",
+        text:
+          args.persist === true
+            ? "Tool activated and saved. Available immediately; survives plugin reloads."
+            : "Tool activated. Available immediately; stays active until the plugin reloads.",
       },
     ],
   };


### PR DESCRIPTION
## Summary

- persist=true now also enables the tool in the live registry — previously it only wrote data.json and told the user to reconnect, which had no effect (registry is built once at plugin load)
- persist becomes a pure "also save" flag; activation is immediate on both paths
- Schema and response wording corrected: lifetime is "until the plugin reloads", not "this session"
- New dedicated activateTool.test.ts: 6 tests (not_found, already-active, persist=false no data.json write, persist=true writes data.json, onActivated gating, swallowed notification failure)
- CHANGELOG Unreleased entries for this and the Batch 1 mutex fix

AUDIT.md Phase 4 Finding 2 (Batch 3).

## Test plan

- [x] bun run check clean
- [x] bun test: 1149 pass / 0 fail (1143 + 6 new)