### PR TITLE
perf(semantic-search): batch embedding pipeline calls

### DIFF
--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.test.ts
@@ -24,19 +24,23 @@ function makeMockFactory(): {
     factoryCalls += 1;
     const pipe: PipelineFn = async (input, _opts) => {
       embedCalls += 1;
-      const text = Array.isArray(input) ? input.join("|") : input;
+      // Batch-shaped output: one hashed row per input text, row-major
+      // [n, dim], matching the real Transformers.js tensor layout.
+      const texts = Array.isArray(input) ? input : [input];
       const dim = 8;
-      const data = new Float32Array(dim);
-      // Stable per-input vector via a tiny hash.
-      let h = 2166136261;
-      for (let i = 0; i < text.length; i++) {
-        h = (h ^ text.charCodeAt(i)) >>> 0;
-        h = Math.imul(h, 16777619) >>> 0;
-      }
-      for (let i = 0; i < dim; i++) {
-        data[i] = ((h >>> (i * 4)) & 0xff) / 255;
-      }
-      return { data, dims: [1, dim] };
+      const data = new Float32Array(dim * texts.length);
+      texts.forEach((text, row) => {
+        // Stable per-input vector via a tiny hash.
+        let h = 2166136261;
+        for (let i = 0; i < text.length; i++) {
+          h = (h ^ text.charCodeAt(i)) >>> 0;
+          h = Math.imul(h, 16777619) >>> 0;
+        }
+        for (let i = 0; i < dim; i++) {
+          data[row * dim + i] = ((h >>> (i * 4)) & 0xff) / 255;
+        }
+      });
+      return { data, dims: [texts.length, dim] };
     };
     return pipe;
   };
@@ -95,16 +99,14 @@ describe("embedder", () => {
     expect(embedCount()).toBe(beforeQ0); // hit
   });
 
