### PR TITLE
perf(mcp-tools): compact JSON payloads and cap unbounded list outputs

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.test.ts
@@ -19,14 +19,14 @@ describe("responseBuilders", () => {
       path: "a.md",
     });
     expect(result.isError).toBe(true);
-    // Byte-identical to the inline JSON.stringify({error, errorCode, path}, null, 2)
+    // Byte-identical to the inline JSON.stringify({error, errorCode, path})
     // shape used by the property tools.
     expect(result.content[0].text).toBe(
-      JSON.stringify(
-        { error: "File not found", errorCode: "file_not_found", path: "a.md" },
-        null,
-        2,
-      ),
+      JSON.stringify({
+        error: "File not found",
+        errorCode: "file_not_found",
+        path: "a.md",
+      }),
     );
   });
 
@@ -36,8 +36,8 @@ describe("responseBuilders", () => {
     expect("isError" in result).toBe(false);
   });
 
-  test("successJson pretty-prints with 2-space indent", () => {
+  test("successJson serializes compact, no indentation", () => {
     const result = successJson({ a: 1 });
-    expect(result.content[0].text).toBe('{\n  "a": 1\n}');
+    expect(result.content[0].text).toBe('{"a":1}');
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/responseBuilders.ts
@@ -22,8 +22,9 @@ export function errorText(message: string): ToolResponse & { isError: true } {
 }
 
 /**
- * JSON error payload (pretty-printed, 2-space indent) with a stable
- * `error` + `errorCode` shape, plus any extra context fields.
+ * JSON error payload (compact, no indentation — consumers are LLMs,
+ * whitespace is pure token cost) with a stable `error` + `errorCode`
+ * shape, plus any extra context fields.
  */
 export function errorJson(
   error: string,
@@ -34,7 +35,7 @@ export function errorJson(
     content: [
       {
         type: "text",
-        text: JSON.stringify({ error, errorCode, ...extras }, null, 2),
+        text: JSON.stringify({ error, errorCode, ...extras }),
       },
     ],
     isError: true,
@@ -48,9 +49,9 @@ export function successText(text: string): ToolResponse {
   };
 }
 
-/** JSON success payload, pretty-printed with 2-space indent. */
+/** JSON success payload, compact (no indentation). */
 export function successJson(value: unknown): ToolResponse {
   return {
-    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+    content: [{ type: "text", text: JSON.stringify(value) }],
   };
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToPeriodicNote.ts
@@ -145,16 +145,12 @@ export async function appendToPeriodicNoteHandler(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            period,
-            path: resolved.path,
-            appended: true,
-            created,
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify({
+          period,
+          path: resolved.path,
+          appended: true,
+          created,
+        }),
       },
     ],
   };
@@ -168,7 +164,5 @@ function errorPayload(
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return errorText(
-    JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
-  );
+  return errorText(JSON.stringify({ error: message, errorCode, ...extras }));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteNoteProperty.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteNoteProperty.ts
@@ -32,11 +32,11 @@ export async function deleteNotePropertyHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            { error: "File not found", errorCode: "file_not_found", path },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: "File not found",
+            errorCode: "file_not_found",
+            path,
+          }),
         },
       ],
       isError: true,
@@ -47,15 +47,11 @@ export async function deleteNotePropertyHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error: "Path is a folder, not a file",
-              errorCode: "not_a_file",
-              path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: "Path is a folder, not a file",
+            errorCode: "not_a_file",
+            path,
+          }),
         },
       ],
       isError: true,

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeDataviewQuery.ts
@@ -132,7 +132,7 @@ export async function executeDataviewQueryHandler(
   // structured error rather than an unhandled rejection.
   let text: string;
   try {
-    text = JSON.stringify(result.value, null, 2);
+    text = JSON.stringify(result.value);
   } catch {
     return errorPayload(
       "Dataview result contains non-serialisable values (circular reference or BigInt). Add LIMIT or simplify the query to reduce result complexity.",
@@ -156,7 +156,5 @@ function errorPayload(
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return errorText(
-    JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
-  );
+  return errorText(JSON.stringify({ error: message, errorCode, ...extras }));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
@@ -174,15 +174,11 @@ export async function executeTemplateHandler(
           content: [
             {
               type: "text",
-              text: JSON.stringify(
-                {
-                  message: "Template executed and file created successfully",
-                  content: processedContent,
-                  path: ctx.arguments.targetPath,
-                },
-                null,
-                2,
-              ),
+              text: JSON.stringify({
+                message: "Template executed and file created successfully",
+                content: processedContent,
+                path: ctx.arguments.targetPath,
+              }),
             },
           ],
         };
@@ -192,14 +188,10 @@ export async function executeTemplateHandler(
         content: [
           {
             type: "text",
-            text: JSON.stringify(
-              {
-                message: "Template executed without creating a file",
-                content: processedContent,
-              },
-              null,
-              2,
-            ),
+            text: JSON.stringify({
+              message: "Template executed without creating a file",
+              content: processedContent,
+            }),
           },
         ],
       };
@@ -293,16 +285,12 @@ async function runCoreTemplates(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              message: "Template executed and file created successfully",
-              content: processed,
-              path: targetPath,
-              ...(warning ? { warning } : {}),
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            message: "Template executed and file created successfully",
+            content: processed,
+            path: targetPath,
+            ...(warning ? { warning } : {}),
+          }),
         },
       ],
     };
