### PR TITLE
refactor(mcp-tools): migrate tool handlers to shared response builders

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.ts
@@ -10,7 +10,7 @@
 
 export type ToolResponse = {
   content: Array<{ type: "text"; text: string }>;
-  isError?: boolean;
+  isError?: true;
 };
 
 /** Plain-text error: `{ content: [text], isError: true }`. */

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ToolLoadingManager,
@@ -40,26 +41,11 @@ export async function activateToolHandler({
   const found = allEntries.find((e) => e.name === args.name);
 
   if (!found) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Unknown tool: '${args.name}'. Run tool_catalog to see available tools.`,
-        },
-      ],
-      isError: true,
-    };
+    return errorText(`Unknown tool: '${args.name}'. Run tool_catalog to see available tools.`);
   }
 
   if (found.enabled) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Tool is already active in the current session.",
-        },
-      ],
-    };
+    return successText("Tool is already active in the current session.");
   }
 
   onActivated?.(args.name);

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToActiveFile.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 import { normalizeAppendBody } from "$/features/mcp-tools/services/patchHelpers";
 
@@ -26,13 +27,10 @@ export async function appendToActiveFileHandler(
 }> {
   const file = ctx.app.workspace.getActiveFile();
   if (!file) {
-    return {
-      content: [{ type: "text", text: "No active file." }],
-      isError: true,
-    };
+    return errorText("No active file.");
   }
   const existing = await ctx.app.vault.read(file);
   const normalized = normalizeAppendBody(ctx.arguments.content, "append");
   await ctx.app.vault.modify(file, existing + normalized);
-  return { content: [{ type: "text", text: "OK" }] };
+  return successText("OK");
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText } from "../services/responseBuilders";
 import { TFile, type App } from "obsidian";
 import {
   DATE_REGEX_BY_PERIOD,
@@ -167,13 +168,5 @@ function errorPayload(
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
-      },
-    ],
-    isError: true,
-  };
+  return errorText(JSON.stringify({ error: message, errorCode, ...extras }, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToVaultFile.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import { TFile, type App } from "obsidian";
 import { normalizeAppendBody } from "$/features/mcp-tools/services/patchHelpers";
 import { ensureParentFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
@@ -31,15 +32,7 @@ export async function appendToVaultFileHandler(
 
   if (existing) {
     if (!(existing instanceof TFile)) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Path ${ctx.arguments.path} is a folder, not a file.`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`Path ${ctx.arguments.path} is a folder, not a file.`);
     }
     const current = await ctx.app.vault.read(existing);
     await ctx.app.vault.modify(existing, current + normalized);
@@ -47,5 +40,5 @@ export async function appendToVaultFileHandler(
     await ensureParentFolderExists(ctx.app, ctx.arguments.path);
     await ctx.app.vault.create(ctx.arguments.path, normalized);
   }
-  return { content: [{ type: "text", text: "OK" }] };
+  return successText("OK");
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultDirectory.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultDirectory.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 import { ensureFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
 
@@ -26,15 +27,7 @@ export async function createVaultDirectoryHandler(
 }> {
   const trimmed = ctx.arguments.path.replace(/^\/+|\/+$/g, "");
   if (!trimmed) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Path is empty after normalisation; cannot create the vault root.",
-        },
-      ],
-      isError: true,
-    };
+    return errorText("Path is empty after normalisation; cannot create the vault root.");
   }
 
   // If a file already exists at this path the request is ambiguous —
@@ -44,19 +37,11 @@ export async function createVaultDirectoryHandler(
     const isFolder =
       (existing as { children?: unknown }).children !== undefined;
     if (!isFolder) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `A file already exists at ${trimmed}; cannot create directory with the same path.`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`A file already exists at ${trimmed}; cannot create directory with the same path.`);
     }
-    return { content: [{ type: "text", text: "OK" }] };
+    return successText("OK");
   }
 
   await ensureFolderExists(ctx.app, trimmed);
