### PR TITLE
fix: resolve remaining scanner warnings in plugin source

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -301,7 +301,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001724", "", {}, "sha512-WqJo7p0TbHDOythNTqYujmaJTvtYRZrjpP8TCvH6Vb9CYJerJNKamKzIWOM4BkQatWj9H2lYulpdAQNBe7QhNA=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001797", "", {}, "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -483,7 +483,7 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
 
     "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
 
@@ -657,7 +657,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
@@ -828,6 +828,8 @@
     "@eslint/eslintrc/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "@modelcontextprotocol/sdk/hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
     "@types/fs-extra/@types/node": ["@types/node@20.17.10", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "caniuse-lite": "^1.0.30001724",
-    "hono": "^4.12.23"
+    "caniuse-lite": "^1.0.30001797",
+    "hono": "^4.12.25"
   },
   "devDependencies": {
-    "prettier": "^3.8.3"
+    "prettier": "^3.8.4"
   }
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/periodicNotesDetector.ts
@@ -1,6 +1,9 @@
 import type { App, TFile } from "obsidian";
 import { moment } from "obsidian";
-import type { Moment } from "moment";
+
+// Obsidian bundles moment and re-exports it; deriving the instance type
+// from the bundled export avoids importing the restricted "moment" package.
+type Moment = ReturnType<typeof moment>;
 import * as periodicNotesLib from "obsidian-daily-notes-interface";
 import { ensureParentFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.ts
@@ -1,5 +1,5 @@
 import { type } from "arktype";
-import type { App } from "obsidian";
+import { TFile, type App } from "obsidian";
 import {
   DATE_REGEX_BY_PERIOD,
   isValidPeriodicDate,
@@ -106,10 +106,26 @@ export async function getOrCreateDailyNoteHandler(
       isError: true,
     };
   }
-  // Null-check + `as TFile` cast per Stefano's heads-up: `instanceof TFile`
-  // is always false under the test mock.
-  const tfile = file as import("obsidian").TFile;
-  const content = await ctx.app.vault.cachedRead(tfile);
+  if (!(file instanceof TFile)) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              error: "Path is not a file",
+              errorCode: "not_a_file",
+              path: resolved.path,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
+  const content = await ctx.app.vault.cachedRead(file);
 
   return {
     content: [

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
@@ -77,6 +77,7 @@ export async function patchVaultFileHandler(
 
   // Strip `path` from the arguments before forwarding — applyPatch only needs
   // the patch-specific fields (operation, targetType, target, content, …).
-  const { path: _, ...patchArgs } = ctx.arguments;
-  return await applyPatch(ctx.app, file, patchArgs as PatchArgs);
+  const patchArgs = { ...ctx.arguments } as PatchArgs & { path?: string };
+  delete patchArgs.path;
+  return await applyPatch(ctx.app, file, patchArgs);
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
@@ -1,5 +1,5 @@
 import { type } from "arktype";
-import type { App, TFile } from "obsidian";
+import { TFile, type App } from "obsidian";
 
 import {
   planRename,
@@ -105,13 +105,14 @@ export async function renameHeadingHandler(ctx: RenameHeadingContext): Promise<{
   const { path, from, to } = ctx.arguments;
 
   // ── 1. Load source file ─────────────────────────────────────────────────
-  const sourceFile = ctx.app.vault.getAbstractFileByPath(path) as TFile | null;
-  if (!sourceFile) {
+  const sourceAbstract = ctx.app.vault.getAbstractFileByPath(path);
+  if (!(sourceAbstract instanceof TFile)) {
     return errorResponse({
       errorCode: "file-not-found",
       message: `Source file not found: ${path}`,
     });
   }
+  const sourceFile = sourceAbstract;
 
   const sourceText = await ctx.app.vault.cachedRead(sourceFile);
   const sourceCache = (ctx.app.metadataCache.getFileCache(sourceFile) ??
@@ -129,8 +130,8 @@ export async function renameHeadingHandler(ctx: RenameHeadingContext): Promise<{
 
   const backlinkerTexts: Record<string, string> = {};
   for (const bp of backlinkerPaths) {
-    const f = ctx.app.vault.getAbstractFileByPath(bp) as TFile | null;
-    if (!f) continue; // resolvedLinks can lag behind file deletes
+    const f = ctx.app.vault.getAbstractFileByPath(bp);
+    if (!(f instanceof TFile)) continue; // resolvedLinks can lag behind file deletes
     try {
       backlinkerTexts[bp] = await ctx.app.vault.cachedRead(f);
     } catch {
@@ -203,8 +204,8 @@ export async function renameHeadingHandler(ctx: RenameHeadingContext): Promise<{
   }
 
   for (const bp of plan.backlinkers) {
-    const f = ctx.app.vault.getAbstractFileByPath(bp.path) as TFile | null;
-    if (!f) {
+    const f = ctx.app.vault.getAbstractFileByPath(bp.path);
+    if (!(f instanceof TFile)) {
       failedFiles.push({
         path: bp.path,
         error: "Backlinker file disappeared between plan and apply.",


### PR DESCRIPTION
## Summary

Fixes every scanner warning that lives in our source:
- moment type import via Obsidian's bundled export (periodicNotesDetector)
- 3x instanceof TFile guards replacing casts (renameHeading)
- instanceof guard replacing the stale-comment cast (getOrCreateDailyNote)
- unused '_' binding removed (patchVaultFile)

Not fixable on our side (documented):
- 5x globalThis + 1x moment: inside bundled third-party code (transformers.js, obsidian-daily-notes-interface)
- 34 dependency advisories: runtime-relevant ones come via @modelcontextprotocol/sdk 1.29.0 (latest, no upstream fix); the rest are dev-only (typescript-eslint 5.x, archiver, svelte-preprocess)
- Shell Execution / FS Access / Vault Enumeration / Clipboard / eval: intrinsic capabilities, see AUDIT.md

## Test plan

- [x] bun run check clean
- [x] bun test: 1153 pass / 0 fail