@@ -312,15 +300,11 @@ async function runCoreTemplates(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            message: "Template executed without creating a file",
-            content: processed,
-            ...(warning ? { warning } : {}),
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify({
+          message: "Template executed without creating a file",
+          content: processed,
+          ...(warning ? { warning } : {}),
+        }),
       },
     ],
   };
@@ -334,7 +318,5 @@ function errorPayload(
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return errorText(
-    JSON.stringify({ error: message, errorCode, ...extras }, null, 2),
-  );
+  return errorText(JSON.stringify({ error: message, errorCode, ...extras }));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.test.ts
@@ -191,4 +191,42 @@ describe("find_broken_links tool", () => {
     expect(data.total_broken_links).toBe(0);
     expect(r.isError).toBeUndefined();
   });
+
+  test("caps output at limit and reports truncated+total (applied after scope)", async () => {
+    setMockFile("Projects/a.md", "");
+    setMockFile("Archive/old.md", "");
+    setMockMetadata("Projects/a.md", {
+      links: [
+        { link: "BrokenA", line: 1 },
+        { link: "BrokenB", line: 2 },
+        { link: "BrokenC", line: 3 },
+      ],
+    });
+    // Outside scope — must not contribute to the full count.
+    setMockMetadata("Archive/old.md", {
+      links: [{ link: "BrokenD", line: 1 }],
+    });
+    const r = await findBrokenLinksHandler({
+      arguments: { scope: ["Projects"], exclude_folders: [], limit: 2 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.broken_links).toHaveLength(2);
+    expect(data.truncated).toBe(true);
+    expect(data.total_broken_links).toBe(3);
+  });
+
+  test("default limit leaves a small result set untouched (no truncated field)", async () => {
+    setMockFile("a.md", "");
+    setMockMetadata("a.md", {
+      links: [
+        { link: "BrokenA", line: 1 },
+        { link: "BrokenB", line: 2 },
+      ],
+    });
+    const r = await findBrokenLinksHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.broken_links).toHaveLength(2);
+    expect(data.truncated).toBeUndefined();
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.ts
@@ -11,13 +11,14 @@ export const findBrokenLinksSchema = type({
     "scope?": type("string[]").describe(
       "Optional list of vault-relative paths or folder prefixes to limit the scan. A folder prefix matches any file under it. Omit for vault-wide scan.",
     ),
+    "limit?": type("number>0").describe("Max results returned (default 200)."),
   },
 }).describe(
   "Scans the vault (or a scoped subset) for unresolved links (wiki-links, markdown links, embeds, frontmatter links) and returns every broken link with its source file, 1-based line number, link target, original syntax, and link type. Uses Obsidian's metadata cache — no file I/O. Always read-only.",
 );
 
 export type FindBrokenLinksContext = {
-  arguments: { exclude_folders?: string[]; scope?: string[] };
+  arguments: { exclude_folders?: string[]; scope?: string[]; limit?: number };
   app: App;
 };
 
@@ -102,21 +103,24 @@ export async function findBrokenLinksHandler(
     for (const f of c.frontmatterLinks ?? []) check(f, "frontmatter");
   }
 
+  const limit = Math.min(
+    1000,
+    Math.max(1, Math.floor(ctx.arguments.limit ?? 200)),
+  );
+  const truncated = broken.length > limit;
+
   return {
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            total_broken_links: broken.length,
-            scanned_files: scannedFiles,
-            excluded_folders: excludes,
-            ...(scope !== undefined ? { scope } : {}),
-            broken_links: broken,
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify({
+          total_broken_links: broken.length,
+          scanned_files: scannedFiles,
+          excluded_folders: excludes,
+          ...(scope !== undefined ? { scope } : {}),
+          ...(truncated ? { truncated: true } : {}),
+          broken_links: truncated ? broken.slice(0, limit) : broken,
+        }),
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/findOrphanedNotes.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/findOrphanedNotes.test.ts
@@ -80,4 +80,27 @@ describe("find_orphaned_notes tool", () => {
     expect(data.total_orphaned).toBe(0);
     expect(data.orphaned_notes).toEqual([]);
   });
+
+  test("caps output at limit and reports truncated+total", async () => {
+    setMockFile("a.md", "");
+    setMockFile("b.md", "");
+    setMockFile("c.md", "");
+    const r = await findOrphanedNotesHandler({
+      arguments: { limit: 2 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.orphaned_notes).toHaveLength(2);
+    expect(data.truncated).toBe(true);
+    expect(data.total_orphaned).toBe(3);
+  });
+
+  test("default limit leaves a small result set untouched (no truncated field)", async () => {
+    setMockFile("a.md", "");
+    setMockFile("b.md", "");
+    const r = await findOrphanedNotesHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.orphaned_notes).toHaveLength(2);
+    expect(data.truncated).toBeUndefined();
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/findOrphanedNotes.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/findOrphanedNotes.ts
@@ -8,13 +8,14 @@ export const findOrphanedNotesSchema = type({
     "exclude_folders?": type("string[]").describe(
       'Vault-relative folder prefixes whose notes are omitted from the orphan list. Default: `["templates","attachments","_archive"]`. Links FROM excluded folders still count as incoming references — they do not make a note an orphan.',
     ),
+    "limit?": type("number>0").describe("Max results returned (default 200)."),
   },
 }).describe(
   "Returns all markdown notes that have zero incoming resolved links from any vault file. Builds the referenced-file set from Obsidian's resolvedLinks cache (no file I/O). Notes in excluded folders are omitted from the output but their outgoing links still count toward other notes' reference status. Always read-only.",
 );
 
 export type FindOrphanedNotesContext = {
-  arguments: { exclude_folders?: string[] };
+  arguments: { exclude_folders?: string[]; limit?: number };
   app: App;
 };
 
@@ -62,20 +63,23 @@ export async function findOrphanedNotesHandler(
     orphans.push({ path: file.path, mtime: stat.mtime, size: stat.size });
   }
 
+  const limit = Math.min(
+    1000,
+    Math.max(1, Math.floor(ctx.arguments.limit ?? 200)),
+  );
+  const truncated = orphans.length > limit;
+
   return {
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            total_orphaned: orphans.length,
-            scanned_files: scannedFiles,
-            excluded_folders: excludes,
-            orphaned_notes: orphans,
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify({
+          total_orphaned: orphans.length,
+          scanned_files: scannedFiles,
+          excluded_folders: excludes,
+          ...(truncated ? { truncated: true } : {}),
+          orphaned_notes: truncated ? orphans.slice(0, limit) : orphans,
+        }),
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getActiveFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getActiveFile.ts
@@ -57,5 +57,5 @@ export async function getActiveFileHandler(ctx: GetActiveFileContext): Promise<{
     },
   };
 
-  return successText(JSON.stringify(body, null, 2));
+  return successText(JSON.stringify(body));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getBacklinks.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getBacklinks.test.ts
@@ -156,4 +156,30 @@ describe("get_backlinks tool", () => {
       "zebra.md",
     ]);
   });
+
+  test("caps output at limit and reports truncated+total", async () => {
+    setMockResolvedLinks("a.md", { "target.md": 3 });
+    setMockResolvedLinks("b.md", { "target.md": 2 });
+    setMockResolvedLinks("c.md", { "target.md": 1 });
+    const r = await getBacklinksHandler({
+      arguments: { path: "target.md", limit: 2 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.backlinks).toHaveLength(2);
+    expect(data.truncated).toBe(true);
+    expect(data.totalBacklinks).toBe(3);
+  });
+
+  test("default limit leaves a small result set untouched (no truncated field)", async () => {
+    setMockResolvedLinks("a.md", { "target.md": 1 });
+    setMockResolvedLinks("b.md", { "target.md": 1 });
+    const r = await getBacklinksHandler({
+      arguments: { path: "target.md" },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.backlinks).toHaveLength(2);
+    expect(data.truncated).toBeUndefined();
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getBacklinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getBacklinks.ts
@@ -11,13 +11,18 @@ export const getBacklinksSchema = type({
     "includeUnresolved?": type('"true" | "false"').describe(
       'When `"true"`, also includes sources whose link does not resolve (typo or broken-link sources matching by path or filename). Default `"false"`: unresolved backlinks are usually noise.',
     ),
+    "limit?": type("number>0").describe("Max results returned (default 200)."),
   },
 }).describe(
   "Lists every file linking to the target, with per-source link count, sorted by count descending. Works even if the target does not exist (backlinks can outlive it). Read-only.",
 );
 
 export type GetBacklinksContext = {
-  arguments: { path: string; includeUnresolved?: "true" | "false" };
+  arguments: {
+    path: string;
+    includeUnresolved?: "true" | "false";
+    limit?: number;
+  };
   app: App;
 };
 
@@ -83,11 +88,18 @@ export async function getBacklinksHandler(ctx: GetBacklinksContext): Promise<{
     return compareName(a.path, b.path);
   });
 
+  const limit = Math.min(
+    1000,
+    Math.max(1, Math.floor(ctx.arguments.limit ?? 200)),
+  );
+  const truncated = backlinks.length > limit;
+
   const output = {
     target,
     totalBacklinks: backlinks.length,
-    backlinks,
+    ...(truncated ? { truncated: true } : {}),
+    backlinks: truncated ? backlinks.slice(0, limit) : backlinks,
   };
 
-  return successText(JSON.stringify(output, null, 2));
+  return successText(JSON.stringify(output));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getFilesByTag.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getFilesByTag.test.ts
@@ -201,4 +201,35 @@ describe("get_files_by_tag tool", () => {
     expect(data.totalFiles).toBe(1);
     expect(data.files[0].path).toBe("note.md");
   });
+
+  test("caps output at limit and reports truncated+total", async () => {
+    setMockFile("a.md", "");
+    setMockFile("b.md", "");
+    setMockFile("c.md", "");
+    setMockMetadata("a.md", { tags: [{ tag: "#k" }] });
+    setMockMetadata("b.md", { tags: [{ tag: "#k" }] });
+    setMockMetadata("c.md", { tags: [{ tag: "#k" }] });
+    const r = await getFilesByTagHandler({
+      arguments: { tag: "k", limit: 2 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.files).toHaveLength(2);
+    expect(data.truncated).toBe(true);
+    expect(data.totalFiles).toBe(3);
+  });
+
+  test("default limit leaves a small result set untouched (no truncated field)", async () => {
+    setMockFile("a.md", "");
+    setMockFile("b.md", "");
+    setMockMetadata("a.md", { tags: [{ tag: "#k" }] });
+    setMockMetadata("b.md", { tags: [{ tag: "#k" }] });
+    const r = await getFilesByTagHandler({
+      arguments: { tag: "k" },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.files).toHaveLength(2);
+    expect(data.truncated).toBeUndefined();
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getFilesByTag.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getFilesByTag.ts
@@ -11,13 +11,14 @@ export const getFilesByTagSchema = type({
     "includeNested?": type('"true" | "false"').describe(
       'When `"true"` (default), `tag="#project"` matches `#project`, `#project/active`, `#project/archived`, etc., mirroring Obsidian\'s hierarchical tag pane behaviour. When `"false"`, only exact matches are returned.',
     ),
+    "limit?": type("number>0").describe("Max results returned (default 200)."),
   },
 }).describe(
   "Returns all vault files tagged with the given tag, with per-file occurrence count. Aggregates inline `#tags` and frontmatter tags via Obsidian's metadata cache (`getAllTags`). Sorted by occurrence count descending, with file path tiebreaker for determinism. Always read-only.",
 );
 
 export type GetFilesByTagContext = {
-  arguments: { tag: string; includeNested?: "true" | "false" };
+  arguments: { tag: string; includeNested?: "true" | "false"; limit?: number };
   app: App;
 };
 
@@ -87,12 +88,19 @@ export async function getFilesByTagHandler(ctx: GetFilesByTagContext): Promise<{
     return compareName(a.path, b.path);
   });
 
+  const limit = Math.min(
+    1000,
+    Math.max(1, Math.floor(ctx.arguments.limit ?? 200)),
+  );
+  const truncated = counts.length > limit;
+
   const output = {
     tag: `#${normalized}`,
     includeNested,
     totalFiles: counts.length,
-    files: counts,
+    ...(truncated ? { truncated: true } : {}),
+    files: truncated ? counts.slice(0, limit) : counts,
   };
 
-  return successText(JSON.stringify(output, null, 2));
+  return successText(JSON.stringify(output));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getNoteOutline.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getNoteOutline.ts
@@ -36,15 +36,11 @@ export async function getNoteOutlineHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error: `File not found: ${path}`,
-              errorCode: "file_not_found",
-              path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: `File not found: ${path}`,
+            errorCode: "file_not_found",
+            path,
+          }),
         },
       ],
       isError: true,
@@ -55,15 +51,11 @@ export async function getNoteOutlineHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error: `Path is a folder: ${path}`,
-              errorCode: "not_a_file",
-              path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: `Path is a folder: ${path}`,
+            errorCode: "not_a_file",
+            path,
+          }),
         },
       ],
       isError: true,
@@ -84,11 +76,11 @@ export async function getNoteOutlineHandler(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          { path, heading_count: headings.length, headings },
-          null,
-          2,
-        ),
+        text: JSON.stringify({
+          path,
+          heading_count: headings.length,
+          headings,
+        }),
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getNoteProperty.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getNoteProperty.ts
@@ -30,15 +30,11 @@ export async function getNotePropertyHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error: "File not found",
-              errorCode: "file_not_found",
-              path: ctx.arguments.path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: "File not found",
+            errorCode: "file_not_found",
+            path: ctx.arguments.path,
+          }),
         },
       ],
       isError: true,