-  return { content: [{ type: "text", text: "OK" }] };
+  return successText("OK");
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultFile.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import { TFile, type App } from "obsidian";
 import { ensureParentFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
 
@@ -30,20 +31,12 @@ export async function createVaultFileHandler(
   const existing = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
   if (existing) {
     if (!(existing instanceof TFile)) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Path ${ctx.arguments.path} is a folder, not a file.`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`Path ${ctx.arguments.path} is a folder, not a file.`);
     }
     await ctx.app.vault.modify(existing, ctx.arguments.content);
   } else {
     await ensureParentFolderExists(ctx.app, ctx.arguments.path);
     await ctx.app.vault.create(ctx.arguments.path, ctx.arguments.content);
   }
-  return { content: [{ type: "text", text: "OK" }] };
+  return successText("OK");
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteActiveFile.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const deleteActiveFileSchema = type({
@@ -21,11 +22,8 @@ export async function deleteActiveFileHandler(
 }> {
   const file = ctx.app.workspace.getActiveFile();
   if (!file) {
-    return {
-      content: [{ type: "text", text: "No active file." }],
-      isError: true,
-    };
+    return errorText("No active file.");
   }
   await ctx.app.fileManager.trashFile(file);
-  return { content: [{ type: "text", text: "OK" }] };
+  return successText("OK");
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteNoteProperty.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteNoteProperty.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successJson } from "../services/responseBuilders";
 import { TFile, type App } from "obsidian";
 
 export const deleteNotePropertySchema = type({
@@ -67,12 +68,5 @@ export async function deleteNotePropertyHandler(
     delete fm[key];
   });
 
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify({ path, key, action: "deleted" }, null, 2),
-      },
-    ],
-  };
+  return successJson({ path, key, action: "deleted" });
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const deleteVaultDirectorySchema = type({
@@ -28,15 +29,7 @@ export async function deleteVaultDirectoryHandler(
 }> {
   const trimmed = ctx.arguments.path.replace(/^\/+|\/+$/g, "");
   if (!trimmed) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Path is empty after normalisation; refusing to delete the vault root.",
-        },
-      ],
-      isError: true,
-    };
+    return errorText("Path is empty after normalisation; refusing to delete the vault root.");
   }
 
   const recursive = (ctx.arguments.recursive ?? "false") === "true";
@@ -48,15 +41,7 @@ export async function deleteVaultDirectoryHandler(
     const isFolder =
       (existing as { children?: unknown }).children !== undefined;
     if (!isFolder) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Path ${trimmed} is a file, not a directory. Use delete_vault_file instead.`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`Path ${trimmed} is a file, not a directory. Use delete_vault_file instead.`);
     }
   }
 
@@ -90,5 +75,5 @@ export async function deleteVaultDirectoryHandler(
     };
   }
 
-  return { content: [{ type: "text", text: "OK" }] };
+  return successText("OK");
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const executeDataviewQuerySchema = type({
@@ -155,13 +156,5 @@ function errorPayload(
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
-      },
-    ],
-    isError: true,
-  };
+  return errorText(JSON.stringify({ error: message, errorCode, ...extras }, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeObsidianCommand.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeObsidianCommand.ts
@@ -30,6 +30,7 @@
  */
 
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import { rateLimitTake } from "$/features/mcp-tools/services/rateLimit";
@@ -72,15 +73,7 @@ export async function executeObsidianCommandHandler(
   const rl = rateLimitTake();
   if (!rl.ok) {
     const waitSec = Math.ceil((rl.retryAfterMs ?? 0) / 1000);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Rate limit exceeded: too many command executions in the last minute. Retry in ${waitSec}s.`,
-        },
-      ],
-      isError: true,
-    };
+    return errorText(`Rate limit exceeded: too many command executions in the last minute. Retry in ${waitSec}s.`);
   }
 
   // --- 2. Permission check ---
@@ -96,15 +89,7 @@ export async function executeObsidianCommandHandler(
   };
 
   if (typeof pluginWithPermCheck.checkCommandPermission !== "function") {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Internal error: permission check not available on plugin.",
-        },
-      ],
-      isError: true,
-    };
+    return errorText("Internal error: permission check not available on plugin.");
   }
 
   const decision = await pluginWithPermCheck.checkCommandPermission(
@@ -115,15 +100,7 @@ export async function executeObsidianCommandHandler(
     const reason = decision.reason
       ? `: ${decision.reason}`
       : ". Command is denied or not allowed by plugin settings.";
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Command denied${reason}`,
-        },
-      ],
-      isError: true,
-    };
+    return errorText(`Command denied${reason}`);
   }
 
   // --- 3. Execute ---
