### PR TITLE
fix(semantic-search): wire unloadModelWhenIdle and default to warm

### DIFF
--- a/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
+++ b/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
@@ -295,7 +295,10 @@
         disabled={saving}
       />
       Unload model when idle (60s)
-      <span class="hint">frees ~150 MB of RAM after inactivity</span>
+      <span class="hint"
+        >frees ~150 MB of RAM after inactivity, next search reloads the model
+        (~1s); takes effect at the next plugin reload</span
+      >
     </label>
   {/if}
 

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.test.ts
@@ -163,6 +163,21 @@ describe("embedder", () => {
     expect(callCount()).toBe(2);
   });
 
+  test("idle timer: omitted unloadWhenIdle keeps the pipeline warm", async () => {
+    // Opt-in contract: without the flag the model must stay loaded,
+    // otherwise the unloadModelWhenIdle setting cannot disable it.
+    const { factory, callCount } = makeMockFactory();
+    const embedder = createEmbedder({
+      pipelineFactory: factory,
+      idleMs: 30,
+    });
+    await embedder.embed("hello");
+    await new Promise((r) => setTimeout(r, 60));
+    expect(embedder.isLoaded()).toBe(true);
+    await embedder.embed("world");
+    expect(callCount()).toBe(1); // no cold reload
+  });
+
   test("concurrent first calls share one pipeline construction", async () => {
     const { factory, callCount } = makeMockFactory();
     const embedder = createEmbedder({ pipelineFactory: factory });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
@@ -172,7 +172,11 @@ class EmbedderImpl implements Embedder {
   }
 
   private touchIdle(): void {
-    if (this.opts.unloadWhenIdle === false) return;
+    // Opt-in: an omitted flag keeps the pipeline warm. The previous
+    // `=== false` check made `undefined` behave like `true`, which
+    // silently disconnected the unloadModelWhenIdle setting and made
+    // every search after 60s idle pay a cold pipeline rebuild.
+    if (this.opts.unloadWhenIdle !== true) return;
     if (this.idleTimer) window.clearTimeout(this.idleTimer);
     this.idleTimer = window.setTimeout(() => {
       this.pipeline = null;

--- a/packages/obsidian-plugin/src/features/semantic-search/types.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/types.ts
@@ -69,7 +69,9 @@ export type SemanticSearchSettings = typeof semanticSearchSettingsSchema.infer;
 export const DEFAULT_SEMANTIC_SETTINGS: SemanticSearchSettings = {
   provider: "auto",
   indexingMode: "live",
-  unloadModelWhenIdle: true,
+  // Warm by default: typical usage is sporadic agent queries, where a
+  // cold pipeline rebuild on every search costs more than the RAM.
+  unloadModelWhenIdle: false,
 };
 
 /**

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -428,9 +428,18 @@ export default class McpToolsPlugin extends Plugin {
       const nativeDownloader = createModelDownloader({
         innerFactory: realPipelineFactory,
       });
+      // Construction-time read: toggling the setting takes effect at
+      // the next plugin reload (the settings UI says so).
+      const semanticPrefs = await globalSettingsMutex.run(async () => {
+        const data = ((await this.loadData()) as Record<string, unknown>) ?? {};
+        return (data.semanticSearch ?? {}) as {
+          unloadModelWhenIdle?: boolean;
+        };
+      });
       const embedder = createEmbedder({
         pipelineFactory: nativeDownloader.factory,
         maxInputTokens: NATIVE_MAX_INPUT_TOKENS,
+        unloadWhenIdle: semanticPrefs.unloadModelWhenIdle === true,
       });
       const nativeEp = createNativeEmbeddingProvider(embedder);
       const nativeStore = registry.storeFor("native-minilm-l6-v2", 384);


### PR DESCRIPTION
PR 5 of the quick-wins bundle, closes it.

**The bug**

The `unloadModelWhenIdle` settings toggle persisted a value the embedder never received. `createEmbedder` in `main.ts` passed no `unloadWhenIdle` flag, and the embedder's check (`=== false`) made `undefined` behave like `true`. Net effect: the MiniLM pipeline always unloaded after 60 seconds idle regardless of the setting, so a typical agent session (sporadic queries, usually more than a minute apart) paid a cold pipeline rebuild on nearly every `search_vault_smart` call. The setting was dead since it shipped.

**The fix**

- `main.ts` reads the setting under the shared settings mutex at construction time and passes it to `createEmbedder`.
- The embedder check flips to opt-in (`!== true`), matching the documented contract.
- New installs default to warm (`unloadModelWhenIdle: false`): the RAM saved by unloading costs more than it buys for sporadic-query usage. Existing installs keep their persisted value, which is `true` for everyone (the old default was force-persisted), identical to today's effective behavior, except the toggle now actually works.
- Settings UI hint now states the reload semantics and the ~1s cold-search cost.

**Verification**

- `bun test`: 1137 pass / 0 fail (new test: omitted flag keeps the pipeline warm past `idleMs`)
- `tsc --noEmit` clean, prettier clean