### PR TITLE
refactor(types): consolidate duplicate PluginLike/RegistryLike definitions

### DIFF
--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/types.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/types.ts
@@ -8,4 +8,12 @@ declare module "obsidian" {
   }
 }
 
-export {};
+/**
+ * Minimal structural view of the tool registry used by the
+ * adaptive-loading meta-tools. Defined here (not as the concrete
+ * ToolRegistryClass type) so handlers stay testable with plain mocks.
+ * Extend locally where a consumer needs more (e.g. disableByName).
+ */
+export type RegistryLike = {
+  listAll: () => { name: string; description: string; enabled: boolean }[];
+};

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
@@ -1,5 +1,6 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
+import type { PluginLike } from "$/features/adaptive-tool-loading/toolLoadingManager";
 import { globalSettingsMutex } from "$/features/command-permissions";
 import { logger } from "$/shared/logger";
 import {
@@ -62,11 +63,6 @@ const defaultRunner: ExecRunner = (file, args, options) => {
     opts?: { timeout?: number; env?: NodeJS.ProcessEnv },
   ) => Promise<{ stdout: string; stderr: string }>;
   return execFile_(file, args, options);
-};
-
-type PluginLike = {
-  loadData: () => Promise<unknown>;
-  saveData: (data: unknown) => Promise<void>;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
@@ -1,6 +1,10 @@
 import { type } from "arktype";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ToolLoadingManager } from "$/features/adaptive-tool-loading/toolLoadingManager";
+import {
+  ToolLoadingManager,
+  type PluginLike,
+} from "$/features/adaptive-tool-loading/toolLoadingManager";
+import type { RegistryLike } from "$/features/adaptive-tool-loading/types";
 
 export const activateToolSchema = type({
   name: '"activate_tool"',
@@ -13,15 +17,6 @@ export const activateToolSchema = type({
 }).describe(
   "Promotes an inactive tool to active status. With persist=false (default) the tool is available immediately and stays active until the Obsidian plugin reloads. With persist=true the promotion is saved and survives plugin reloads. Run tool_catalog first to see available tool names.",
 );
-
-type RegistryLike = {
-  listAll: () => { name: string; description: string; enabled: boolean }[];
-};
-
-type PluginLike = {
-  loadData: () => Promise<unknown>;
-  saveData: (data: unknown) => Promise<void>;
-};
 
 export async function activateToolHandler({
   arguments: args,

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/toolCatalog.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/toolCatalog.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import type { RegistryLike } from "$/features/adaptive-tool-loading/types";
 
 export const toolCatalogSchema = type({
   name: '"tool_catalog"',
@@ -14,10 +15,8 @@ type ToolEntry = {
   description?: string;
 };
 
-type RegistryLike = {
-  listAll: () => { name: string; description: string; enabled: boolean }[];
-};
-
+// Read-only persistence view — intentionally narrower than the shared
+// PluginLike (no saveData): the catalog never writes.
 type PluginLike = {
   loadData: () => Promise<unknown>;
 };


### PR DESCRIPTION
## Summary

- RegistryLike exported from adaptive-tool-loading/types.ts, reused in activateTool.ts and toolCatalog.ts (were identical copies)
- PluginLike imported from toolLoadingManager.ts in activateTool.ts and preWarm.ts (were exact copies)
- Read-only subset in toolCatalog.ts and extended variant in autoWrite.ts intentionally stay local (documented inline)

No behavior change. AUDIT.md Phase 3 (Batch 4).

## Test plan

- [x] bun run check clean
- [x] bun test: 1149 pass / 0 fail