@@ -138,23 +115,8 @@ export async function executeObsidianCommandHandler(
   const success = commandsApi.executeCommandById(ctx.arguments.commandId);
 
   if (!success) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Command not found: '${ctx.arguments.commandId}'. Use list_obsidian_commands to discover available commands.`,
-        },
-      ],
-      isError: true,
-    };
+    return errorText(`Command not found: '${ctx.arguments.commandId}'. Use list_obsidian_commands to discover available commands.`);
   }
 
-  return {
-    content: [
-      {
-        type: "text",
-        text: `Executed Obsidian command '${ctx.arguments.commandId}'.`,
-      },
-    ],
-  };
+  return successText(`Executed Obsidian command '${ctx.arguments.commandId}'.`);
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText } from "../services/responseBuilders";
 import { TFile, type App } from "obsidian";
 import { moment } from "obsidian";
 import type McpToolsPlugin from "$/main";
@@ -333,13 +334,5 @@ function errorPayload(
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
-      },
-    ],
-    isError: true,
-  };
+  return errorText(JSON.stringify({ error: message, errorCode, ...extras }, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import { requestUrl } from "obsidian";
 import TurndownService from "turndown";
 
@@ -123,10 +124,7 @@ export async function fetchHandler(ctx: FetchContext): Promise<{
 
   const urlError = validateFetchUrl(ctx.arguments.url);
   if (urlError) {
-    return {
-      content: [{ type: "text", text: `Fetch rejected: ${urlError}` }],
-      isError: true,
-    };
+    return errorText(`Fetch rejected: ${urlError}`);
   }
 
   let response;
@@ -149,25 +147,9 @@ export async function fetchHandler(ctx: FetchContext): Promise<{
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (message === "__FETCH_TIMEOUT__") {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Fetch failed: request timed out after ${REQUEST_TIMEOUT_MS}ms.`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`Fetch failed: request timed out after ${REQUEST_TIMEOUT_MS}ms.`);
     }
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Fetch failed: ${message}`,
-        },
-      ],
-      isError: true,
-    };
+    return errorText(`Fetch failed: ${message}`);
   }
 
   let body = response.text;
@@ -193,7 +175,5 @@ export async function fetchHandler(ctx: FetchContext): Promise<{
     ? `\n\n[Content truncated. ${totalLength - startIndex - maxLength} characters remaining; resume with startIndex=${startIndex + maxLength}.]`
     : "";
 
-  return {
-    content: [{ type: "text", text: sliced + truncationNote }],
-  };
+  return successText(sliced + truncationNote);
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getActiveFile.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const getActiveFileSchema = type({
@@ -21,17 +22,14 @@ export async function getActiveFileHandler(ctx: GetActiveFileContext): Promise<{
 }> {
   const file = ctx.app.workspace.getActiveFile();
   if (!file) {
-    return {
-      content: [{ type: "text", text: "No active file." }],
-      isError: true,
-    };
+    return errorText("No active file.");
   }
 
   const content = await ctx.app.vault.read(file);
 
   // Plain markdown — return raw content, no parsing overhead.
   if (ctx.arguments.format !== "json") {
-    return { content: [{ type: "text", text: content }] };
+    return successText(content);
   }
 
   // JSON shape: matches the ApiNoteJson contract (content, frontmatter, path,
@@ -59,7 +57,5 @@ export async function getActiveFileHandler(ctx: GetActiveFileContext): Promise<{
     },
   };
 
-  return {
-    content: [{ type: "text", text: JSON.stringify(body, null, 2) }],
-  };
+  return successText(JSON.stringify(body, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getBacklinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getBacklinks.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const getBacklinksSchema = type({
@@ -88,7 +89,5 @@ export async function getBacklinksHandler(ctx: GetBacklinksContext): Promise<{
     backlinks,
   };
 
-  return {
-    content: [{ type: "text", text: JSON.stringify(output, null, 2) }],
-  };
+  return successText(JSON.stringify(output, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getFilesByTag.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getFilesByTag.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const getFilesByTagSchema = type({
@@ -29,15 +30,7 @@ export async function getFilesByTagHandler(ctx: GetFilesByTagContext): Promise<{
   // the lookup contract.
   const normalized = ctx.arguments.tag.trim().replace(/^#+/, "").toLowerCase();
   if (!normalized) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: 'Invalid tag: input is empty or contains only "#" characters.',
-        },
-      ],
-      isError: true,
-    };
+    return errorText('Invalid tag: input is empty or contains only "#" characters.');
   }
 
   const includeNested = (ctx.arguments.includeNested ?? "true") === "true";
@@ -99,7 +92,5 @@ export async function getFilesByTagHandler(ctx: GetFilesByTagContext): Promise<{
     files: counts,
   };
 
-  return {
-    content: [{ type: "text", text: JSON.stringify(output, null, 2) }],
-  };
+  return successText(JSON.stringify(output, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 import type { App, TFile } from "obsidian";
 import { logger } from "$/shared/logger";
 
@@ -99,7 +100,5 @@ export async function getRecentFilesHandler(
 
   const output = { totalFiles, files };
 
-  return {
-    content: [{ type: "text", text: JSON.stringify(output, null, 2) }],
-  };
+  return successText(JSON.stringify(output, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getServerInfo.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getServerInfo.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 
 export const getServerInfoSchema = type({
   name: '"get_server_info"',
@@ -35,7 +36,5 @@ export async function getServerInfoHandler(
     transport: "streamable-http",
     ...(localTransport ? { localTransport } : {}),
   };
-  return {
-    content: [{ type: "text", text: JSON.stringify(body, null, 2) }],
-  };
+  return successText(JSON.stringify(body, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listObsidianCommands.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listObsidianCommands.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const listObsidianCommandsSchema = type({
@@ -39,7 +40,5 @@ export async function listObsidianCommandsHandler(
       )
     : all;
 
-  return {
-    content: [{ type: "text", text: JSON.stringify({ commands }, null, 2) }],
-  };
+  return successText(JSON.stringify({ commands }, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const listTagsSchema = type({
@@ -55,7 +56,5 @@ export async function listTagsHandler(
     tags: sorted.map(([tag, count]) => ({ tag, count })),
   };
 
-  return {
-    content: [{ type: "text", text: JSON.stringify(output, null, 2) }],
-  };
+  return successText(JSON.stringify(output, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listVaultFiles.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listVaultFiles.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const listVaultFilesSchema = type({
@@ -29,7 +30,5 @@ export async function listVaultFilesHandler(
     ? all.filter((f) => f.path.startsWith(prefix)).map((f) => f.path)
     : all.map((f) => f.path);
 
-  return {
-    content: [{ type: "text", text: JSON.stringify({ files }, null, 2) }],
-  };
+  return successText(JSON.stringify({ files }, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App, TFile } from "obsidian";
 import {
   resolveHeadingPath,
@@ -54,10 +55,7 @@ export async function patchActiveFileHandler(
 }> {
   const file = ctx.app.workspace.getActiveFile();
   if (!file) {
-    return {
-      content: [{ type: "text", text: "No active file." }],
-      isError: true,
-    };
+    return errorText("No active file.");
   }
   return await applyPatch(ctx.app, file, ctx.arguments);
 }
@@ -123,12 +121,9 @@ export async function applyPatch(
           : args.content + String(existing);
     });
     if (rejection !== null) {
-      return {
-        content: [{ type: "text", text: rejection }],
-        isError: true,
-      };
+      return errorText(rejection);
     }
-    return { content: [{ type: "text", text: "OK" }] };
+    return successText("OK");
   }
 
   const fileContent = await app.vault.read(file);
@@ -139,22 +134,14 @@ export async function applyPatch(
     const fullPath = resolveHeadingPath(fileContent, args.target, delimiter);
 
     if (!fullPath && !createIfMissing) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Heading "${args.target}" not found and createTargetIfMissing=false.`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`Heading "${args.target}" not found and createTargetIfMissing=false.`);
     }
 
     if (!fullPath) {
       // Target heading not found — append at EOF (createIfMissing=true path).
       const normalized = normalizeAppendBody(args.content, args.operation);
       await app.vault.modify(file, fileContent + normalized);
-      return { content: [{ type: "text", text: "OK" }] };
+      return successText("OK");
     }
 
     // Resolve the leaf name from the full path and locate the heading line.
