### PR TITLE
feat: add MCP tool annotations to all 45 tools

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -1,6 +1,7 @@
 import type { App } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import type { ToolRegistry } from "$/features/mcp-transport/services/toolRegistry";
+import { TOOL_ANNOTATIONS } from "./toolAnnotations";
 
 import {
   getServerInfoHandler,
@@ -351,4 +352,8 @@ export async function registerTools(
       plugin: ctx.plugin,
     }),
   );
+
+  // Covers the meta-tools registered later in mcpServer.ts too:
+  // annotations are looked up by name at list() time.
+  registry.setAnnotations(TOOL_ANNOTATIONS);
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
@@ -1,0 +1,113 @@
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * MCP tool annotations (spec 2025-03-26+), keyed by public tool name.
+ *
+ * These are HINTS for clients (confirmation gating, visual badges) —
+ * never security boundaries. Spec defaults for a non-listed field:
+ * readOnlyHint false, destructiveHint true, idempotentHint false,
+ * openWorldHint true. Every vault tool sets openWorldHint: false
+ * (closed domain); `fetch` is the only open-world tool.
+ *
+ * destructiveHint is explicit on every writer, including where it
+ * matches the spec default, so the classification is reviewable here
+ * instead of implied. The mcpServer full-registry test enforces that
+ * every registered tool has an entry.
+ */
+const READ_ONLY: ToolAnnotations = {
+  readOnlyHint: true,
+  openWorldHint: false,
+};
+
+/** Additive writers: they never overwrite or remove existing content. */
+const SAFE_WRITE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  openWorldHint: false,
+};
+
+/** Writers that can overwrite or remove existing content. */
+const DESTRUCTIVE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  openWorldHint: false,
+};
+
+export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
+  // Health / server
+  get_server_info: READ_ONLY,
+
+  // Active file
+  get_active_file: READ_ONLY,
+  // Replaces the whole file content.
+  update_active_file: { ...DESTRUCTIVE, idempotentHint: true },
+  append_to_active_file: SAFE_WRITE,
+  patch_active_file: DESTRUCTIVE,
+  delete_active_file: DESTRUCTIVE,
+  // Only changes which file the Obsidian UI shows.
+  show_file_in_obsidian: { ...READ_ONLY, idempotentHint: true },
+
+  // Vault files
+  list_vault_files: READ_ONLY,
+  get_vault_file: READ_ONLY,
+  get_vault_file_partial: READ_ONLY,
+  // Overwrites when the path already exists (documented behavior).
+  create_vault_file: { ...DESTRUCTIVE, idempotentHint: true },
+  append_to_vault_file: SAFE_WRITE,
+  patch_vault_file: DESTRUCTIVE,
+  delete_vault_file: DESTRUCTIVE,
+  rename_vault_file: DESTRUCTIVE,
+  rename_heading: DESTRUCTIVE,
+  create_vault_directory: { ...SAFE_WRITE, idempotentHint: true },
+  delete_vault_directory: DESTRUCTIVE,
+
+  // Search
+  search_vault: READ_ONLY,
+  search_vault_simple: READ_ONLY,
+  search_vault_smart: READ_ONLY,
+  search_and_replace: DESTRUCTIVE,
+
+  // Network
+  fetch: { readOnlyHint: true, openWorldHint: true },
+
+  // Obsidian commands / integrations
+  // Commands are arbitrary; assume the worst.
+  execute_obsidian_command: DESTRUCTIVE,
+  list_obsidian_commands: READ_ONLY,
+  // Templater templates can run user-defined code and write files.
+  execute_template: DESTRUCTIVE,
+  execute_dataview_query: READ_ONLY,
+
+  // Graph / metadata
+  find_broken_links: READ_ONLY,
+  find_orphaned_notes: READ_ONLY,
+  get_backlinks: READ_ONLY,
+  get_outgoing_links: READ_ONLY,
+  get_files_by_tag: READ_ONLY,
+  list_tags: READ_ONLY,
+  list_property_values: READ_ONLY,
+  get_note_outline: READ_ONLY,
+
+  // Note properties
+  get_note_property: READ_ONLY,
+  // Replaces the existing value for the key.
+  set_note_property: { ...DESTRUCTIVE, idempotentHint: true },
+  delete_note_property: DESTRUCTIVE,
+
+  // Periodic notes / misc
+  get_recent_files: READ_ONLY,
+  list_bookmarks: READ_ONLY,
+  get_or_create_daily_note: { ...SAFE_WRITE, idempotentHint: true },
+  get_or_create_periodic_note: { ...SAFE_WRITE, idempotentHint: true },
+  append_to_periodic_note: SAFE_WRITE,
+
+  // Adaptive-loading meta-tools (registered in mcpServer.ts; lookup is
+  // name-keyed at list() time, so the entry can live here regardless).
+  tool_catalog: READ_ONLY,
+  activate_tool: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -153,6 +153,24 @@ describe("end-to-end: HTTP → McpServer", () => {
         "update_active_file",
       ]);
       expect(names).toHaveLength(45);
