### PR TITLE
refactor(mcp-tools): extract shared response builders

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import {
+  errorJson,
+  errorText,
+  successJson,
+  successText,
+} from "./responseBuilders";
+
+describe("responseBuilders", () => {
+  test("errorText wraps the message and sets isError", () => {
+    expect(errorText("File not found: a.md")).toEqual({
+      content: [{ type: "text", text: "File not found: a.md" }],
+      isError: true,
+    });
+  });
+
+  test("errorJson keeps the error/errorCode/extras key order", () => {
+    const result = errorJson("File not found", "file_not_found", {
+      path: "a.md",
+    });
+    expect(result.isError).toBe(true);
+    // Byte-identical to the inline JSON.stringify({error, errorCode, path}, null, 2)
+    // shape used by the property tools.
+    expect(result.content[0].text).toBe(
+      JSON.stringify(
+        { error: "File not found", errorCode: "file_not_found", path: "a.md" },
+        null,
+        2,
+      ),
+    );
+  });
+
+  test("successText wraps plain text without isError", () => {
+    const result = successText("OK");
+    expect(result).toEqual({ content: [{ type: "text", text: "OK" }] });
+    expect("isError" in result).toBe(false);
+  });
+
+  test("successJson pretty-prints with 2-space indent", () => {
+    const result = successJson({ a: 1 });
+    expect(result.content[0].text).toBe('{\n  "a": 1\n}');
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared MCP tool response builders.
+ *
+ * The same three shapes were copy-pasted (with drift) across the tool
+ * handlers: a plain-text error, a JSON-stringified payload, and a plain
+ * text success. Centralizing them keeps the wire format identical in
+ * every tool. The exact message strings stay at the call sites — these
+ * helpers only own the envelope.
+ */
+
+export type ToolResponse = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+/** Plain-text error: `{ content: [text], isError: true }`. */
+export function errorText(message: string): ToolResponse & { isError: true } {
+  return {
+    content: [{ type: "text", text: message }],
+    isError: true,
+  };
+}
+
+/**
+ * JSON error payload (pretty-printed, 2-space indent) with a stable
+ * `error` + `errorCode` shape, plus any extra context fields.
+ */
+export function errorJson(
+  error: string,
+  errorCode: string,
+  extras?: Record<string, unknown>,
+): ToolResponse & { isError: true } {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ error, errorCode, ...extras }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+/** Plain-text success: `{ content: [text] }`. */
+export function successText(text: string): ToolResponse {
+  return {
+    content: [{ type: "text", text }],
+  };
+}
+
+/** JSON success payload, pretty-printed with 2-space indent. */
+export function successJson(value: unknown): ToolResponse {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+  };
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultFile.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype";
 import type { App } from "obsidian";
+import { errorText, successText } from "../services/responseBuilders";
 
 export const deleteVaultFileSchema = type({
   name: '"delete_vault_file"',
@@ -23,13 +24,8 @@ export async function deleteVaultFileHandler(
 }> {
   const file = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
   if (!file) {
-    return {
-      content: [
-        { type: "text", text: `File not found: ${ctx.arguments.path}` },
-      ],
-      isError: true,
-    };
+    return errorText(`File not found: ${ctx.arguments.path}`);
   }
   await ctx.app.fileManager.trashFile(file);
-  return { content: [{ type: "text", text: "OK" }] };
+  return successText("OK");
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype";
 import { TFile, type App } from "obsidian";
+import { errorText, successJson } from "../services/responseBuilders";
 
 export const getOutgoingLinksSchema = type({
   name: '"get_outgoing_links"',
@@ -50,16 +51,10 @@ export async function getOutgoingLinksHandler(
   const sourcePath = ctx.arguments.path;
   const abstract = ctx.app.vault.getAbstractFileByPath(sourcePath);
   if (!abstract) {
-    return {
-      content: [{ type: "text", text: `File not found: ${sourcePath}` }],
-      isError: true,
-    };
+    return errorText(`File not found: ${sourcePath}`);
   }
   if (!(abstract instanceof TFile)) {
-    return {
-      content: [{ type: "text", text: `Path is a folder: ${sourcePath}` }],
-      isError: true,
-    };
+    return errorText(`Path is a folder: ${sourcePath}`);
   }
   const file = abstract;
 
@@ -127,7 +122,5 @@ export async function getOutgoingLinksHandler(
     links: filtered,
   };
 
-  return {
-    content: [{ type: "text", text: JSON.stringify(output, null, 2) }],
-  };
+  return successJson(output);
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
@@ -1,5 +1,12 @@
 import { type } from "arktype";
 import { TFile, type App } from "obsidian";
+// Response envelopes shared across tools — aliased to the original local
+// names to keep this file's call sites stable.
+import {
+  errorText as errorResponse,
+  successJson as jsonResponse,
+  successText as textResponse,
+} from "../services/responseBuilders";
 
 export const getVaultFilePartialSchema = type({
   name: '"get_vault_file_partial"',
@@ -44,32 +51,6 @@ type MockCache = {
   blocks?: Record<string, MockBlock>;
   frontmatter?: Record<string, unknown>;
 };
-
-function errorResponse(message: string): {
-  content: Array<{ type: "text"; text: string }>;
-  isError: true;
-} {
-  return {
-    content: [{ type: "text", text: message }],
-    isError: true,
-  };
-}
-
-function jsonResponse(value: unknown): {
-  content: Array<{ type: "text"; text: string }>;
-} {
-  return {
-    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
-  };
-}
-
-function textResponse(text: string): {
-  content: Array<{ type: "text"; text: string }>;
-} {
-  return {
-    content: [{ type: "text", text }],
-  };
-}
 
 /**
  * Find the heading entry that matches a target path. `target` may be a single


### PR DESCRIPTION
## Summary

- New services/responseBuilders.ts: errorText, errorJson, successText, successJson — envelope only, message strings stay at call sites
- errorJson preserves the exact {error, errorCode, ...extras} key order used by the property tools (asserted byte-identical in tests)
- First consumers migrated: getVaultFilePartial (replaces its local helpers), deleteVaultFile, getOutgoingLinks
- 4 new unit tests for the builders

Remaining handler migrations are mechanical follow-ups; kept out to keep this PR reviewable.

AUDIT.md Phase 3 (Batch 5).

## Test plan

- [x] bun run check clean
- [x] bun test: 1153 pass / 0 fail (1149 + 4 new)
- [x] Existing tool tests pass unchanged — response payloads byte-identical