@@ -184,15 +171,7 @@ export async function applyPatch(
       !args.allowRootHeadings &&
       hasAnyH1(lines)
     ) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Heading "${args.target}" is a level-${headingLevel} heading with no level-1 (#) parent, while the document does contain an H1 elsewhere — the section boundary is ambiguous. Refusing to patch. Pass allowRootHeadings:true to target it explicitly, or createTargetIfMissing:true to bypass. (Files with no H1 at all are accepted automatically.)`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`Heading "${args.target}" is a level-${headingLevel} heading with no level-1 (#) parent, while the document does contain an H1 elsewhere — the section boundary is ambiguous. Refusing to patch. Pass allowRootHeadings:true to target it explicitly, or createTargetIfMissing:true to bypass. (Files with no H1 at all are accepted automatically.)`);
     }
 
     // Find end of this heading's section: next heading at same-or-higher level.
@@ -245,7 +224,7 @@ export async function applyPatch(
     }
 
     await app.vault.modify(file, lines.join("\n"));
-    return { content: [{ type: "text", text: "OK" }] };
+    return successText("OK");
   }
 
   // --- block branch ---
@@ -254,22 +233,14 @@ export async function applyPatch(
     const pos = findBlockPositionFromCache(cache, args.target);
 
     if (!pos && !createIfMissing) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Block "^${args.target}" not found in active file (createTargetIfMissing=false).`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`Block "^${args.target}" not found in active file (createTargetIfMissing=false).`);
     }
 
     if (!pos) {
       // Block not found — append at EOF (createIfMissing=true path).
       const normalized = normalizeAppendBody(args.content, args.operation);
       await app.vault.modify(file, fileContent + normalized);
-      return { content: [{ type: "text", text: "OK" }] };
+      return successText("OK");
     }
 
     // 0.3.x parity: reject when block resolves inside a table or fenced code
@@ -277,15 +248,7 @@ export async function applyPatch(
     // see fork #81, #83. 0.4.3 fork #84: full block range
     // check, not just startLine — see range wrapper in patchHelpers.ts.
     if (isBlockRangeStructurallyUnsafe(lines, pos.startLine, pos.endLine)) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Block "^${args.target}" resolved to line ${pos.startLine + 1} but it is inside a markdown table or fenced code block. Refusing to patch — replacing or splicing this region would corrupt the surrounding structure. Move the block id outside the table/code block to make it patchable.`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`Block "^${args.target}" resolved to line ${pos.startLine + 1} but it is inside a markdown table or fenced code block. Refusing to patch — replacing or splicing this region would corrupt the surrounding structure. Move the block id outside the table/code block to make it patchable.`);
     }
 
     if (args.operation === "append") {
@@ -302,17 +265,9 @@ export async function applyPatch(
     }
 
     await app.vault.modify(file, lines.join("\n"));
-    return { content: [{ type: "text", text: "OK" }] };
+    return successText("OK");
   }
 
   // Unreachable if ArkType validation ran correctly.
