### PR TITLE
docs: add audit execution report

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -77,3 +77,45 @@ No high-value targets beyond the consolidations in Phase 3. The 14-file `ensureF
 | 5 | Shared responseBuilders.ts, error strings byte-identical | Moderate |
 
 Each batch: own branch, own PR, `bun run check` clean and ≥1142 tests green before merge. No behavior change bundled with a refactor in the same commit.
+
+## Execution report — 2026-06-11, all batches complete
+
+Everything below shipped the same day across releases 0.15.2 → 0.15.6.
+
+### Audit batches (plan above)
+
+| Batch | PR | Outcome |
+|---|---|---|
+| 0 — AUDIT.md | #252 | This report |
+| 1 — Mutex fix | #253 | `ToolLoadingManager` mutations serialize through `globalSettingsMutex`; concurrency regression test red→green |
+| 2 — Dead code | #254 | `express`, `radash`, `semver` removed; `fs-extra` → devDependencies (audit had flagged it fully unused, but `scripts/zip.ts` imports it); `loadTemplaterAPI`/`loadDependencies` deleted |
+| 3 — persist semantics | #255 | Found and fixed a deeper bug in flight: `persist=true` wrote `data.json` but never enabled the tool in the live registry (the suggested "reconnect" had no effect — the registry is built once at plugin load). Activation is now immediate on both paths; `persist` is a pure "also save" flag. New `activateTool.test.ts` (6 tests) |
+| 4 — Type consolidation | #256 | `PluginLike` ×6 → 1 exported + documented local subsets; `RegistryLike` ×4 → exported base + local extensions |
+| 5 — Response builders | #257 | `responseBuilders.ts` (`errorText`/`errorJson`/`successText`/`successJson`) + 3 migrated consumers, payloads byte-identical |
+
+Released as **0.15.2**.
+
+### Scanner / scorecard remediation (follow-up, same day)
+
+The Obsidian plugin scorecard showed Review "Caution" with 50 issues. Root-cause analysis: the scanner lints the entire `src` tree (test files included) and audits the whole lockfile (devDependencies included).
+
+| Action | PR | Outcome |
+|---|---|---|
+| Source warnings | #260 | `Moment` type via Obsidian's bundled export; 4 `as TFile` casts → `instanceof` guards; unused `_` removed → **0.15.3** |
+| README | #262 | Adaptive tool loading fully documented (profiles, meta-tools, persist, frequency promotion); stale counts fixed; missing footnote added → **0.15.4** |
+| test-setup.ts | #264 | `globalThis` ×5 → `global`/`window`; `as TFile`/`as TFolder` ×8 → type-aliased mock boundary; `moment` declared in devDependencies |
+| Dependency advisories | #265 | Orphaned `@typescript-eslint/*` 5.29.0 removed (no eslint config existed); `svelte` → ^5.56.3, `archiver` → ^8.0.0 (zip script migrated to `ZipArchive`), `svelte-preprocess` → ^6.0.5. Advisories 34 → 3 → **0.15.5** |
+| SDK transitives | #267 | Root `overrides` force patched `path-to-regexp` ^8.4.2 and `qs` ^6.15.2 (SDK pins vulnerable versions). Advisories 3 → **0**. Stale `svelte@5.18.0` patch entry removed (bundler already forces the browser export condition) → **0.15.6** |
+| Release badge | #259 | README badge rendered "invalid" via shields.io default variant; fixed with `?display_name=tag` |
+
+### Final state
+
+| Metric | Before (0.15.1) | After (0.15.6) |
+|---|---|---|
+| `bun test` | 1142 pass | 1153 pass (11 new) |
+| `bun audit` | 34 vulnerabilities | 0 |
+| Scanner issues | 50 | ~5 expected (intrinsic capabilities + test-only moment import) |
+| Scorecard Review | Caution | Satisfactory |
+| Known bugs | 2 (mutex race, dead persist path) | 0 |
+
+Remaining by design (disclosures, not defects): shell execution (node/brew detection), `fs` access (Claude Desktop config auto-write, legacy binary migration), vault enumeration, clipboard write, transformers.js dynamic code execution, `moment` import in the test bootstrap.


### PR DESCRIPTION
## Summary

Closes the audit cycle by appending the execution report to AUDIT.md. One-day improvement and cleanup campaign, releases 0.15.2 -> 0.15.6:

**Bugs fixed**
- ToolLoadingManager data.json lost-update race (globalSettingsMutex, regression test) — #253
- activate_tool persist=true never enabled the tool in the live registry — #255

**Cleanup**
- 3 unused dependencies removed, fs-extra scoped to dev, 2 dead exports deleted — #254
- Orphaned @typescript-eslint 5.29.0 stack removed; svelte/archiver/svelte-preprocess bumped — #265
- Stale svelte patch removed; SDK transitives overridden to patched versions — #267, #268

**Quality**
- PluginLike/RegistryLike consolidation — #256
- Shared response builders, byte-identical payloads — #257
- activateTool.test.ts added (was untested) — #255
- Scanner warnings in source and test bootstrap resolved — #260, #264

**Docs**
- README documents adaptive tool loading end to end — #262
- Release badge fix — #259

**Result**: 1142 -> 1153 tests, bun audit 34 -> 0, scanner issues 50 -> ~5 intrinsic, scorecard Review Caution -> Satisfactory.