-  test("embedBatch: returns one vector per input, dedupes duplicates via cache", async () => {
+  test("embedBatch: returns one vector per input, dedupes duplicates in-batch", async () => {
     const { factory, embedCount } = makeMockFactory();
     const embedder = createEmbedder({ pipelineFactory: factory });
     const out = await embedder.embedBatch(["a", "b", "c", "a"]);
     expect(out).toHaveLength(4);
     expect(out[0]).toBe(out[3]); // same Float32Array reference
-    // a, b, c are 3 distinct strings → 3 pipeline calls. The duplicate
-    // "a" hits the cache after the first one resolves.
-    expect(embedCount()).toBeLessThanOrEqual(4);
-    expect(embedCount()).toBeGreaterThanOrEqual(3);
+    // a, b, c dedupe to 3 unique texts → ONE batched pipeline call.
+    expect(embedCount()).toBe(1);
   });
 
   test("unload: clears pipeline; next call re-loads", async () => {
@@ -268,5 +270,91 @@ describe("resolveBackend", () => {
     ).toBe("webgpu");
     // No reset between calls; the cached result wins.
     expect(await resolveBackend(undefined)).toBe("webgpu");
+  });
+});
+
+/** Mock factory that also records the raw input of every pipe() call. */
+function makeRecordingFactory(): {
+  factory: PipelineFactory;
+  callCount: () => number;
+  inputs: () => (string | string[])[];
+} {
+  let factoryCalls = 0;
+  const inputs: (string | string[])[] = [];
+  const factory: PipelineFactory = async (_model: string) => {
+    factoryCalls += 1;
+    const pipe: PipelineFn = async (input, _opts) => {
+      inputs.push(input);
+      const texts = Array.isArray(input) ? input : [input];
+      const dim = 8;
+      const data = new Float32Array(dim * texts.length);
+      texts.forEach((text, row) => {
+        data[row * dim] = text.length;
+      });
+      return { data, dims: [texts.length, dim] };
+    };
+    return pipe;
+  };
+  return {
+    factory,
+    callCount: () => factoryCalls,
+    inputs: () => [...inputs],
+  };
+}
+
+describe("embedder — embedBatch batching", () => {
+  test("a batch of unique texts is one pipeline call with a string[] arg, order preserved", async () => {
+    const { factory, inputs } = makeRecordingFactory();
+    const embedder = createEmbedder({ pipelineFactory: factory });
+    const out = await embedder.embedBatch(["aa", "b", "cccc"]);
+    expect(inputs()).toEqual([["aa", "b", "cccc"]]);
+    expect(out.map((v) => v[0])).toEqual([2, 1, 4]);
+  });
+
+  test("embedBatch reads the LRU but does not write it", async () => {
+    const { factory, inputs } = makeRecordingFactory();
+    const embedder = createEmbedder({ pipelineFactory: factory });
+    // Seed the query cache.
+    await embedder.embed("query");
+    // Batch containing the cached query only embeds the new text.
+    await embedder.embedBatch(["query", "doc"]);
+    expect(inputs()).toEqual(["query", ["doc"]]);
+    // The batch result was NOT cached: embedding "doc" as a query
+    // re-runs the pipeline.
+    await embedder.embed("doc");
+    expect(inputs()).toEqual(["query", ["doc"], "doc"]);
+  });
+
+  test("more than EMBED_BATCH_SIZE inputs split into ceil(n/8) sequential calls", async () => {
+    const { factory, inputs } = makeRecordingFactory();
+    const embedder = createEmbedder({ pipelineFactory: factory });
+    const texts = Array.from({ length: 9 }, (_, i) => `t${i}`);
+    const out = await embedder.embedBatch(texts);
+    expect(out).toHaveLength(9);
+    const shapes = inputs();
+    expect(shapes).toHaveLength(2);
+    expect(shapes[0]).toHaveLength(8);
+    expect(shapes[1]).toHaveLength(1);
+  });
+
+  test("empty batch returns [] without loading the pipeline", async () => {
+    const { factory, callCount } = makeRecordingFactory();
+    const embedder = createEmbedder({ pipelineFactory: factory });
+    expect(await embedder.embedBatch([])).toEqual([]);
+    expect(callCount()).toBe(0);
+    expect(embedder.isLoaded()).toBe(false);
+  });
+
+  test("embedBatch touches the idle timer when unloadWhenIdle is on", async () => {
+    const { factory } = makeRecordingFactory();
+    const embedder = createEmbedder({
+      pipelineFactory: factory,
+      idleMs: 30,
+      unloadWhenIdle: true,
+    });
+    await embedder.embedBatch(["a"]);
+    expect(embedder.isLoaded()).toBe(true);
+    await new Promise((r) => setTimeout(r, 60));
+    expect(embedder.isLoaded()).toBe(false);
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embedder.ts
@@ -23,6 +23,9 @@
 const DEFAULT_MODEL = "Xenova/all-MiniLM-L6-v2";
 const DEFAULT_CACHE_SIZE = 32;
 const DEFAULT_IDLE_MS = 60_000;
+// Max texts per pipeline call in embedBatch. The tokenizer pads to the
+// longest text in the batch, so bigger is not monotonically better.
+const EMBED_BATCH_SIZE = 8;
 
 /** Minimal subset of Transformers.js's pipeline output that we use. */
 export type EmbedTensor = { data: Float32Array; dims?: number[] };
@@ -90,9 +93,9 @@ class EmbedderImpl implements Embedder {
   private loadPromise: Promise<PipelineFn> | null = null;
   // Cache stores Promise<Float32Array> rather than Float32Array so
   // concurrent embed(sameText) calls share the in-flight work and
-  // resolve to the same array reference. Identity holds across
-  // duplicates within an embedBatch call, which the indexer relies on
-  // when chunk-delta detection re-embeds a partial set.
+  // resolve to the same array reference. Query-only: embedBatch reads
+  // it but never writes (document chunks must not evict query entries);
+  // within-batch duplicate identity comes from embedBatch's dedupe map.
   private cache = new Map<string, Promise<Float32Array>>();
   private idleTimer: number | null = null;
 
@@ -130,11 +133,72 @@ class EmbedderImpl implements Embedder {
   }
 
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
-    // Each call routes through the per-string cache, so duplicated
-    // batch entries reuse work. Concurrency is fine: the first batch
-    // call triggers `ensurePipeline()` and the rest await the same
-    // promise.
-    return Promise.all(texts.map((t) => this.embed(t)));
+    this.touchIdle();
+    // Before ensurePipeline(): an all-cached or empty batch must not
+    // cold-load the model.
+    if (texts.length === 0) return [];
+
+    // Cache policy: batch traffic is document chunks (indexing); it
+    // READS the query LRU (a chunk equal to a recent query reuses the
+    // vector) but never WRITES it — 32 slots of query cache would be
+    // churned to nothing by a single file's chunks. Duplicate texts
+    // within the batch still resolve to the SAME Float32Array
+    // reference (invariant the indexer's chunk-delta reuse relies on)
+    // via the dedupe map below.
+    const results = new Array<Promise<Float32Array>>(texts.length);
+    const missing = new Map<string, number[]>();
+    texts.forEach((text, i) => {
+      const cached = this.cache.get(text);
+      if (cached) {
+        results[i] = cached;
+      } else {
+        const positions = missing.get(text);
+        if (positions) positions.push(i);
+        else missing.set(text, [i]);
+      }
+    });
+
+    const entries = Array.from(missing.entries());
+    for (let start = 0; start < entries.length; start += EMBED_BATCH_SIZE) {
+      const slice = entries.slice(start, start + EMBED_BATCH_SIZE);
+      const batchTexts = slice.map(([text]) => text);
+      const batchPromise = (async (): Promise<Float32Array[]> => {
+        const pipe = await this.ensurePipeline();
+        const result = await pipe(batchTexts, {
+          pooling: "mean",
+          normalize: true,
+          truncation: true,
+          max_length: this.opts.maxInputTokens,
+        });
+        // [batch, dim] row-major; without dims, derive the stride from
+        // the flat length (must divide evenly).
+        const stride =
+          result.dims?.length === 2 && typeof result.dims[1] === "number"
+            ? result.dims[1]
+            : result.data.length / batchTexts.length;
+        if (!Number.isInteger(stride)) {
+          throw new Error(
+            `embedBatch: cannot infer row stride (data ${result.data.length}, batch ${batchTexts.length})`,
+          );
+        }
+        return batchTexts.map(
+          (_, row) =>
+            new Float32Array(
+              result.data.subarray(row * stride, (row + 1) * stride),
+            ),
+        );
+      })();
+      slice.forEach(([, positions], row) => {
+        const rowPromise = batchPromise.then((rows) => {
+          const v = rows[row];
+          if (!v) throw new Error("embedBatch: missing row in batch result");
+          return v;
+        });
+        for (const pos of positions) results[pos] = rowPromise;
+      });
+    }
+
+    return Promise.all(results);
   }
 
   async unload(): Promise<void> {

--- a/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/embeddingGemmaProvider.ts
@@ -20,5 +20,9 @@ export function createEmbeddingGemmaProvider(
         ? "task: search result | query: " + text
         : "title: none | text: " + text,
     pipelineFactory,
+    // 2K-context model: padding to the longest text in the batch makes
+    // attention memory batch × seq², which can OOM integrated GPUs at
+    // the default batch of 8.
+    batchSize: 4,
   });
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
@@ -113,14 +113,18 @@ async function fakeChunker(content: string): Promise<Chunk[]> {
 function fakeEmbeddingProvider(): {
   embedder: EmbeddingProvider;
   embeds: () => string[];
+  /** One entry per embed() invocation, preserving the batch shape. */
+  embedCalls: () => string[][];
 } {
   const calls: string[] = [];
+  const shapes: string[][] = [];
   const embedder: EmbeddingProvider = {
     providerKey: "test-provider",
     dimensions: DIM,
     maxInputTokens: 512,
     getMaxInputTokens: async () => 512,
     embed: async (texts, _role) => {
+      shapes.push([...texts]);
       for (const text of texts) calls.push(text);
       return texts.map((text) => {
         const v = new Float32Array(DIM);
@@ -131,7 +135,11 @@ function fakeEmbeddingProvider(): {
     isAvailable: async () => true,
     getModelSizeBytes: () => 0,
   };
-  return { embedder, embeds: () => [...calls] };
+  return {
+    embedder,
+    embeds: () => [...calls],
+    embedCalls: () => shapes.map((s) => [...s]),
+  };
 }
 
 async function collect(
@@ -1166,6 +1174,69 @@ describe("live indexer — unchanged-file no-op skip", () => {
     expect(afterModify.upserts).toBe(afterBuild.upserts + 1);
     expect(rawStore.size()).toBe(2);
 
+    await indexer.stop();
+  });
+});
+
+describe("live indexer — batched embed calls", () => {
+  test("a modified file embeds only its changed chunks, in one call", async () => {
+    const rawStore = await makeStore();
+    const { vault, files, emit } = makeVault({
+      "a.md": "one---CHUNK---two---CHUNK---three",
+    });
+    const { embedder, embedCalls } = fakeEmbeddingProvider();
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store: rawStore,
+      debounceMs: 10,
+    });
+    await indexer.start();
+    // Full build: one batched call with all three chunks (overlap
+    // wrapper prepends the previous chunk's text).
+    expect(embedCalls()).toEqual([["one", "one\ntwo", "two\nthree"]]);
+
+    // Change two chunks, keep the first.
+    files.set("a.md", "one---CHUNK---TWO---CHUNK---THREE");
+    emit("modify", "a.md");
+    await new Promise((r) => setTimeout(r, 60));
+
+    const calls = embedCalls();
+    expect(calls).toHaveLength(2);
+    // Reused "one" not re-embedded; the two changed chunks ride in
+    // one batched call.
+    expect(calls[1]).toEqual(["one\nTWO", "TWO\nTHREE"]);
+    expect(rawStore.size()).toBe(3);
+
+    await indexer.stop();
+  });
+
+  test("duplicate chunks within a file embed once and share the vector", async () => {
+    const rawStore = await makeStore();
+    // After the overlap wrapper, chunks 2 and 3 are both "same\nsame".
+    const { vault } = makeVault({
+      "a.md": "same---CHUNK---same---CHUNK---same",
+    });
+    const { embedder, embedCalls } = fakeEmbeddingProvider();
+    const indexer = createLiveIndexer({
+      vault,
+      chunker: fakeChunker,
+      embedder,
+      store: rawStore,
+      debounceMs: 10,
+    });
+    await indexer.start();
+    // contentHash is computed on the raw chunk text (pre-overlap), so
+    // all three "same" chunks share one hash and embed exactly once —
+    // consistent with the existing reuse path, which already treats
+    // equal hashes as vector-interchangeable across re-indexes.
+    expect(embedCalls()).toEqual([["same"]]);
+    const records = Array.from(rawStore.recordsFor("a.md"));
+    expect(records).toHaveLength(3);
+    const vecs = records.map((r) => r.vector);
+    expect(vecs[1]).toBe(vecs[0] as Float32Array);
+    expect(vecs[2]).toBe(vecs[0] as Float32Array);
     await indexer.stop();
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -508,20 +508,53 @@ async function processOnePath(deps: ProcessDeps, path: string): Promise<void> {
     existingByHash.set(r.contentHash, r);
   }
 
-  const records: EmbeddingRecord[] = [];
-  for (const c of chunks) {
+  // Two-pass: collect every chunk that needs an embed (deduped by
+  // contentHash) and run ONE batched embedder call. Per-chunk calls
+  // were batch-of-1 inferences — tokenization and the forward pass
+  // batch far better in a single pipeline invocation.
+  const vectors = new Array<Float32Array | undefined>(chunks.length);
+  const toEmbedTexts: string[] = [];
+  const slotsByHash = new Map<string, number[]>();
+  chunks.forEach((c, i) => {
     const reused = existingByHash.get(c.contentHash);
-    const vector =
-      reused?.vector ?? (await deps.embedder.embed([c.text], "document"))[0];
-    records.push({
+    if (reused) {
+      vectors[i] = reused.vector;
+      return;
+    }
+    const slots = slotsByHash.get(c.contentHash);
+    if (slots) {
+      slots.push(i);
+    } else {
+      slotsByHash.set(c.contentHash, [i]);
+      toEmbedTexts.push(c.text);
+    }
+  });
+
+  if (toEmbedTexts.length > 0) {
+    const embedded = await deps.embedder.embed(toEmbedTexts, "document");
+    let k = 0;
+    for (const slots of slotsByHash.values()) {
+      const vector = embedded[k++];
+      for (const i of slots) vectors[i] = vector;
+    }
+  }
+
+  const records: EmbeddingRecord[] = chunks.map((c, i) => {
+    const vector = vectors[i];
+    if (!vector) {
+      throw new Error(
+        `indexer: missing embedding for chunk ${path}#${c.id} (batch result misaligned)`,
+      );
+    }
+    return {
       chunkId: `${path}#${c.id}`,
       filePath: path,
       offset: c.offset,
       heading: c.heading,
       contentHash: c.contentHash,
       vector,
-    });
-  }
+    };
+  });
 
   // A save that didn't change the chunking (the common autosave case)
   // would otherwise mark the store dirty and trigger a full-store

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.test.ts
@@ -23,7 +23,10 @@ function makeMockFactory(dim: number): {
     return async (input) => {
       const texts = Array.isArray(input) ? input : [input];
       calls.push(...texts);
-      return { data: new Float32Array(dim), dims: [1, dim] };
+      return {
+        data: new Float32Array(dim * texts.length),
+        dims: [texts.length, dim],
+      };
     };
   };
   return { factory, calls };
@@ -35,9 +38,10 @@ function makeMockFactoryWithOpts(dim: number): {
 } {
   const optsLog: Array<object | undefined> = [];
   const factory = async (_model: string): Promise<MockPipelineFn> => {
-    return async (_input, opts) => {
+    return async (input, opts) => {
       optsLog.push(opts);
-      return { data: new Float32Array(dim), dims: [1, dim] };
+      const n = Array.isArray(input) ? input.length : 1;
+      return { data: new Float32Array(dim * n), dims: [n, dim] };
     };
   };
   return { factory, optsLog };
@@ -134,9 +138,13 @@ describe("TransformersProviderImpl", () => {
     let loadCount = 0;
     const factory = async (
       _model: string,
-    ): Promise<(input: string) => Promise<{ data: Float32Array }>> => {
+    ): Promise<
+      (input: string | string[]) => Promise<{ data: Float32Array }>
+    > => {
       loadCount++;
-      return async () => ({ data: new Float32Array(768) });
+      return async (input) => ({
+        data: new Float32Array(768 * (Array.isArray(input) ? input.length : 1)),
+      });
     };
     const provider = createTransformersProvider({
       modelId: "test-model",
@@ -375,5 +383,73 @@ describe("NativeEmbeddingProvider", () => {
     expect(captured).toEqual(["hello", "world"]);
     expect(result).toHaveLength(2);
     expect(result[0]).toBeInstanceOf(Float32Array);
+  });
+});
+
+describe("TransformersProviderImpl — batched pipeline calls", () => {
+  function makeShapeRecordingFactory(dim: number): {
+    factory: (model: string) => Promise<MockPipelineFn>;
+    invocations: string[][];
+  } {
+    const invocations: string[][] = [];
+    const factory = async (_model: string): Promise<MockPipelineFn> => {
+      return async (input) => {
+        const texts = Array.isArray(input) ? input : [input];
+        invocations.push([...texts]);
+        const data = new Float32Array(dim * texts.length);
+        // Distinguishable rows: row r starts with r + 1.
+        texts.forEach((_, r) => {
+          data[r * dim] = r + 1;
+        });
+        return { data, dims: [texts.length, dim] };
+      };
+    };
+    return { factory, invocations };
+  }
+
+  function makeProvider(
+    factory: (model: string) => Promise<MockPipelineFn>,
+    batchSize?: number,
+  ) {
+    return createTransformersProvider({
+      modelId: "test-model",
+      providerKey: "test",
+      dimensions: 16,
+      maxInputTokensByBackend: { wasm: 512, webgpu: 512 },
+      modelSizeBytes: 1_000_000,
+      taskPrompt: (t, role) => `${role}: ${t}`,
+      pipelineFactory: factory as never,
+      ...(batchSize === undefined ? {} : { batchSize }),
+    });
+  }
+
+  test("one pipeline call per batch, prompts applied per text, rows sliced in order", async () => {
+    const { factory, invocations } = makeShapeRecordingFactory(16);
+    const provider = makeProvider(factory);
+    const out = await provider.embed(["a", "b", "c"], "document");
+    expect(invocations).toEqual([
+      ["document: a", "document: b", "document: c"],
+    ]);
+    expect(out.map((v) => v[0])).toEqual([1, 2, 3]);
+    expect(out.every((v) => v.length === 16)).toBe(true);
+  });
+
+  test("batchSize caps the sub-batch size", async () => {
+    const { factory, invocations } = makeShapeRecordingFactory(16);
+    const provider = makeProvider(factory, 2);
+    const out = await provider.embed(["a", "b", "c", "d", "e"], "query");
+    expect(out).toHaveLength(5);
+    expect(invocations.map((i) => i.length)).toEqual([2, 2, 1]);
+  });
+
+  test("empty input returns [] without loading the pipeline", async () => {
+    let loads = 0;
+    const factory = async (_m: string): Promise<MockPipelineFn> => {
+      loads++;
+      return async () => ({ data: new Float32Array(16), dims: [1, 16] });
+    };
+    const provider = makeProvider(factory);
+    expect(await provider.embed([], "document")).toEqual([]);
+    expect(loads).toBe(0);
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/transformersProvider.ts
@@ -36,7 +36,16 @@ export type TransformersProviderOpts = {
   modelSizeBytes: number;
   taskPrompt: TaskPromptFn;
   pipelineFactory: PipelineFactory;
+  /**
+   * Max texts per pipeline call. The tokenizer pads every text in a
+   * batch to the longest one, so attention memory scales with
+   * batch × seq² — large-context models on WebGPU need a smaller
+   * batch (EmbeddingGemma uses 4). Default 8.
+   */
+  batchSize?: number;
 };
+
+const DEFAULT_BATCH_SIZE = 8;
 
 class TransformersProviderImpl implements EmbeddingProvider {
   readonly providerKey: string;
@@ -74,20 +83,47 @@ class TransformersProviderImpl implements EmbeddingProvider {
     texts: string[],
     role: "document" | "query",
   ): Promise<Float32Array[]> {
+    // Before ensurePipeline(): an all-reused reindex must not cold-load
+    // the model.
+    if (texts.length === 0) return [];
     const pipe = await this.ensurePipeline();
     const maxLen = await this.getMaxInputTokens();
-    return Promise.all(
-      texts.map(async (text) => {
-        const prompted = this.opts.taskPrompt(text, role);
-        const result = await pipe(prompted, {
-          pooling: "mean",
-          normalize: true,
-          truncation: true,
-          max_length: maxLen,
-        });
-        return new Float32Array(result.data);
-      }),
-    );
+    const batchSize = this.opts.batchSize ?? DEFAULT_BATCH_SIZE;
+
+    // One pipeline call per sub-batch: tokenization and the forward
+    // pass are batched by Transformers.js, which beats per-text calls
+    // by a wide margin (kernel-launch and tensor-upload overhead
+    // dominates at batch size 1, especially on WebGPU). Sub-batches
+    // run sequentially — concurrent pipe() calls on one ORT session
+    // queue anyway but multiply peak memory.
+    const out: Float32Array[] = [];
+    for (let start = 0; start < texts.length; start += batchSize) {
+      const batch = texts
+        .slice(start, start + batchSize)
+        .map((text) => this.opts.taskPrompt(text, role));
+      const result = await pipe(batch, {
+        pooling: "mean",
+        normalize: true,
+        truncation: true,
+        max_length: maxLen,
+      });
+      // [batch, dim] tensor, row-major. Fall back to the declared
+      // dimensions if dims is missing.
+      const stride =
+        result.dims?.length === 2 && typeof result.dims[1] === "number"
+          ? result.dims[1]
+          : this.opts.dimensions;
+      for (let row = 0; row < batch.length; row++) {
+        // Copy each row into an owned Float32Array, independent of the
+        // pipeline's internal buffer.
+        out.push(
+          new Float32Array(
+            result.data.subarray(row * stride, (row + 1) * stride),
+          ),
+        );
+      }
+    }
+    return out;
   }
 
   private async ensurePipeline(): Promise<PipelineFn> {


### PR DESCRIPTION
PR 1 of 3 of the semantic-search perf pack (audit items: embed batching, mtime persistence, lazy store init).

**Problem**

Every chunk was a batch-of-1 inference: `processOnePath` called `embedder.embed([c.text])` per chunk, and both provider layers unrolled arrays into per-text `pipe()` calls. Kernel-launch and tensor-upload overhead dominates at batch size 1, especially on WebGPU. Expected 2-5x on full rebuilds.

**Changes**

1. `transformersProvider.embed()` sends one `pipe(texts[], opts)` call per sub-batch (default 8, sequential sub-batches to bound peak memory), slicing rows from the `[batch, dim]` tensor into owned arrays. Empty input returns before `ensurePipeline()`, so an all-reused reindex never cold-loads the model. EmbeddingGemma caps at `batchSize: 4` (2K context: the tokenizer pads to the longest text, attention memory scales with batch × seq²).
2. `embedder.embedBatch()` does real batching: cache-hit/missing partition, in-batch dedupe (duplicate texts share one `Float32Array`, the invariant the indexer relies on), one chunked pipeline call. Document batches READ the query LRU but no longer WRITE it, so indexing stops churning the 32-slot query cache (audit finding L2).
3. `indexer.processOnePath` is two-pass: collect chunks needing embeds (deduped by contentHash), one batched `embed(texts, "document")` call, reassemble records in order. The `sameRecordSet` no-op skip is untouched.

**Note on vectors**

Batched embeddings are not bit-identical to single-text ones (padding + FP reduction order). Cosine drift is negligible and equal-hash chunks were already treated as vector-interchangeable by the reuse path, so mixed stores are fine. No `FORMAT_VERSION` bump.

**Verification**

- `bun test`: 1128 pass / 0 fail (10 new tests: single-call batching, in-batch dedupe + reference identity, LRU read-not-write, sub-batch split at 8, empty-batch early return, idle-timer touch, per-file batched calls with reuse, prompted-text batching with row slicing)
- Test mocks updated to batch-shaped `[n, dim]` tensors matching the real Transformers.js layout
- `tsc --noEmit` clean, prettier clean