-  return {
-    content: [
-      {
-        type: "text",
-        text: `Unknown targetType: ${(args as unknown as { targetType: string }).targetType}`,
-      },
-    ],
-    isError: true,
-  };
+  return errorText(`Unknown targetType: ${(args as unknown as { targetType: string }).targetType}`);
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText } from "../services/responseBuilders";
 import { TFile, type App } from "obsidian";
 import {
   applyPatch,
@@ -53,26 +54,10 @@ export async function patchVaultFileHandler(
 }> {
   const file = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
   if (!file) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `File not found: ${ctx.arguments.path}`,
-        },
-      ],
-      isError: true,
-    };
+    return errorText(`File not found: ${ctx.arguments.path}`);
   }
   if (!(file instanceof TFile)) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Path is a folder: ${ctx.arguments.path}`,
-        },
-      ],
-      isError: true,
-    };
+    return errorText(`Path is a folder: ${ctx.arguments.path}`);
   }
 
   // Strip `path` from the arguments before forwarding — applyPatch only needs

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import { TFile, type App } from "obsidian";
 
 import {
@@ -51,10 +52,7 @@ function errorResponse(payload: {
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return {
-    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
-    isError: true,
-  };
+  return errorText(JSON.stringify(payload, null, 2));
 }
 
 function successResponse(payload: {
@@ -62,9 +60,7 @@ function successResponse(payload: {
   updatedFiles: string[];
   linkRewriteCount: number;
 }): { content: Array<{ type: "text"; text: string }> } {
-  return {
-    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
-  };
+  return successText(JSON.stringify(payload, null, 2));
 }
 
 function partialFailureResponse(payload: {
@@ -74,10 +70,7 @@ function partialFailureResponse(payload: {
   failedFiles: Array<{ path: string; error: string }>;
   linkRewriteCount: number;
 }): { content: Array<{ type: "text"; text: string }>; isError: true } {
-  return {
-    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
-    isError: true,
-  };
+  return errorText(JSON.stringify(payload, null, 2));
 }
 
 /**

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText } from "../services/responseBuilders";
 import type { App, TAbstractFile } from "obsidian";
 
 export const renameVaultFileSchema = type({
@@ -39,17 +40,11 @@ export async function renameVaultFileHandler(
 
   const source = ctx.app.vault.getAbstractFileByPath(from);
   if (!source) {
-    return {
-      content: [{ type: "text", text: `Source file not found: ${from}` }],
-      isError: true,
-    };
+    return errorText(`Source file not found: ${from}`);
   }
 
   if (ctx.app.vault.getAbstractFileByPath(to)) {
-    return {
-      content: [{ type: "text", text: `Destination already exists: ${to}` }],
-      isError: true,
-    };
+    return errorText(`Destination already exists: ${to}`);
   }
 
   // Fail-loud on missing destination parent. Mirrors the bias established
@@ -60,15 +55,7 @@ export async function renameVaultFileHandler(
   if (slash > 0) {
     const parent = to.slice(0, slash);
     if (!ctx.app.vault.getAbstractFileByPath(parent)) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Destination parent directory does not exist: ${parent}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorText(`Destination parent directory does not exist: ${parent}`);
     }
   }
 
@@ -83,15 +70,7 @@ export async function renameVaultFileHandler(
       }
     ).renameFile(source, to);
   } catch (e) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to rename: ${e instanceof Error ? e.message : String(e)}`,
