### PR TITLE
docs: fix release badge rendering with display_name=tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Connector for Obsidian
 
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/istefox/obsidian-mcp-connector)](https://github.com/istefox/obsidian-mcp-connector/releases/latest)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/istefox/obsidian-mcp-connector?display_name=tag)](https://github.com/istefox/obsidian-mcp-connector/releases/latest)
 [![Build status](https://img.shields.io/github/actions/workflow/status/istefox/obsidian-mcp-connector/release.yml)](https://github.com/istefox/obsidian-mcp-connector/actions)
 [![License](https://img.shields.io/github/license/istefox/obsidian-mcp-connector)](LICENSE)
 


### PR DESCRIPTION
The default shields.io github/v/release badge renders 'invalid' despite valid published releases (verified: workflow success, release non-draft, name/tag correct). The ?display_name=tag variant renders v0.15.2 correctly. One-line README change.