@@ -49,15 +45,11 @@ export async function getNotePropertyHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error: "Path is a folder, not a file",
-              errorCode: "not_a_file",
-              path: ctx.arguments.path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: "Path is a folder, not a file",
+            errorCode: "not_a_file",
+            path: ctx.arguments.path,
+          }),
         },
       ],
       isError: true,
@@ -75,15 +67,11 @@ export async function getNotePropertyHandler(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            path: ctx.arguments.path,
-            key: ctx.arguments.key,
-            value: value ?? null,
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify({
+          path: ctx.arguments.path,
+          key: ctx.arguments.key,
+          value: value ?? null,
+        }),
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreateDailyNote.ts
@@ -36,17 +36,13 @@ export async function getOrCreateDailyNoteHandler(
         content: [
           {
             type: "text",
-            text: JSON.stringify(
-              {
-                error:
-                  "Invalid date format for period 'daily' — expected `YYYY-MM-DD`.",
-                errorCode: "invalid_date_for_period",
-                period: "daily",
-                date,
-              },
-              null,
-              2,
-            ),
+            text: JSON.stringify({
+              error:
+                "Invalid date format for period 'daily' — expected `YYYY-MM-DD`.",
+              errorCode: "invalid_date_for_period",
+              period: "daily",
+              date,
+            }),
           },
         ],
         isError: true,
@@ -57,17 +53,13 @@ export async function getOrCreateDailyNoteHandler(
         content: [
           {
             type: "text",
-            text: JSON.stringify(
-              {
-                error:
-                  "Date is well-shaped but not a real calendar date (e.g. month 13, Feb 30).",
-                errorCode: "invalid_date_for_period",
-                period: "daily",
-                date,
-              },
-              null,
-              2,
-            ),
+            text: JSON.stringify({
+              error:
+                "Date is well-shaped but not a real calendar date (e.g. month 13, Feb 30).",
+              errorCode: "invalid_date_for_period",
+              period: "daily",
+              date,
+            }),
           },
         ],
         isError: true,
@@ -91,16 +83,12 @@ export async function getOrCreateDailyNoteHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error:
-                "Internal: daily note resolved but not retrievable after create.",
-              errorCode: "internal_error",
-              path: resolved.path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error:
+              "Internal: daily note resolved but not retrievable after create.",
+            errorCode: "internal_error",
+            path: resolved.path,
+          }),
         },
       ],
       isError: true,