-        },
-      ],
-      isError: true,
-    };
+    return errorText(`Failed to rename: ${e instanceof Error ? e.message : String(e)}`);
   }
 
   return {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVault.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVault.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 import { apply as applyJsonLogic } from "json-logic-js";
 import { executeDataviewQueryHandler } from "./executeDataviewQuery";
@@ -33,15 +34,7 @@ export async function searchVaultHandler(ctx: SearchVaultContext): Promise<{
     try {
       rule = JSON.parse(query);
     } catch {
-      return {
-        content: [
-          {
-            type: "text",
-            text: 'JsonLogic query must be a valid JSON string. Example: {"==": [{"var": "frontmatter.status"}, "active"]}',
-          },
-        ],
-        isError: true,
-      };
+      return errorText('JsonLogic query must be a valid JSON string. Example: {"==": [{"var": "frontmatter.status"}, "active"]}');
     }
 
     const results = ctx.app.vault
@@ -65,9 +58,7 @@ export async function searchVaultHandler(ctx: SearchVaultContext): Promise<{
       })
       .map((f) => ({ path: f.path }));
 
-    return {
-      content: [{ type: "text", text: JSON.stringify(results) }],
-    };
+    return successText(JSON.stringify(results));
   }
 
   return executeDataviewQueryHandler({ arguments: { query }, app: ctx.app });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSimple.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSimple.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 const DEFAULT_CONTEXT = 100;