+
+      // Annotations completeness: every exposed tool must carry MCP
+      // annotations with an explicit readOnlyHint and openWorldHint.
+      // A failure here means a new tool was registered without an
+      // entry in mcp-tools/toolAnnotations.ts.
+      const missingAnnotations = (
+        tools as Array<{
+          name: string;
+          annotations?: { readOnlyHint?: boolean; openWorldHint?: boolean };
+        }>
+      )
+        .filter(
+          (t) =>
+            typeof t.annotations?.readOnlyHint !== "boolean" ||
+            typeof t.annotations?.openWorldHint !== "boolean",
+        )
+        .map((t) => t.name);
+      expect(missingAnnotations).toEqual([]);
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.test.ts
@@ -510,3 +510,35 @@ describe("ToolRegistry list() memoization", () => {
     expect(tools.list()).not.toBe(first);
   });
 });
+
+describe("ToolRegistry annotations", () => {
+  test("list() includes annotations for matching names and omits them otherwise", () => {
+    const { tools } = buildRegistryWithTwoTools();
+
+    tools.setAnnotations({
+      alpha: { readOnlyHint: true, openWorldHint: false },
+      never_registered: { readOnlyHint: true },
+    });
+
+    const listed = tools.list().tools;
+    const alpha = listed.find((t) => t.name === "alpha");
+    const beta = listed.find((t) => t.name === "beta");
+    expect(alpha?.annotations).toEqual({
+      readOnlyHint: true,
+      openWorldHint: false,
+    });
+    expect(beta && "annotations" in beta).toBe(false);
+  });
+
+  test("setAnnotations invalidates the memoized list()", () => {
+    const { tools } = buildRegistryWithTwoTools();
+
+    const first = tools.list();
+    tools.setAnnotations({ alpha: { readOnlyHint: true } });
+    const second = tools.list();
+    expect(second).not.toBe(first);
+    expect(second.tools.find((t) => t.name === "alpha")?.annotations).toEqual({
+      readOnlyHint: true,
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
@@ -3,6 +3,7 @@ import {
   ErrorCode,
   McpError,
   type Result,
+  type ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import { type, type Type } from "arktype";
 import { formatMcpError } from "./formatMcpError";
@@ -174,8 +175,26 @@ export class ToolRegistryClass<
       name: string;
       description: string | undefined;
       inputSchema: Record<string, unknown>;
+      annotations?: ToolAnnotations;
     }[];
   } | null = null;
+
+  /** MCP tool annotations, keyed by public tool name (set via setAnnotations). */
+  private annotationsByName = new Map<string, ToolAnnotations>();
+
+  /**
+   * Attach MCP tool annotations (readOnlyHint, destructiveHint, ...)
+   * by public tool name. Lookup happens lazily in list(), so the order
+   * relative to register() does not matter; entries for names that
+   * never register are simply unused. Invalidates the memoized list().
+   */
+  setAnnotations = (byName: Record<string, ToolAnnotations>) => {
+    for (const [name, annotations] of Object.entries(byName)) {
+      this.annotationsByName.set(name, annotations);
+    }
+    this.listCache = null;
+    return this;
+  };
 
   register<
     Schema extends TSchema,
@@ -243,12 +262,16 @@ export class ToolRegistryClass<
   list = () => {
     this.listCache ??= {
       tools: Array.from(this.enabled.values()).map((schema) => {
+        const name = (schema.get("name").toJsonSchema() as { const: string })
+          .const;
+        const annotations = this.annotationsByName.get(name);
         return {
-          name: (schema.get("name").toJsonSchema() as { const: string }).const,
+          name,
           description: schema.description,
           inputSchema: normalizeInputSchema(
             schema.get("arguments").toJsonSchema(),
           ),
+          ...(annotations ? { annotations } : {}),
         };
       }),
     };


### PR DESCRIPTION
PR 3 of the quick-wins bundle. Stacked on #275 (base will be retargeted to main once #275 merges).

**Changes**

Every tool in `tools/list` now carries MCP tool annotations (spec 2025-03-26): `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. Clients that honor them (Claude Desktop, Claude Code, Cursor) can gate confirmations on destructive calls and skip them on read-only ones.

Classification highlights, all reviewable in one place (`mcp-tools/toolAnnotations.ts`):
- 24 read-only tools (`search_*`, `get_*`, `list_*`, `find_*`, `execute_dataview_query`, `tool_catalog`)
- additive writers marked `destructiveHint: false` (`append_*`, `create_vault_directory`, `get_or_create_*`)
- overwriters/removers marked destructive, including `create_vault_file` (documented overwrite-on-exists) and `execute_obsidian_command`/`execute_template` (arbitrary effects, assume the worst)
- `fetch` is the only `openWorldHint: true` tool

One declared deviation from the plan: annotations live in a name-keyed map applied once via `registry.setAnnotations()` rather than a third `register()` argument. Same wire format, 45 call sites untouched, and the full-registry test now fails if a new tool ships without an entry.

Token cost on `tools/list`: roughly +10-15 tokens per tool, accepted in exchange for client-side safety gating (declared in the plan).

**Verification**

- `bun test`: 1142 pass / 0 fail (3 new tests: annotations in list, cache invalidation, registry-wide completeness)
- `tsc --noEmit` clean, prettier clean