@@ -111,15 +99,11 @@ export async function getOrCreateDailyNoteHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error: "Path is not a file",
-              errorCode: "not_a_file",
-              path: resolved.path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: "Path is not a file",
+            errorCode: "not_a_file",
+            path: resolved.path,
+          }),
         },
       ],
       isError: true,
@@ -131,11 +115,7 @@ export async function getOrCreateDailyNoteHandler(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          { path: resolved.path, content, created },
-          null,
-          2,
-        ),
+        text: JSON.stringify({ path: resolved.path, content, created }),
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOrCreatePeriodicNote.ts
@@ -41,16 +41,12 @@ export async function getOrCreatePeriodicNoteHandler(
         content: [
           {
             type: "text",
-            text: JSON.stringify(
-              {
-                error: `Invalid date format for period '${period}' — expected ${describeFormat(period)}.`,
-                errorCode: "invalid_date_for_period",
-                period,
-                date,
-              },
-              null,
-              2,
-            ),
+            text: JSON.stringify({
+              error: `Invalid date format for period '${period}' — expected ${describeFormat(period)}.`,
+              errorCode: "invalid_date_for_period",
+              period,
+              date,
+            }),
           },
         ],
         isError: true,
@@ -61,17 +57,13 @@ export async function getOrCreatePeriodicNoteHandler(
         content: [
           {
             type: "text",
-            text: JSON.stringify(
-              {
-                error:
-                  "Date is well-shaped but not a real calendar value (e.g. month 13, Feb 30, ISO-week 99).",
-                errorCode: "invalid_date_for_period",
-                period,
-                date,
-              },
-              null,
-              2,
-            ),
+            text: JSON.stringify({
+              error:
+                "Date is well-shaped but not a real calendar value (e.g. month 13, Feb 30, ISO-week 99).",
+              errorCode: "invalid_date_for_period",
+              period,
+              date,
+            }),
           },
         ],
         isError: true,
@@ -91,17 +83,13 @@ export async function getOrCreatePeriodicNoteHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error:
-                "Internal: periodic note resolved but not retrievable after create.",
-              errorCode: "internal_error",
-              period,
-              path: resolved.path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error:
+              "Internal: periodic note resolved but not retrievable after create.",
+            errorCode: "internal_error",
+            period,
+            path: resolved.path,
+          }),
         },
       ],
       isError: true,
