### PR TITLE
perf: memoize tools/list and skip no-op index rewrites

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
@@ -480,3 +480,33 @@ describe("ToolRegistry — tool-error log redaction", () => {
     expect(JSON.stringify(meta)).not.toContain("private-note-body");
   });
 });
+
+describe("ToolRegistry list() memoization", () => {
+  test("repeated list() calls return the same object until enable/disable", () => {
+    const { tools, alphaSchema } = buildRegistryWithTwoTools();
+
+    const first = tools.list();
+    expect(tools.list()).toBe(first);
+
+    tools.disable(alphaSchema);
+    const afterDisable = tools.list();
+    expect(afterDisable).not.toBe(first);
+    expect(afterDisable.tools.map((t) => t.name)).toEqual(["beta"]);
+    expect(tools.list()).toBe(afterDisable);
+
+    tools.enable(alphaSchema);
+    const afterEnable = tools.list();
+    expect(afterEnable).not.toBe(afterDisable);
+    // Re-enabling appends to the Set, so alpha moves to the end.
+    expect(afterEnable.tools.map((t) => t.name)).toEqual(["beta", "alpha"]);
+  });
+
+  test("enableByName/disableByName also invalidate the cache", () => {
+    const { tools } = buildRegistryWithTwoTools();
+
+    const first = tools.list();
+    tools.disableByName("beta");
+    expect(tools.list().tools.map((t) => t.name)).toEqual(["alpha"]);
+    expect(tools.list()).not.toBe(first);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
@@ -162,6 +162,21 @@ export class ToolRegistryClass<
 > extends Map<TSchema, THandler> {
   private enabled = new Set<TSchema>();
 
+  /**
+   * Memoized `list()` result. ArkType `toJsonSchema()` + the
+   * normalization walk are pure functions of the enabled set, which
+   * only changes via `enable()`/`disable()` — recomputing them on
+   * every `tools/list` request (one per client session in stateless
+   * transport) is wasted work.
+   */
+  private listCache: {
+    tools: {
+      name: string;
+      description: string | undefined;
+      inputSchema: Record<string, unknown>;
+    }[];
+  } | null = null;
+
   register<
     Schema extends TSchema,
     Handler extends (
@@ -183,11 +198,13 @@ export class ToolRegistryClass<
 
   enable = <Schema extends TSchema>(schema: Schema) => {
     this.enabled.add(schema);
+    this.listCache = null;
     return this;
   };
 
   disable = <Schema extends TSchema>(schema: Schema) => {
     this.enabled.delete(schema);
+    this.listCache = null;
     return this;
   };
 
@@ -224,7 +241,7 @@ export class ToolRegistryClass<
   };
 
   list = () => {
-    return {
+    this.listCache ??= {
       tools: Array.from(this.enabled.values()).map((schema) => {
         return {
           name: (schema.get("name").toJsonSchema() as { const: string }).const,
@@ -235,6 +252,7 @@ export class ToolRegistryClass<
         };
       }),
     };
+    return this.listCache;
   };
 
   listAll = (): { name: string; description: string; enabled: boolean }[] =>

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
@@ -1078,3 +1078,94 @@ describe("indexer — isUserIgnored exclusion (#238)", () => {
     await indexer.stop();
   });
 });
+
+/**
+ * Proxies every method to the wrapped store and counts delete/upsert
+ * calls, so tests can assert that a no-op save never touches the
+ * store (which would mark it dirty and trigger a full-store rewrite
+ * at the next flush).
+ */
+function wrapStoreWithWriteSpy(store: Awaited<ReturnType<typeof makeStore>>): {
+  store: typeof store;
+  writes: () => { deletes: number; upserts: number };
+} {
+  let deletes = 0;
+  let upserts = 0;
+  const wrapped: typeof store = {
+    init: () => store.init(),
+    size: () => store.size(),
+    scan: () => store.scan(),
+    recordsFor: (path) => store.recordsFor(path),
+    upsert: (records) => {
+      upserts++;
+      return store.upsert(records);
+    },
+    delete: (path) => {
+      deletes++;
+      return store.delete(path);
+    },
+    close: () => store.close(),
+    flush: () => store.flush(),
+  };
+  return { store: wrapped, writes: () => ({ deletes, upserts }) };
+}
+
+describe("live indexer — unchanged-file no-op skip", () => {
+  test("modify event with identical content skips delete/upsert", async () => {
+    const rawStore = await makeStore();
+    const { vault, files, emit } = makeVault({
+      "a.md": "alpha---CHUNK---beta",
+    });
+    const { embedder } = fakeEmbeddingProvider();
+    const { store, writes } = wrapStoreWithWriteSpy(rawStore);
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 10,
+    });
+    await indexer.start();
+    const afterBuild = writes();
+
+    // Same content saved again: chunking is identical, so the path
+    // must not be rewritten.
+    files.set("a.md", "alpha---CHUNK---beta");
+    emit("modify", "a.md");
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(writes()).toEqual(afterBuild);
+    expect(rawStore.size()).toBe(2);
+
+    await indexer.stop();
+  });
+
+  test("modify event with changed content still rewrites the path", async () => {
+    const rawStore = await makeStore();
+    const { vault, files, emit } = makeVault({
+      "a.md": "alpha---CHUNK---beta",
+    });
+    const { embedder } = fakeEmbeddingProvider();
+    const { store, writes } = wrapStoreWithWriteSpy(rawStore);
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 10,
+    });
+    await indexer.start();
+    const afterBuild = writes();
+
+    files.set("a.md", "alpha---CHUNK---gamma");
+    emit("modify", "a.md");
+    await new Promise((r) => setTimeout(r, 60));
+
+    const afterModify = writes();
+    expect(afterModify.deletes).toBe(afterBuild.deletes + 1);
+    expect(afterModify.upserts).toBe(afterBuild.upserts + 1);
+    expect(rawStore.size()).toBe(2);
+
+    await indexer.stop();
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -523,6 +523,34 @@ async function processOnePath(deps: ProcessDeps, path: string): Promise<void> {
     });
   }
 
+  // A save that didn't change the chunking (the common autosave case)
+  // would otherwise mark the store dirty and trigger a full-store
+  // rewrite at the next flush.
+  if (sameRecordSet(records, deps.store.recordsFor(path))) return;
+
   await deps.store.delete(path);
   await deps.store.upsert(records);
+}
+
+/**
+ * True when the freshly built records match the stored ones
+ * field-for-field. Vectors are excluded: a matching contentHash means
+ * the vector was reused from the matching stored record.
+ */
+function sameRecordSet(
+  next: EmbeddingRecord[],
+  current: Iterable<EmbeddingRecord>,
+): boolean {
+  const byId = new Map<string, EmbeddingRecord>();
+  for (const r of current) byId.set(r.chunkId, r);
+  if (byId.size !== next.length) return false;
+  return next.every((r) => {
+    const e = byId.get(r.chunkId);
+    return (
+      e !== undefined &&
+      e.contentHash === r.contentHash &&
+      e.offset === r.offset &&
+      e.heading === r.heading
+    );
+  });
 }


### PR DESCRIPTION
PR 2 of the quick-wins bundle from the 2026-06-12 audit.

**Changes**

1. `ToolRegistryClass.list()` memoizes its result. ArkType `toJsonSchema()` plus the normalization walk (structuredClone + recursive description dedup) ran for every enabled tool on every `tools/list` request, one per client session on the stateless transport. The result is a pure function of the enabled set, so the cache invalidates only in `enable()`/`disable()` (which also covers `enableByName`/`disableByName` and `register`).
2. `processOnePath` in the live indexer now compares the freshly built records against `recordsFor(path)` (chunkId, contentHash, offset, heading; vectors excluded since a matching hash means the vector was reused) and returns early when identical. An autosave that doesn't change the chunking no longer marks the store dirty, so the debounced flush skips the full-store rewrite (previously O(vault chunks) serialization plus two full-file writes per no-op save).

**Verification**

- `bun test`: 1140 pass / 0 fail (4 new tests: memoize + invalidation, no-op skip + changed-content rewrite)
- `tsc --noEmit` clean, prettier clean