@@ -71,7 +72,5 @@ export async function searchVaultSimpleHandler(
     }
   }
 
-  return {
-    content: [{ type: "text", text: JSON.stringify({ results }, null, 2) }],
-  };
+  return successText(JSON.stringify({ results }, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import { isSmartConnectionsAvailable } from "$/features/semantic-search/services/providerFactory";
@@ -141,7 +142,5 @@ export async function searchVaultSmartHandler(
   const isExcluded = createExclusionFilter(ctx.app);
   results = results.filter((r) => !isExcluded(r.filePath));
 
-  return {
-    content: [{ type: "text", text: JSON.stringify({ results }, null, 2) }],
-  };
+  return successText(JSON.stringify({ results }, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/showFileInObsidian.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/showFileInObsidian.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const showFileInObsidianSchema = type({
@@ -29,5 +30,5 @@ export async function showFileInObsidianHandler(
     "",
     ctx.arguments.newLeaf ?? false,
   );
-  return { content: [{ type: "text", text: "File opened successfully" }] };
+  return successText("File opened successfully");
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/toolCatalog.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/toolCatalog.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
 import type { RegistryLike } from "$/features/adaptive-tool-loading/types";
 
 export const toolCatalogSchema = type({
@@ -56,7 +57,5 @@ export async function toolCatalogHandler({
     };
   });
 
-  return {
-    content: [{ type: "text", text: JSON.stringify(catalog, null, 2) }],
-  };
+  return successText(JSON.stringify(catalog, null, 2));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/updateActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/updateActiveFile.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 
 export const updateActiveFileSchema = type({
@@ -25,11 +26,8 @@ export async function updateActiveFileHandler(
 }> {
   const file = ctx.app.workspace.getActiveFile();
   if (!file) {
-    return {
-      content: [{ type: "text", text: "No active file." }],
-      isError: true,
-    };
+    return errorText("No active file.");
   }
   await ctx.app.vault.modify(file, ctx.arguments.content);
-  return { content: [{ type: "text", text: "OK" }] };
+  return successText("OK");
 }


### PR DESCRIPTION
## Summary

Completes the response-builders migration started in PR #257:

- Codemod (exact-shape matching only) migrated 70 inline envelopes across 31 tool files to errorText/successText/successJson
- Net -267 lines, zero message-string changes
- ToolResponse.isError tightened to the `true` literal for assignability with handlers' local result types
- Left inline by design: multi-line JSON error payloads with extra fields, binary content responses (getVaultFile), local helper wrappers (executeTemplate, renameHeading)

## Test plan

- [x] bun run check clean
- [x] bun test: 1153 pass / 0 fail — payloads byte-identical by construction (codemod only rewrites the envelope, never the text expression)