@@ -112,17 +100,12 @@ export async function getOrCreatePeriodicNoteHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error:
-                "Internal: periodic note resolved to a folder, not a file.",
-              errorCode: "internal_error",
-              period,
-              path: resolved.path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: "Internal: periodic note resolved to a folder, not a file.",
+            errorCode: "internal_error",
+            period,
+            path: resolved.path,
+          }),
         },
       ],
       isError: true,
@@ -135,11 +118,7 @@ export async function getOrCreatePeriodicNoteHandler(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          { period, path: resolved.path, content, created },
-          null,
-          2,
-        ),
+        text: JSON.stringify({ period, path: resolved.path, content, created }),
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.test.ts
@@ -246,4 +246,40 @@ describe("get_outgoing_links tool", () => {
       targetPath: null,
     });
   });
+
+  test("caps output at limit and reports truncated+total", async () => {
+    setMockFile("note.md", "");
+    setMockMetadata("note.md", {
+      links: [
+        { link: "a", original: "[[a]]" },
+        { link: "b", original: "[[b]]" },
+        { link: "c", original: "[[c]]" },
+      ],
+    });
+    const r = await getOutgoingLinksHandler({
+      arguments: { path: "note.md", limit: 2 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.links).toHaveLength(2);
+    expect(data.truncated).toBe(true);
+    expect(data.totalLinks).toBe(3);
+  });
+
+  test("default limit leaves a small result set untouched (no truncated field)", async () => {
+    setMockFile("note.md", "");
+    setMockMetadata("note.md", {
+      links: [
+        { link: "a", original: "[[a]]" },
+        { link: "b", original: "[[b]]" },
+      ],
+    });
+    const r = await getOutgoingLinksHandler({
+      arguments: { path: "note.md" },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.links).toHaveLength(2);
+    expect(data.truncated).toBeUndefined();
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.ts
@@ -12,6 +12,7 @@ export const getOutgoingLinksSchema = type({
     "includeUnresolved?": type('"true" | "false"').describe(
       'Default `"true"`: unresolved links included with `resolved: false`. `"false"` filters them out.',
     ),
+    "limit?": type("number>0").describe("Max results returned (default 200)."),
   },
 }).describe(
   "Returns every link in a file: body links, embeds (`![[…]]`), and frontmatter links. Each entry has linkpath, original syntax, display text, layer (`body` | `frontmatter`), embed flag, resolution status, and resolved path. Document order. `isError: true` if the file does not exist.",
@@ -22,6 +23,7 @@ export type GetOutgoingLinksContext = {
     path: string;
     includeEmbeds?: "true" | "false";
     includeUnresolved?: "true" | "false";
+    limit?: number;
   };
   app: App;
 };
@@ -116,10 +118,17 @@ export async function getOutgoingLinksHandler(
 
   const filtered = includeUnresolved ? out : out.filter((l) => l.resolved);
 
+  const limit = Math.min(
+    1000,
+    Math.max(1, Math.floor(ctx.arguments.limit ?? 200)),
+  );
+  const truncated = filtered.length > limit;
+
   const output = {
     source: sourcePath,
     totalLinks: filtered.length,
-    links: filtered,
+    ...(truncated ? { truncated: true } : {}),
+    links: truncated ? filtered.slice(0, limit) : filtered,
   };
 
   return successJson(output);

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
@@ -100,5 +100,5 @@ export async function getRecentFilesHandler(
 
   const output = { totalFiles, files };
 
-  return successText(JSON.stringify(output, null, 2));
+  return successText(JSON.stringify(output));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getServerInfo.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getServerInfo.ts
@@ -36,5 +36,5 @@ export async function getServerInfoHandler(
     transport: "streamable-http",
     ...(localTransport ? { localTransport } : {}),
   };
-  return successText(JSON.stringify(body, null, 2));
+  return successText(JSON.stringify(body));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
@@ -154,11 +154,13 @@ export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            { path: file.path, content: text, frontmatter, tags, stat },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            path: file.path,
+            content: text,
+            frontmatter,
+            tags,
+            stat,
+          }),
         },
       ],
     };
@@ -182,16 +184,12 @@ export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              kind: "binary_file",
-              filename: file.path,
-              mimeType: "application/octet-stream",
-              hint: "This file is binary (video, PDF, Office document, or archive) and cannot be returned as text content. Use show_file_in_obsidian to open it in the Obsidian UI.",
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            kind: "binary_file",
+            filename: file.path,
+            mimeType: "application/octet-stream",
+            hint: "This file is binary (video, PDF, Office document, or archive) and cannot be returned as text content. Use show_file_in_obsidian to open it in the Obsidian UI.",
+          }),
         },
       ],
     };
