### PR TITLE
chore(deps): override SDK transitives to patched versions (3 -> 0 advisories)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,8 @@
     "hono": "^4.12.23",
     "ip-address": "^10.1.1",
     "onnxruntime-web": "1.26.0",
+    "path-to-regexp": "^8.4.2",
+    "qs": "^6.15.2",
     "vite": "5.4.11",
   },
   "packages": {
@@ -441,7 +443,7 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
@@ -457,7 +459,7 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
     "queue-tick": ["queue-tick@1.0.1", "", {}, "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="],
 
@@ -562,8 +564,6 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
-    "@modelcontextprotocol/sdk/hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
     "@types/fs-extra/@types/node": ["@types/node@20.17.10", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA=="],
 

--- a/package.json
+++ b/package.json
@@ -25,15 +25,14 @@
     "release": "bun --filter '*' release",
     "zip": "bun --filter '*' zip"
   },
-  "patchedDependencies": {
-    "svelte@5.18.0": "patches/svelte@5.18.0.patch"
-  },
   "overrides": {
     "vite": "5.4.11",
     "onnxruntime-web": "1.26.0",
     "hono": "^4.12.23",
     "fast-uri": "^3.1.2",
-    "ip-address": "^10.1.1"
+    "ip-address": "^10.1.1",
+    "path-to-regexp": "^8.4.2",
+    "qs": "^6.15.2"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

- Overrides path-to-regexp to ^8.4.2 and qs to ^6.15.2 (patched releases exist; the SDK pins vulnerable versions)
- bun audit: 3 -> 0 vulnerabilities
- Removes the stale svelte@5.18.0 patchedDependencies entry (patch stopped applying after the svelte bump; redundant since bun.config.ts forces the browser export condition — bundle verified clean of server-runtime markers)

Note: patches/svelte@5.18.0.patch file is now orphaned, left in place pending explicit removal approval.

## Test plan

- [x] bun install clean
- [x] bun audit: No vulnerabilities found
- [x] bun run check clean
- [x] bun test: 1153 pass / 0 fail
- [x] bun run build (production) successful