### PR TITLE
perf: cut tools/list token cost by 26% (schema dedup + description trims)

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
@@ -41,7 +41,9 @@ export async function activateToolHandler({
   const found = allEntries.find((e) => e.name === args.name);
 
   if (!found) {
-    return errorText(`Unknown tool: '${args.name}'. Run tool_catalog to see available tools.`);
+    return errorText(
+      `Unknown tool: '${args.name}'. Run tool_catalog to see available tools.`,
+    );
   }
 
   if (found.enabled) {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
@@ -19,18 +19,18 @@ export const appendToPeriodicNoteSchema = type({
   name: '"append_to_periodic_note"',
   arguments: {
     "period?": type('"daily"|"weekly"|"monthly"|"quarterly"|"yearly"').describe(
-      "Period granularity. Defaults to `daily` so the common case is one positional `content` away.",
+      "Period granularity. Default `daily`.",
     ),
     content: type("string").describe("Markdown content to append."),
     "date?": type("string").describe(
       "Period-specific ISO date. Formats: daily `YYYY-MM-DD`, weekly `YYYY-Www`, monthly `YYYY-MM`, quarterly `YYYY-QN`, yearly `YYYY`. Default: the period instance containing today in the plugin process timezone.",
     ),
     "underHeading?": type("string>0").describe(
-      "If provided, appends inside this heading's section (matched by exact leaf name, or by a `Parent::Child` path with `::` as the delimiter). Without it, appends at end-of-file. If the heading is not found, the call fails with `errorCode: \"heading_not_found\"` — and an auto-created note is left in place (the file's existence is the right end state; add the heading via `patch_vault_file` and retry).",
+      'Appends inside this heading\'s section (exact leaf name or `Parent::Child` path). If the heading is missing the call fails with `errorCode: "heading_not_found"` but the auto-created note is kept; add the heading via `patch_vault_file` and retry.',
     ),
   },
 }).describe(
-  "Appends content to a periodic note (daily by default). Auto-creates the note if it doesn't exist via the same path as `get_or_create_periodic_note` (plugin API when enabled, ISO fallback otherwise). `underHeading` targets a section via the shared heading walker (same fence-aware semantics as `patch_vault_file`); without it, content is appended at EOF.",
+  "Appends to a periodic note (daily by default), auto-creating it like `get_or_create_periodic_note`. With `underHeading`, inserts inside that section; otherwise appends at end of file.",
 );
 
 export type AppendToPeriodicNoteContext = {
@@ -168,5 +168,7 @@ function errorPayload(
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return errorText(JSON.stringify({ error: message, errorCode, ...extras }, null, 2));
+  return errorText(
+    JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
+  );
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultDirectory.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultDirectory.ts
@@ -27,7 +27,9 @@ export async function createVaultDirectoryHandler(
 }> {
   const trimmed = ctx.arguments.path.replace(/^\/+|\/+$/g, "");
   if (!trimmed) {
-    return errorText("Path is empty after normalisation; cannot create the vault root.");
+    return errorText(
+      "Path is empty after normalisation; cannot create the vault root.",
+    );
   }
 
   // If a file already exists at this path the request is ambiguous —
@@ -37,7 +39,9 @@ export async function createVaultDirectoryHandler(
     const isFolder =
       (existing as { children?: unknown }).children !== undefined;
     if (!isFolder) {
-      return errorText(`A file already exists at ${trimmed}; cannot create directory with the same path.`);
+      return errorText(
+        `A file already exists at ${trimmed}; cannot create directory with the same path.`,
+      );
     }
     return successText("OK");
   }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteVaultDirectory.ts
@@ -29,7 +29,9 @@ export async function deleteVaultDirectoryHandler(
 }> {
   const trimmed = ctx.arguments.path.replace(/^\/+|\/+$/g, "");
   if (!trimmed) {
-    return errorText("Path is empty after normalisation; refusing to delete the vault root.");
+    return errorText(
+      "Path is empty after normalisation; refusing to delete the vault root.",
+    );
   }
 
   const recursive = (ctx.arguments.recursive ?? "false") === "true";
@@ -41,7 +43,9 @@ export async function deleteVaultDirectoryHandler(
     const isFolder =
       (existing as { children?: unknown }).children !== undefined;
     if (!isFolder) {
-      return errorText(`Path ${trimmed} is a file, not a directory. Use delete_vault_file instead.`);
+      return errorText(
+        `Path ${trimmed} is a file, not a directory. Use delete_vault_file instead.`,
+      );
     }
   }
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.ts
@@ -156,5 +156,7 @@ function errorPayload(
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return errorText(JSON.stringify({ error: message, errorCode, ...extras }, null, 2));
+  return errorText(
+    JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
+  );
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeObsidianCommand.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeObsidianCommand.ts
@@ -73,7 +73,9 @@ export async function executeObsidianCommandHandler(
   const rl = rateLimitTake();
   if (!rl.ok) {
     const waitSec = Math.ceil((rl.retryAfterMs ?? 0) / 1000);
-    return errorText(`Rate limit exceeded: too many command executions in the last minute. Retry in ${waitSec}s.`);
+    return errorText(
+      `Rate limit exceeded: too many command executions in the last minute. Retry in ${waitSec}s.`,
+    );
   }
 
   // --- 2. Permission check ---
@@ -89,7 +91,9 @@ export async function executeObsidianCommandHandler(
   };
 
   if (typeof pluginWithPermCheck.checkCommandPermission !== "function") {
-    return errorText("Internal error: permission check not available on plugin.");
+    return errorText(
+      "Internal error: permission check not available on plugin.",
+    );
   }
 
   const decision = await pluginWithPermCheck.checkCommandPermission(
@@ -115,7 +119,9 @@ export async function executeObsidianCommandHandler(
   const success = commandsApi.executeCommandById(ctx.arguments.commandId);
 
   if (!success) {
-    return errorText(`Command not found: '${ctx.arguments.commandId}'. Use list_obsidian_commands to discover available commands.`);
+    return errorText(
+      `Command not found: '${ctx.arguments.commandId}'. Use list_obsidian_commands to discover available commands.`,
+    );
   }
 
   return successText(`Executed Obsidian command '${ctx.arguments.commandId}'.`);

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
@@ -47,7 +47,7 @@ export const executeTemplateSchema = type({
     ),
   },
 }).describe(
-  'Renders a template. If targetPath is given and createFile="true", creates a new note at that path and returns the rendered content. Two-tier template engine: Templater (community plugin) when installed; falls back to the core Templates plugin for basic {{title}}/{{date}}/{{time}} substitution. `errorCode: "templater_not_installed"` when neither engine is available, `template_not_found` if the template file is missing, `template_execution_failed` on a Templater render error, `core_templates_execution_failed` on a core-Templates read error. The `arguments` map is Templater-specific and is ignored (with a warning) on the core-Templates path.',
+  'Renders a template via Templater when installed, else the core Templates plugin ({{title}}/{{date}}/{{time}} only). With targetPath and createFile="true" also creates the note at targetPath. Error codes: templater_not_installed, template_not_found, template_execution_failed, core_templates_execution_failed. `arguments` is Templater-only (warning on the core path).',
 );
 
 export type ExecuteTemplateContext = {
@@ -334,5 +334,7 @@ function errorPayload(
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return errorText(JSON.stringify({ error: message, errorCode, ...extras }, null, 2));
+  return errorText(
+    JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
+  );
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/fetch.ts
@@ -147,7 +147,9 @@ export async function fetchHandler(ctx: FetchContext): Promise<{
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (message === "__FETCH_TIMEOUT__") {
-      return errorText(`Fetch failed: request timed out after ${REQUEST_TIMEOUT_MS}ms.`);
+      return errorText(
+        `Fetch failed: request timed out after ${REQUEST_TIMEOUT_MS}ms.`,
+      );
     }
     return errorText(`Fetch failed: ${message}`);
   }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getBacklinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getBacklinks.ts
@@ -9,11 +9,11 @@ export const getBacklinksSchema = type({
       "Vault-relative path of the target file. The tool returns every file that links to this path.",
     ),
     "includeUnresolved?": type('"true" | "false"').describe(
-      'When `"true"`, also include backlinks where the source uses a linkpath that does not actually resolve to this file (typo or broken-link sources matching the target by path or filename). Default `"false"` because unresolved backlinks are usually noise; opt in when auditing or fixing broken links. For richer per-link context (display text, raw syntax) call `get_outgoing_links` from each source instead.',
+      'When `"true"`, also includes sources whose link does not resolve (typo or broken-link sources matching by path or filename). Default `"false"`: unresolved backlinks are usually noise.',
     ),
   },
 }).describe(
-  "Returns every file that links to the given target, with per-source link count. Aggregates resolved backlinks via Obsidian's `metadataCache.resolvedLinks` reverse-index; opt-in `includeUnresolved` extends with broken-link sources matched by path or filename. Sorted by count descending with path tiebreaker for determinism. Always read-only. Does not error if the target file doesn't currently exist on disk — backlinks can outlive their target.",
+  "Lists every file linking to the target, with per-source link count, sorted by count descending. Works even if the target does not exist (backlinks can outlive it). Read-only.",
 );
 
 export type GetBacklinksContext = {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getFilesByTag.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getFilesByTag.ts
@@ -30,7 +30,9 @@ export async function getFilesByTagHandler(ctx: GetFilesByTagContext): Promise<{
   // the lookup contract.
   const normalized = ctx.arguments.tag.trim().replace(/^#+/, "").toLowerCase();
   if (!normalized) {
-    return errorText('Invalid tag: input is empty or contains only "#" characters.');
+    return errorText(
+      'Invalid tag: input is empty or contains only "#" characters.',
+    );
   }
 
   const includeNested = (ctx.arguments.includeNested ?? "true") === "true";

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
@@ -12,14 +12,14 @@ export const getOrCreatePeriodicNoteSchema = type({
   name: '"get_or_create_periodic_note"',
   arguments: {
     period: type('"daily"|"weekly"|"monthly"|"quarterly"|"yearly"').describe(
-      "Period granularity. `daily` is also reachable via `get_or_create_daily_note` (zero-friction shortcut for the common case).",
+      "Period granularity. For daily, `get_or_create_daily_note` is a shortcut.",
     ),
     "date?": type("string").describe(
-      "Period-specific ISO date. Formats: daily `YYYY-MM-DD`, weekly `YYYY-Www` (ISO week), monthly `YYYY-MM`, quarterly `YYYY-QN` (N=1-4), yearly `YYYY`. Default: the period instance containing today in the plugin process timezone (the user's machine TZ in the in-process / desktop deployment).",
+      "Period-specific ISO date: daily `YYYY-MM-DD`, weekly `YYYY-Www`, monthly `YYYY-MM`, quarterly `YYYY-QN`, yearly `YYYY`. Default: the period containing today, host machine timezone.",
     ),
   },
 }).describe(
-  "Reads the periodic note for the given `period` (and optional `date`), creating it if missing. Returns `{path, content, created}`. When the Daily Notes core plugin or the community Periodic Notes plugin covers the period, the note is created via the plugin's API so the configured template + interpolations run; otherwise it is created as an empty file at the ISO path under the vault root. **Structured writes to the resolved note** (set a frontmatter field, replace under a heading, edit a block) compose: get the path, then `set_note_property` (Module D) or `patch_vault_file` — there is no dedicated `patch_periodic_note` (ADR-0002 Alt #7).",
+  "Reads the periodic note for `period` (and optional `date`), creating it if missing. Returns `{path, content, created}`. Uses the Daily Notes / Periodic Notes plugin API when available (so configured templates run); otherwise creates an empty file at the ISO path. For structured edits, take the returned path and use `set_note_property` or `patch_vault_file`.",
 );
 
 export type GetOrCreatePeriodicNoteContext = {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.ts
@@ -7,14 +7,14 @@ export const getOutgoingLinksSchema = type({
   arguments: {
     path: type("string>0").describe("Vault-relative path to the source file."),
     "includeEmbeds?": type('"true" | "false"').describe(
-      'When `"true"` (default), embedded references (`![[link]]`) are returned alongside regular links, marked with `embed: true`. When `"false"`, only regular links are returned.',
+      'Default `"true"`: embeds included, marked `embed: true`. `"false"` returns only regular links.',
     ),
     "includeUnresolved?": type('"true" | "false"').describe(
-      'When `"true"` (default), unresolved links (link target text that does not match any vault file) are included with `resolved: false` and `targetPath: null`. Set to `"false"` to filter them out.',
+      'Default `"true"`: unresolved links included with `resolved: false`. `"false"` filters them out.',
     ),
   },
 }).describe(
-  "Returns every link emanating from the given file: body links (`[[wikilink]]`, `[md](path)`), embeds (`![[…]]`), and frontmatter links (e.g. `parent: [[Other]]`). Each entry carries its raw linkpath, original syntax, optional display text, source layer (`body` | `frontmatter`), embed flag, resolution status, and the resolved vault path when available. Order preserves document position. Returns `isError: true` when the source file does not exist.",
+  "Returns every link in a file: body links, embeds (`![[…]]`), and frontmatter links. Each entry has linkpath, original syntax, display text, layer (`body` | `frontmatter`), embed flag, resolution status, and resolved path. Document order. `isError: true` if the file does not exist.",
 );
 
 export type GetOutgoingLinksContext = {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
@@ -13,17 +13,17 @@ export const getVaultFilePartialSchema = type({
   arguments: {
     filename: type("string>0").describe("Vault-relative path to the file."),
     mode: type('"frontmatter" | "heading" | "block" | "document-map"').describe(
-      'One of: `"frontmatter"` (returns a single frontmatter field value), `"heading"` (returns the markdown section under the target heading), `"block"` (returns the markdown range of the target block reference), or `"document-map"` (returns the file outline — heading list, block-id list, frontmatter-field list — with no body content).',
+      "`frontmatter` = one field value; `heading` = the markdown section under the heading; `block` = the range of the block reference; `document-map` = outline only (headings, block ids, frontmatter keys), no body.",
     ),
     "target?": type("string>0").describe(
-      "Field name for `frontmatter`, heading text (optionally nested via `targetDelimiter`) for `heading`, or block id (with or without the leading `^`) for `block`. Required for all modes EXCEPT `document-map` (where it is ignored).",
+      "Frontmatter field name, heading text (nested path via `targetDelimiter`), or block id (leading `^` optional). Ignored for `document-map`.",
     ),
     "targetDelimiter?": type("string>0").describe(
-      'Delimiter used to address a nested heading path, e.g. `"Parent::Child::Grandchild"`. Defaults to `"::"` (matching the Local REST API convention). Only meaningful for `mode: "heading"`.',
+      'Delimiter for nested heading paths, e.g. `Parent::Child`. Default `::`. Only for `mode: "heading"`.',
     ),
   },
 }).describe(
-  "Returns a partial read of a vault file: a single frontmatter field, a heading section, a block range, or the file outline. All four modes operate on Obsidian's already-cached metadata (`MetadataCache`) and `vault.cachedRead`; no Local REST API required. The `frontmatter` and `document-map` modes are zero-I/O on cached data; `heading` and `block` perform one cached read each. Useful for context-window economics on large notes (e.g. spot-check a frontmatter field on a 30 KB file without loading the body). Always read-only.",
+  "Reads part of a vault file without loading the body: a single frontmatter field, a heading section, a block range, or the file outline. Read-only and cheap on large notes.",
 );
 
 export type GetVaultFilePartialContext = {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchActiveFile.ts
@@ -134,7 +134,9 @@ export async function applyPatch(
     const fullPath = resolveHeadingPath(fileContent, args.target, delimiter);
 
     if (!fullPath && !createIfMissing) {
-      return errorText(`Heading "${args.target}" not found and createTargetIfMissing=false.`);
+      return errorText(
+        `Heading "${args.target}" not found and createTargetIfMissing=false.`,
+      );
     }
 
     if (!fullPath) {
@@ -171,7 +173,9 @@ export async function applyPatch(
       !args.allowRootHeadings &&
       hasAnyH1(lines)
     ) {
-      return errorText(`Heading "${args.target}" is a level-${headingLevel} heading with no level-1 (#) parent, while the document does contain an H1 elsewhere — the section boundary is ambiguous. Refusing to patch. Pass allowRootHeadings:true to target it explicitly, or createTargetIfMissing:true to bypass. (Files with no H1 at all are accepted automatically.)`);
+      return errorText(
+        `Heading "${args.target}" is a level-${headingLevel} heading with no level-1 (#) parent, while the document does contain an H1 elsewhere — the section boundary is ambiguous. Refusing to patch. Pass allowRootHeadings:true to target it explicitly, or createTargetIfMissing:true to bypass. (Files with no H1 at all are accepted automatically.)`,
+      );
     }
 
     // Find end of this heading's section: next heading at same-or-higher level.
@@ -233,7 +237,9 @@ export async function applyPatch(
     const pos = findBlockPositionFromCache(cache, args.target);
 
     if (!pos && !createIfMissing) {
-      return errorText(`Block "^${args.target}" not found in active file (createTargetIfMissing=false).`);
+      return errorText(
+        `Block "^${args.target}" not found in active file (createTargetIfMissing=false).`,
+      );
     }
 
     if (!pos) {
@@ -248,7 +254,9 @@ export async function applyPatch(
     // see fork #81, #83. 0.4.3 fork #84: full block range
     // check, not just startLine — see range wrapper in patchHelpers.ts.
     if (isBlockRangeStructurallyUnsafe(lines, pos.startLine, pos.endLine)) {
-      return errorText(`Block "^${args.target}" resolved to line ${pos.startLine + 1} but it is inside a markdown table or fenced code block. Refusing to patch — replacing or splicing this region would corrupt the surrounding structure. Move the block id outside the table/code block to make it patchable.`);
+      return errorText(
+        `Block "^${args.target}" resolved to line ${pos.startLine + 1} but it is inside a markdown table or fenced code block. Refusing to patch — replacing or splicing this region would corrupt the surrounding structure. Move the block id outside the table/code block to make it patchable.`,
+      );
     }
 
     if (args.operation === "append") {
@@ -269,5 +277,7 @@ export async function applyPatch(
   }
 
   // Unreachable if ArkType validation ran correctly.
-  return errorText(`Unknown targetType: ${(args as unknown as { targetType: string }).targetType}`);
+  return errorText(
+    `Unknown targetType: ${(args as unknown as { targetType: string }).targetType}`,
+  );
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
@@ -22,10 +22,10 @@ export const patchVaultFileSchema = type({
       "Delimiter used to join ancestor heading names (default: '::').",
     ),
     "createTargetIfMissing?": type("boolean").describe(
-      "When true, creates the target if not found. Defaults to true for heading/frontmatter, false for block. Note: with the default `true` for headings, patching a level-2-or-deeper heading on a file that has no parent H1 will silently create the section instead of failing loud — pass `false` explicitly to get the H2-root reject guard if your vault treats a missing H1 as an integrity error.",
+      "Creates the target if not found. Default true for heading/frontmatter, false for block. Pass false to fail loud when patching an H2-or-deeper heading in a file with no parent H1.",
     ),
     "allowRootHeadings?": type("boolean").describe(
-      "When true, allow targeting a level-2-or-deeper heading that has no level-1 (#) parent even in a document that contains an H1 elsewhere (the ambiguous 'mixed' case the H2-root guard otherwise rejects with createTargetIfMissing=false). Files with no H1 at all are already accepted without this flag. Default false.",
+      "Allows targeting an H2-or-deeper heading with no H1 parent in a file that has an H1 elsewhere (otherwise rejected when createTargetIfMissing=false). Default false.",
     ),
   },
 }).describe(

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.ts
@@ -55,7 +55,9 @@ export async function renameVaultFileHandler(
   if (slash > 0) {
     const parent = to.slice(0, slash);
     if (!ctx.app.vault.getAbstractFileByPath(parent)) {
-      return errorText(`Destination parent directory does not exist: ${parent}`);
+      return errorText(
+        `Destination parent directory does not exist: ${parent}`,
+      );
     }
   }
 
@@ -70,7 +72,9 @@ export async function renameVaultFileHandler(
       }
     ).renameFile(source, to);
   } catch (e) {
-    return errorText(`Failed to rename: ${e instanceof Error ? e.message : String(e)}`);
+    return errorText(
+      `Failed to rename: ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
 
   return {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchAndReplace.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchAndReplace.ts
@@ -22,7 +22,7 @@ export const searchAndReplaceSchema = type({
     ),
   },
 }).describe(
-  'Regex find-and-replace across the vault or a scoped file list. Safe by default: `dry_run` is `true` — no files are modified unless you explicitly pass `dry_run:"false"`. Validates the regex before any file access. Returns files_matched, total_replacements, and per-file preview (max 5 match contexts). In preview entries, `line_number: 0` is a sentinel for multi-line matches where no per-line preview is available (consistent with `find_broken_links` frontmatter sentinel). JavaScript regex semantics apply; `g` flag is always active. Patterns with nested quantifiers (e.g. `(a+)+`) are rejected to protect the Obsidian main thread.',
+  'Regex find-and-replace across the vault or a scoped file list. `dry_run` defaults to `"true"` (preview only); pass `"false"` to write. Returns files_matched, total_replacements, and up to 5 match previews per file (`line_number: 0` = multi-line match). JavaScript regex, `g` flag always active; patterns with nested quantifiers are rejected.',
 );
 
 export type SearchAndReplaceContext = {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVault.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVault.ts
@@ -34,7 +34,9 @@ export async function searchVaultHandler(ctx: SearchVaultContext): Promise<{
     try {
       rule = JSON.parse(query);
     } catch {
-      return errorText('JsonLogic query must be a valid JSON string. Example: {"==": [{"var": "frontmatter.status"}, "active"]}');
+      return errorText(
+        'JsonLogic query must be a valid JSON string. Example: {"==": [{"var": "frontmatter.status"}, "active"]}',
+      );
     }
 
     const results = ctx.app.vault

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.ts
@@ -11,11 +11,11 @@ export const setNotePropertySchema = type({
     value: type(
       "string | number | boolean | string[] | number[] | null",
     ).describe(
-      "Value to set. Native JSON types map to YAML: string, number, boolean, or a homogeneous list of strings/numbers. Dates are passed as ISO 8601 strings. Passing `null` removes the key (same as `delete_note_property`). Mixed-type lists are not supported — use `patch_vault_file` for those.",
+      "String, number, boolean, or homogeneous list of strings/numbers (dates as ISO 8601 strings). `null` removes the key. No mixed-type lists.",
     ),
   },
 }).describe(
-  'Sets a single frontmatter (note property) key on a vault note via Obsidian\'s atomic `processFrontMatter` API (no read-modify-write race). Creates the frontmatter block if the note has none. Passing `value: null` deletes the key. Coexists with `patch_vault_file targetType:"frontmatter"`, which replaces the entire block; this tool is for single-key edits.',
+  'Sets one frontmatter key on a note atomically. Creates the frontmatter block if missing; `value: null` deletes the key. To replace the whole block use `patch_vault_file` with `targetType: "frontmatter"`.',
 );
 
 export type SetNotePropertyContext = {

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
@@ -149,6 +149,92 @@ describe("normalizeInputSchema", () => {
     const out = normalizeInputSchema(input);
     expect(out.additionalProperties).toEqual({ type: "string" });
   });
+
+  test("strips anyOf member descriptions duplicating the parent's", () => {
+    // ArkType propagates a union's .describe() onto every branch; the
+    // wire format only needs the property-level copy.
+    const desc = "Period granularity.";
+    const input = {
+      type: "object",
+      properties: {
+        period: {
+          description: desc,
+          anyOf: [
+            { const: "daily", description: desc },
+            { const: "weekly", description: desc },
+          ],
+        },
+      },
+    };
+    const out = normalizeInputSchema(input) as {
+      properties: {
+        period: { description: string; anyOf: Record<string, unknown>[] };
+      };
+    };
+    expect(out.properties.period.description).toBe(desc);
+    for (const member of out.properties.period.anyOf) {
+      expect("description" in member).toBe(false);
+    }
+  });
+
+  test("hoists a description shared by all anyOf members when the parent has none", () => {
+    const desc = "Value to set.";
+    const input = {
+      type: "object",
+      properties: {
+        value: {
+          anyOf: [
+            { type: "string", description: desc },
+            { type: "number", description: desc },
+          ],
+        },
+      },
+    };
+    const out = normalizeInputSchema(input) as {
+      properties: {
+        value: { description: string; anyOf: Record<string, unknown>[] };
+      };
+    };
+    expect(out.properties.value.description).toBe(desc);
+    for (const member of out.properties.value.anyOf) {
+      expect("description" in member).toBe(false);
+    }
+  });
+
+  test("preserves anyOf member descriptions that genuinely differ", () => {
+    const input = {
+      type: "object",
+      properties: {
+        mode: {
+          anyOf: [
+            { const: "a", description: "First mode." },
+            { const: "b", description: "Second mode." },
+          ],
+        },
+      },
+    };
+    const out = normalizeInputSchema(input) as {
+      properties: { mode: { anyOf: { description: string }[] } };
+    };
+    expect(out.properties.mode.anyOf[0].description).toBe("First mode.");
+    expect(out.properties.mode.anyOf[1].description).toBe("Second mode.");
+  });
+
+  test("dedupe does not mutate the input object", () => {
+    const desc = "Shared description.";
+    const input = {
+      type: "object",
+      properties: {
+        period: {
+          description: desc,
+          anyOf: [{ const: "daily", description: desc }],
+        },
+      },
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    normalizeInputSchema(input);
+    expect(input).toEqual(snapshot);
+  });
 });
 
 describe("ToolRegistry list() — issue #77 regression", () => {

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
@@ -31,6 +31,46 @@ interface HandlerContext {
  *
  * See issues #63 (Letta Cloud) and #77 (openai-codex).
  */
+/**
+ * ArkType propagates a union's `.describe()` text onto every branch, so
+ * the generated JSON Schema carries the same description once per
+ * `anyOf` member on top of the property-level copy — a 5-way enum pays
+ * for its description six times. Strip member descriptions that
+ * duplicate the parent's, and hoist a description shared by every
+ * member when the parent has none. Wire-size optimization only
+ * (~19% of tools/list bytes measured at 0.15.6); no semantic change.
+ */
+function dedupeUnionDescriptions(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) dedupeUnionDescriptions(item);
+    return;
+  }
+  if (typeof node !== "object" || node === null) return;
+  const obj = node as Record<string, unknown>;
+
+  if (Array.isArray(obj.anyOf)) {
+    const members = obj.anyOf.filter(
+      (m): m is Record<string, unknown> => typeof m === "object" && m !== null,
+    );
+    if (typeof obj.description === "string") {
+      for (const m of members) {
+        if (m.description === obj.description) delete m.description;
+      }
+    } else {
+      const descriptions = new Set(members.map((m) => m.description));
+      if (descriptions.size === 1) {
+        const [shared] = descriptions;
+        if (typeof shared === "string") {
+          obj.description = shared;
+          for (const m of members) delete m.description;
+        }
+      }
+    }
+  }
+
+  for (const value of Object.values(obj)) dedupeUnionDescriptions(value);
+}
+
 export function normalizeInputSchema(
   jsonSchema: unknown,
 ): Record<string, unknown> {
@@ -42,8 +82,11 @@ export function normalizeInputSchema(
       ? (jsonSchema as Record<string, unknown>)
       : { type: "object" };
 
-  // Clone to avoid mutating the caller's object.
-  const result: Record<string, unknown> = { ...base };
+  // Deep clone: dedupeUnionDescriptions mutates nested nodes, and the
+  // caller's object must stay untouched.
+  const result: Record<string, unknown> = structuredClone(base);
+
+  dedupeUnionDescriptions(result);
 
   // Force-set `type: "object"` if missing — MCP inputSchema must be an
   // object type by protocol.


### PR DESCRIPTION
Two independent changes that reduce the token cost of the tool list, measured on the full 45-tool dump (bytes/4 approximation).

**1. Dedupe union member descriptions in schema normalization (fix)**

ArkType propagates a union's `.describe()` text onto every branch, so the generated JSON Schema repeated the same description once per `anyOf` member on top of the property-level copy. A 5-value enum paid for its description six times; `period` on the periodic-note tools was the worst case. `normalizeInputSchema` now strips member descriptions that duplicate the parent's and hoists a description shared by all members when the parent has none. Wire-format change only, no semantic difference. This alone is ~19% of tools/list bytes. 4 new unit tests, including a non-mutation guard.

**2. Trim the 9 tool descriptions above ~400 tokens (refactor)**

Removed internal API names (`MetadataCache`, `resolvedLinks`, `vault.cachedRead`), ADR references, module names, and stale Local REST API mentions (removed in 0.13.0). Kept everything that guides the model: defaults, type constraints, error codes, and recovery semantics (`heading_not_found`, the H1/H2 guard on `patch_vault_file`, `dry_run` behavior).

**Measured result**

| | before | after |
|---|---|---|
| full tools/list | ~11,418 tok | ~8,422 tok (-26%) |
| avg per tool | 254 tok | 187 tok |
| worst tool (`get_vault_file_partial`) | 818 tok | 282 tok |

1136 tests green, `tsc --noEmit` clean.