@@ -206,16 +204,12 @@ export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              kind: "binary_file",
-              filename: file.path,
-              mimeType: mimeEntry.mime,
-              hint: "This file is too large to be returned inline (exceeds the 10 MiB cap to avoid overflowing the MCP client context window). Use show_file_in_obsidian to open it in the Obsidian UI.",
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            kind: "binary_file",
+            filename: file.path,
+            mimeType: mimeEntry.mime,
+            hint: "This file is too large to be returned inline (exceeds the 10 MiB cap to avoid overflowing the MCP client context window). Use show_file_in_obsidian to open it in the Obsidian UI.",
+          }),
         },
       ],
     };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listBookmarks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listBookmarks.ts
@@ -130,11 +130,7 @@ export async function listBookmarksHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            { enabled: false, total_items: 0, items: [] },
-            null,
-            2,
-          ),
+          text: JSON.stringify({ enabled: false, total_items: 0, items: [] }),
         },
       ],
     };
@@ -144,16 +140,12 @@ export async function listBookmarksHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              enabled: true,
-              total_items: 0,
-              items: [],
-              note: "Bookmarks plugin not yet initialized",
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            enabled: true,
+            total_items: 0,
+            items: [],
+            note: "Bookmarks plugin not yet initialized",
+          }),
         },
       ],
     };
@@ -173,11 +165,11 @@ export async function listBookmarksHandler(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          { enabled: true, total_items: countItems(items), items },
-          null,
-          2,
-        ),
+        text: JSON.stringify({
+          enabled: true,
+          total_items: countItems(items),
+          items,
+        }),
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listObsidianCommands.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listObsidianCommands.test.ts
@@ -65,4 +65,35 @@ describe("list_obsidian_commands tool", () => {
     const data = JSON.parse(r.content[0].text as string);
     expect(data.commands).toEqual([]);
   });
+
+  test("caps output at limit and reports truncated+total", async () => {
+    setMockCommands([
+      { id: "a", name: "A" },
+      { id: "b", name: "B" },
+      { id: "c", name: "C" },
+    ]);
+    const r = await listObsidianCommandsHandler({
+      arguments: { limit: 2 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.commands).toHaveLength(2);
+    expect(data.truncated).toBe(true);
+    expect(data.total).toBe(3);
+  });
+
+  test("default limit leaves a small result set untouched (no truncated field)", async () => {
+    setMockCommands([
+      { id: "a", name: "A" },
+      { id: "b", name: "B" },
+    ]);
+    const r = await listObsidianCommandsHandler({
+      arguments: {},
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.commands).toHaveLength(2);
+    expect(data.truncated).toBeUndefined();
+    expect(data.total).toBeUndefined();
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listObsidianCommands.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listObsidianCommands.ts
@@ -8,13 +8,14 @@ export const listObsidianCommandsSchema = type({
     "filter?": type("string").describe(
       "Case-insensitive substring; matches against command id or display name.",
     ),
+    "limit?": type("number>0").describe("Max results returned (default 200)."),
   },
 }).describe(
   "Lists registered Obsidian commands (core + plugins). Always read-only and unrestricted by command-permissions.",
 );
 
 export type ListObsidianCommandsContext = {
-  arguments: { filter?: string };
+  arguments: { filter?: string; limit?: number };
   app: App;
 };
 
@@ -40,5 +41,16 @@ export async function listObsidianCommandsHandler(
       )
     : all;
 
-  return successText(JSON.stringify({ commands }, null, 2));
+  const limit = Math.min(
+    1000,
+    Math.max(1, Math.floor(ctx.arguments.limit ?? 200)),
+  );
+  const truncated = commands.length > limit;
+
+  return successText(
+    JSON.stringify({
+      commands: truncated ? commands.slice(0, limit) : commands,
+      ...(truncated ? { truncated: true, total: commands.length } : {}),
+    }),
+  );
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listPropertyValues.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listPropertyValues.ts
@@ -75,11 +75,12 @@ export async function listPropertyValuesHandler(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          { key, values, truncated: totalDistinct > limit, totalDistinct },
-          null,
-          2,
-        ),
+        text: JSON.stringify({
+          key,
+          values,
+          truncated: totalDistinct > limit,
+          totalDistinct,
+        }),
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.test.ts
@@ -136,4 +136,24 @@ describe("list_tags tool", () => {
       "#project/active",
     ]);
   });
+
+  test("caps output at limit and reports truncated+total", async () => {
+    setMockTags({ "#a": 3, "#b": 2, "#c": 1 });
+    const r = await listTagsHandler({
+      arguments: { limit: 2 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.tags).toHaveLength(2);
+    expect(data.truncated).toBe(true);
+    expect(data.totalTags).toBe(3);
+  });
+
+  test("default limit leaves a small result set untouched (no truncated field)", async () => {
+    setMockTags({ "#a": 1, "#b": 2 });
+    const r = await listTagsHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.tags).toHaveLength(2);
+    expect(data.truncated).toBeUndefined();
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.ts
@@ -8,13 +8,14 @@ export const listTagsSchema = type({
     "sort?": type('"name" | "count"').describe(
       "Sort by tag name (alphabetical, ascending) or by usage count (descending). Defaults to 'count'.",
     ),
+    "limit?": type("number>0").describe("Max results returned (default 200)."),
   },
 }).describe(
   "Lists all tags used across the vault with their usage counts. Aggregates both inline `#tags` and frontmatter tags via Obsidian's metadata cache. Useful for discovering content categories, finding related notes, and understanding vault organization. Always read-only.",
 );
 
 export type ListTagsContext = {
-  arguments: { sort?: "name" | "count" };
+  arguments: { sort?: "name" | "count"; limit?: number };
   app: App;
 };
 
@@ -51,10 +52,18 @@ export async function listTagsHandler(
     return compareName(a[0], b[0]);
   });
 
+  const limit = Math.min(
+    1000,
+    Math.max(1, Math.floor(ctx.arguments.limit ?? 200)),
+  );
+  const all = sorted.map(([tag, count]) => ({ tag, count }));
+  const truncated = all.length > limit;
+
   const output = {
-    totalTags: sorted.length,
-    tags: sorted.map(([tag, count]) => ({ tag, count })),
+    totalTags: all.length,
+    ...(truncated ? { truncated: true } : {}),
+    tags: truncated ? all.slice(0, limit) : all,
   };
 
-  return successText(JSON.stringify(output, null, 2));
+  return successText(JSON.stringify(output));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listVaultFiles.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listVaultFiles.test.ts
@@ -68,4 +68,28 @@ describe("list_vault_files tool", () => {
       JSON.parse(r2.content[0].text as string).files,
     );
   });
+
+  test("caps output at limit and reports truncated+total", async () => {
+    setMockFile("a.md", "");
+    setMockFile("b.md", "");
+    setMockFile("c.md", "");
+    const r = await listVaultFilesHandler({
+      arguments: { limit: 2 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.files).toHaveLength(2);
+    expect(data.truncated).toBe(true);
+    expect(data.total).toBe(3);
+  });
+
+  test("default limit leaves a small result set untouched (no truncated field)", async () => {
+    setMockFile("a.md", "");
+    setMockFile("b.md", "");
+    const r = await listVaultFilesHandler({ arguments: {}, app: mockApp() });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.files).toHaveLength(2);
+    expect(data.truncated).toBeUndefined();
+    expect(data.total).toBeUndefined();
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listVaultFiles.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listVaultFiles.ts
@@ -8,13 +8,14 @@ export const listVaultFilesSchema = type({
     "directory?": type("string").describe(
       "Optional vault-relative directory prefix. Empty/omitted = vault root (all files).",
     ),
+    "limit?": type("number>0").describe("Max results returned (default 200)."),
   },
 }).describe(
   "Lists vault files, optionally filtered by directory prefix. Returns an array of vault-relative paths.",
 );
 
 export type ListVaultFilesContext = {
-  arguments: { directory?: string };
+  arguments: { directory?: string; limit?: number };
   app: App;
 };
 
@@ -30,5 +31,16 @@ export async function listVaultFilesHandler(
     ? all.filter((f) => f.path.startsWith(prefix)).map((f) => f.path)
     : all.map((f) => f.path);
 
-  return successText(JSON.stringify({ files }, null, 2));
+  const limit = Math.min(
+    1000,
+    Math.max(1, Math.floor(ctx.arguments.limit ?? 200)),
+  );
+  const truncated = files.length > limit;
+
+  return successText(
+    JSON.stringify({
+      files: truncated ? files.slice(0, limit) : files,
+      ...(truncated ? { truncated: true, total: files.length } : {}),
+    }),
+  );
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
@@ -52,7 +52,7 @@ function errorResponse(payload: {
   content: Array<{ type: "text"; text: string }>;
   isError: true;
 } {
-  return errorText(JSON.stringify(payload, null, 2));
+  return errorText(JSON.stringify(payload));
 }
 
 function successResponse(payload: {
@@ -60,7 +60,7 @@ function successResponse(payload: {
   updatedFiles: string[];
   linkRewriteCount: number;
 }): { content: Array<{ type: "text"; text: string }> } {
-  return successText(JSON.stringify(payload, null, 2));
+  return successText(JSON.stringify(payload));
 }
 
 function partialFailureResponse(payload: {
@@ -70,7 +70,7 @@ function partialFailureResponse(payload: {
   failedFiles: Array<{ path: string; error: string }>;
   linkRewriteCount: number;
 }): { content: Array<{ type: "text"; text: string }>; isError: true } {
-  return errorText(JSON.stringify(payload, null, 2));
+  return errorText(JSON.stringify(payload));
 }
 
 /**

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameVaultFile.ts
@@ -78,8 +78,6 @@ export async function renameVaultFileHandler(
   }
 
   return {
-    content: [
-      { type: "text", text: JSON.stringify({ ok: true, path: to }, null, 2) },
-    ],
+    content: [{ type: "text", text: JSON.stringify({ ok: true, path: to }) }],
   };
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchAndReplace.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchAndReplace.ts
@@ -72,16 +72,12 @@ export async function searchAndReplaceHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error: `Invalid regex: ${msg}`,
-              errorCode: "invalid_regex",
-              pattern,
-              flags,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: `Invalid regex: ${msg}`,
+            errorCode: "invalid_regex",
+            pattern,
+            flags,
+          }),
         },
       ],
       isError: true,
@@ -97,16 +93,12 @@ export async function searchAndReplaceHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error:
-                "Pattern contains nested quantifiers (ReDoS risk). Simplify the pattern.",
-              errorCode: "unsafe_regex",
-              pattern,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error:
+              "Pattern contains nested quantifiers (ReDoS risk). Simplify the pattern.",
+            errorCode: "unsafe_regex",
+            pattern,
+          }),
         },
       ],
       isError: true,
@@ -174,18 +166,14 @@ export async function searchAndReplaceHandler(
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            dry_run: dryRun,
-            pattern,
-            flags_used: flags,
-            files_matched: details.length,
-            total_replacements: totalReplacements,
-            details,
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify({
+          dry_run: dryRun,
+          pattern,
+          flags_used: flags,
+          files_matched: details.length,
+          total_replacements: totalReplacements,
+          details,
+        }),
       },
     ],
   };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSimple.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSimple.ts
@@ -72,5 +72,5 @@ export async function searchVaultSimpleHandler(
     }
   }
 
-  return successText(JSON.stringify({ results }, null, 2));
+  return successText(JSON.stringify({ results }));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
@@ -142,5 +142,5 @@ export async function searchVaultSmartHandler(
   const isExcluded = createExclusionFilter(ctx.app);
   results = results.filter((r) => !isExcluded(r.filePath));
 
-  return successText(JSON.stringify({ results }, null, 2));
+  return successText(JSON.stringify({ results }));
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.ts
@@ -72,11 +72,11 @@ export async function setNotePropertyHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            { error: "Invalid frontmatter key", errorCode: "invalid_key", key },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: "Invalid frontmatter key",
+            errorCode: "invalid_key",
+            key,
+          }),
         },
       ],
       isError: true,
@@ -89,11 +89,11 @@ export async function setNotePropertyHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            { error: "File not found", errorCode: "file_not_found", path },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: "File not found",
+            errorCode: "file_not_found",
+            path,
+          }),
         },
       ],
       isError: true,
@@ -104,15 +104,11 @@ export async function setNotePropertyHandler(
       content: [
         {
           type: "text",
-          text: JSON.stringify(
-            {
-              error: "Path is a folder, not a file",
-              errorCode: "not_a_file",
-              path,
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify({
+            error: "Path is a folder, not a file",
+            errorCode: "not_a_file",
+            path,
+          }),
         },
       ],
       isError: true,
@@ -131,8 +127,6 @@ export async function setNotePropertyHandler(
 
   const action = value === null ? "deleted" : "set";
   return {
-    content: [
-      { type: "text", text: JSON.stringify({ path, key, action }, null, 2) },
-    ],
+    content: [{ type: "text", text: JSON.stringify({ path, key, action }) }],
   };
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/toolCatalog.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/toolCatalog.ts
@@ -22,6 +22,15 @@ type PluginLike = {
   loadData: () => Promise<unknown>;
 };
 
+// Inactive tools only surface their first sentence — the remaining prose is
+// pure token cost in the catalog listing. Split on the first ". " sentence
+// boundary and keep the period; a single-sentence description is returned
+// verbatim.
+function firstSentence(description: string): string {
+  const i = description.indexOf(". ");
+  return i === -1 ? description : description.slice(0, i + 1);
+}
+
 export async function toolCatalogHandler({
   registry,
   plugin,
@@ -47,7 +56,9 @@ export async function toolCatalogHandler({
         name: entry.name,
         status: "inactive",
         call_count: callCount,
-        description: entry.description || undefined,
+        description: entry.description
+          ? firstSentence(entry.description)
+          : undefined,
       };
     }
     return {
@@ -57,5 +68,5 @@ export async function toolCatalogHandler({
     };
   });
 
-  return successText(JSON.stringify(catalog, null, 2));
+  return successText(JSON.stringify(catalog));
 }


### PR DESCRIPTION
LLMs consume tool results, so JSON indentation was pure token cost (120 to 180 tokens per call on medium payloads). This is PR 1 of the quick-wins bundle from the 2026-06-12 four-dimension audit (performance, tokens, architecture, spec).

**Changes**

1. All tool result payloads switch to compact `JSON.stringify` (no indentation): `successJson`/`errorJson` in `responseBuilders.ts` plus 22 single-line and ~40 multi-line inline sites across 38 tool files. Wire shape is unchanged, only whitespace.
2. Optional `limit` argument (default 200, clamped to [1,1000]) on eight list/scan tools: `list_tags`, `get_backlinks`, `get_outgoing_links`, `find_orphaned_notes`, `get_files_by_tag`, `list_vault_files`, `find_broken_links`, `list_obsidian_commands`. When the result array exceeds the limit it is sliced and the payload gains `truncated: true`; the two tools without a full-count field also gain `total`. The truncation signal is emitted only when slicing occurs, so untruncated payloads are byte-identical to before.
3. `tool_catalog` trims inactive tool descriptions to their first sentence.

**Verification**

- `bun test`: 1152 pass / 0 fail (16 new tests: cap + default-unchanged per tool)
- `tsc --noEmit` clean, prettier clean