### PR TITLE
perf(semantic-search): persist file mtimes to skip session-start scan

### DIFF
--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
@@ -505,6 +505,9 @@ function wrapStoreWithFlushSpy(store: Awaited<ReturnType<typeof makeStore>>): {
     size: () => store.size(),
     scan: () => store.scan(),
     recordsFor: (path) => store.recordsFor(path),
+    hasRecords: (path) => store.hasRecords(path),
+    mtimeFor: (path) => store.mtimeFor(path),
+    setMtime: (path, mtime) => store.setMtime(path, mtime),
     upsert: (records) => store.upsert(records),
     delete: (path) => store.delete(path),
     close: () => store.close(),
@@ -1104,6 +1107,9 @@ function wrapStoreWithWriteSpy(store: Awaited<ReturnType<typeof makeStore>>): {
     size: () => store.size(),
     scan: () => store.scan(),
     recordsFor: (path) => store.recordsFor(path),
+    hasRecords: (path) => store.hasRecords(path),
+    mtimeFor: (path) => store.mtimeFor(path),
+    setMtime: (path, mtime) => store.setMtime(path, mtime),
     upsert: (records) => {
       upserts++;
       return store.upsert(records);
@@ -1238,5 +1244,204 @@ describe("live indexer — batched embed calls", () => {
     expect(vecs[1]).toBe(vecs[0] as Float32Array);
     expect(vecs[2]).toBe(vecs[0] as Float32Array);
     await indexer.stop();
+  });
+});
+
+describe("indexer — persisted mtime skip", () => {
+  const BIN = "/p/embeddings.bin";
+  const IDX = "/p/embeddings.index.json";
+
+  function sharedStorePair() {
+    const adapter = memAdapter();
+    const make = () =>
+      createEmbeddingStore({
+        adapter,
+        binPath: BIN,
+        indexPath: IDX,
+        vectorDim: DIM,
+      });
+    return { adapter, make };
+  }
+
+  function mtimeVaultWithReadSpy(
+    initial: Record<string, { content: string; mtime: number }>,
+  ) {
+    const { vault, files } = makeMtimeVault(initial);
+    let reads = 0;
+    const spied: VaultLike = {
+      ...vault,
+      read: async (path) => {
+        reads++;
+        return vault.read(path);
+      },
+    };
+    return { vault: spied, files, reads: () => reads };
+  }
+
+  test("session start skips files whose persisted mtime matches", async () => {
+    const { make } = sharedStorePair();
+    const vaultData = {
+      "a.md": { content: "alpha", mtime: 100 },
+      "b.md": { content: "beta", mtime: 200 },
+    };
+
+    // Session 1: full build persists records + mtimes.
+    const store1 = make();
+    await store1.init();
+    const v1 = mtimeVaultWithReadSpy(vaultData);
+    const { embedder: e1 } = fakeEmbeddingProvider();
+    const idx1 = createLiveIndexer({
+      vault: v1.vault,
+      chunker: fakeChunker,
+      embedder: e1,
+      store: store1,
+      debounceMs: 10,
+    });
+    await idx1.start();
+    await idx1.stop();
+
+    // Session 2: fresh store instance over the same adapter, same vault.
+    const store2 = make();
+    await store2.init();
+    const v2 = mtimeVaultWithReadSpy(vaultData);
+    const { embedder: e2, embedCalls } = fakeEmbeddingProvider();
+    const idx2 = createLiveIndexer({
+      vault: v2.vault,
+      chunker: fakeChunker,
+      embedder: e2,
+      store: store2,
+      debounceMs: 10,
+    });
+    await idx2.start();
+    expect(v2.reads()).toBe(0); // not even read, let alone re-embedded
+    expect(embedCalls()).toEqual([]);
+    expect(store2.size()).toBe(2);
+    await idx2.stop();
+  });
+
+  test("explicit rebuildAll() re-processes despite matching mtimes", async () => {
+    const { make } = sharedStorePair();
+    const vaultData = { "a.md": { content: "alpha", mtime: 100 } };
+
+    const store1 = make();
+    await store1.init();
+    const v1 = mtimeVaultWithReadSpy(vaultData);
+    const { embedder: e1 } = fakeEmbeddingProvider();
+    const idx1 = createLiveIndexer({
+      vault: v1.vault,
+      chunker: fakeChunker,
+      embedder: e1,
+      store: store1,
+      debounceMs: 10,
+    });
+    await idx1.start();
+    await idx1.stop();
+
+    const store2 = make();
+    await store2.init();
+    const v2 = mtimeVaultWithReadSpy(vaultData);
+    const { embedder: e2 } = fakeEmbeddingProvider();
+    const idx2 = createLiveIndexer({
+      vault: v2.vault,
+      chunker: fakeChunker,
+      embedder: e2,
+      store: store2,
+      debounceMs: 10,
+    });
+    await idx2.rebuildAll(); // manual button: default force
+    expect(v2.reads()).toBe(1); // read again (embed still skipped via hash)
+  });
+
+  test("matching mtime without records is processed (crash-heal guard)", async () => {
+    const { make } = sharedStorePair();
+    const store = make();
+    await store.init();
+    // Sidecar claims current, but no records exist for the path.
+    store.setMtime("a.md", 100);
+    const v = mtimeVaultWithReadSpy({
+      "a.md": { content: "alpha", mtime: 100 },
+    });
+    const { embedder, embedCalls } = fakeEmbeddingProvider();
+    const idx = createLiveIndexer({
+      vault: v.vault,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 10,
+    });
+    await idx.start();
+    expect(v.reads()).toBe(1);
+    expect(embedCalls()).toEqual([["alpha"]]);
+    expect(store.size()).toBe(1);
+    await idx.stop();
+  });
+
+  test("transient read failure does not record an mtime", async () => {
+    const { make } = sharedStorePair();
+    const store = make();
+    await store.init();
+    const { vault } = makeMtimeVault({
+      "a.md": { content: "alpha", mtime: 100 },
+    });
+    const failing: VaultLike = {
+      ...vault,
+      read: async () => {
+        throw new Error("EBUSY");
+      },
+      getFileMtime: () => 100,
+    };
+    const { embedder } = fakeEmbeddingProvider();
+    const idx = createLiveIndexer({
+      vault: failing,
+      chunker: fakeChunker,
+      embedder,
+      store,
+      debounceMs: 10,
+    });
+    await idx.start();
+    // Read failed while the path is still listed: vectors preserved,
+    // and crucially no mtime recorded, or the retry would be skipped.
+    expect(store.mtimeFor("a.md")).toBeUndefined();
+    await idx.stop();
+  });
+
+  test("low-power: first cycle after restart skips unchanged files via persisted mtimes", async () => {
+    const { make } = sharedStorePair();
+    const vaultData = { "a.md": { content: "alpha", mtime: 100 } };
+
+    const store1 = make();
+    await store1.init();
+    const v1 = mtimeVaultWithReadSpy(vaultData);
+    const { embedder: e1 } = fakeEmbeddingProvider();
+    const lp1 = createLowPowerIndexer({
+      vault: v1.vault,
+      chunker: fakeChunker,
+      embedder: e1,
+      store: store1,
+      intervalMs: 60_000,
+    });
+    await lp1.start();
+    await lp1.stop();
+    await store1.flush();
+
+    // "Restart": fresh indexer + fresh store instance, same adapter.
+    const store2 = make();
+    await store2.init();
+    const v2 = mtimeVaultWithReadSpy(vaultData);
+    const { embedder: e2 } = fakeEmbeddingProvider();
+    const lp2 = createLowPowerIndexer({
+      vault: v2.vault,
+      chunker: fakeChunker,
+      embedder: e2,
+      store: store2,
+      intervalMs: 60_000,
+    });
+    await lp2.start();
+    expect(v2.reads()).toBe(0); // skipped via sidecar, not even re-read
+    await lp2.stop();
+
+    // The manual rebuild still forces a full pass.
+    await lp2.rebuildAll();
+    expect(v2.reads()).toBe(1);
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -42,6 +42,13 @@ export interface VaultLike {
    */
   getMarkdownFiles(): Array<{ path: string; mtime?: number }>;
   read(path: string): Promise<string>;
+  /**
+   * O(1) mtime lookup for a single path, used by the live event path
+   * to capture the mtime BEFORE reading the file (recording it after
+   * the read could stamp newer mtime on older content). Optional:
+   * without it, live-edited files simply don't get a persisted mtime.
+   */
+  getFileMtime?(path: string): number | undefined;
   /** Returns an unsubscribe function. */
   on(event: VaultEvent, handler: (path: string) => void): () => void;
 }
@@ -83,11 +90,22 @@ export type StartOpts = {
   initialRebuild?: boolean;
 };
 
+export type RebuildOpts = {
+  /**
+   * `true` (default) re-processes every file — the contract of the
+   * manual "Rebuild index" button and of `startRebuildFor`. `false`
+   * (used by `start()`) skips files whose persisted mtime matches and
+   * whose records are present, so a session start does not re-read the
+   * whole vault.
+   */
+  force?: boolean;
+};
+
 export interface SemanticIndexer {
   start(opts?: StartOpts): Promise<void>;
   stop(): Promise<void>;
-  /** Force a full re-build over all markdown files. */
-  rebuildAll(): Promise<void>;
+  /** Full re-build over all markdown files. See {@link RebuildOpts}. */
+  rebuildAll(opts?: RebuildOpts): Promise<void>;
   /**
    * Drain any pending debounce timers and await every in-flight
    * file processing. Test helper — production code does not need
@@ -129,7 +147,9 @@ class LiveIndexerImpl implements SemanticIndexer {
     );
 
     if (opts.initialRebuild !== false) {
-      await this.rebuildAll();
+      // Session start is not a user-requested rebuild: unchanged files
+      // (persisted mtime matches, records present) are skipped.
+      await this.rebuildAll({ force: false });
     }
   }
 
@@ -151,7 +171,8 @@ class LiveIndexerImpl implements SemanticIndexer {
     return this.opts.isExcluded?.(path) ?? false;
   }
 
-  async rebuildAll(): Promise<void> {
+  async rebuildAll(opts: RebuildOpts = {}): Promise<void> {
+    const force = opts.force ?? true;
     if (!(await this.opts.embedder.isAvailable())) {
       logger.warn(
         "live indexer: embedding provider not available, skipping rebuild",
@@ -164,13 +185,30 @@ class LiveIndexerImpl implements SemanticIndexer {
     logger.info("live indexer: rebuildAll starting", {
       providerKey: this.opts.embedder.providerKey,
       fileCount: files.length,
+      force,
     });
+    let skipped = 0;
     for (const f of files) {
-      await this.processFile(f.path);
+      // Session-start pass: a file whose persisted mtime matches and
+      // whose records are present is current — skip the read entirely.
+      // The hasRecords guard self-heals a stale sidecar (e.g. records
+      // discarded by sentinel recovery while mtimes survived a crash
+      // window elsewhere).
+      if (
+        !force &&
+        f.mtime !== undefined &&
+        f.mtime === this.opts.store.mtimeFor(f.path) &&
+        this.opts.store.hasRecords(f.path)
+      ) {
+        skipped++;
+        continue;
+      }
+      await this.processFile(f.path, f.mtime);
     }
     logger.info("live indexer: rebuildAll finished", {
       providerKey: this.opts.embedder.providerKey,
       fileCount: files.length,
+      skippedUnchanged: skipped,
     });
   }
 
@@ -220,13 +258,13 @@ class LiveIndexerImpl implements SemanticIndexer {
     this.timers.set(path, handle);
   }
 
-  private async processFile(path: string): Promise<void> {
+  private async processFile(path: string, knownMtime?: number): Promise<void> {
     // Serialize per-path so a fast modify→delete sequence does not
     // race the in-flight processor for the prior modify event.
     const prior = this.inFlight.get(path);
     const next = (async () => {
       if (prior) await prior.catch(() => {});
-      await this.doProcessFile(path);
+      await this.doProcessFile(path, knownMtime);
     })();
     this.inFlight.set(path, next);
     try {
@@ -241,8 +279,11 @@ class LiveIndexerImpl implements SemanticIndexer {
     }
   }
 
-  private async doProcessFile(path: string): Promise<void> {
-    await processOnePath(this.opts, path);
+  private async doProcessFile(
+    path: string,
+    knownMtime?: number,
+  ): Promise<void> {
+    await processOnePath(this.opts, path, knownMtime);
   }
 
   private scheduleFlush(): void {
@@ -337,6 +378,7 @@ class LowPowerIndexerImpl implements SemanticIndexer {
   private running = false;
   private cycleInFlight: Promise<void> | null = null;
   private lastSeenMtime = new Map<string, number>();
+  private bypassPersistedMtime = false;
   private readonly intervalMs: number;
   private readonly opts: LowPowerIndexerOpts;
 
@@ -378,16 +420,26 @@ class LowPowerIndexerImpl implements SemanticIndexer {
     return this.opts.isExcluded?.(path) ?? false;
   }
 
-  async rebuildAll(): Promise<void> {
+  async rebuildAll(opts: RebuildOpts = {}): Promise<void> {
+    const force = opts.force ?? true;
     if (!(await this.opts.embedder.isAvailable())) {
       logger.warn(
         "low-power indexer: embedding provider not available, skipping rebuild",
       );
       return;
     }
-    // Force every file to be considered stale, then run a cycle.
-    this.lastSeenMtime.clear();
-    await this.runCycle();
+    if (force) {
+      // Force every file to be considered stale: clear the in-memory
+      // map AND bypass the persisted mtimes for this cycle, otherwise
+      // the sidecar would defeat the manual "Rebuild index" button.
+      this.lastSeenMtime.clear();
+      this.bypassPersistedMtime = true;
+    }
+    try {
+      await this.runCycle();
+    } finally {
+      this.bypassPersistedMtime = false;
+    }
   }
 
   async flush(): Promise<void> {
@@ -417,10 +469,18 @@ class LowPowerIndexerImpl implements SemanticIndexer {
         // hide at query time, physical cleanup only via manual Rebuild).
         seenPaths.add(f.path);
         if (this.isExcluded(f.path)) continue;
-        const prev = this.lastSeenMtime.get(f.path);
+        // Seed from the persisted sidecar so the first cycle after a
+        // restart skips unchanged files too. Guarded by hasRecords so
+        // a stale sidecar without records self-heals, and bypassed
+        // entirely during a forced rebuild.
+        const persisted =
+          this.bypassPersistedMtime || !this.opts.store.hasRecords(f.path)
+            ? undefined
+            : this.opts.store.mtimeFor(f.path);
+        const prev = this.lastSeenMtime.get(f.path) ?? persisted;
         const cur = f.mtime ?? Number.POSITIVE_INFINITY; // unknown mtime → process every cycle
         if (prev !== undefined && cur <= prev) continue;
-        await processOnePath(this.opts, f.path);
+        await processOnePath(this.opts, f.path, f.mtime);
         if (f.mtime !== undefined) this.lastSeenMtime.set(f.path, f.mtime);
       }
 
@@ -475,7 +535,15 @@ type ProcessDeps = {
  * index stays consistent with what `chunker` would produce on a
  * fresh re-build.
  */
-async function processOnePath(deps: ProcessDeps, path: string): Promise<void> {
+async function processOnePath(
+  deps: ProcessDeps,
+  path: string,
+  knownMtime?: number,
+): Promise<void> {
+  // Capture the mtime BEFORE reading: stamping it after the read could
+  // record a newer mtime for older content if the file changes in
+  // between, and a too-old mtime only costs one redundant re-process.
+  const mtime = knownMtime ?? deps.vault.getFileMtime?.(path);
   let content: string;
   try {
     content = await deps.vault.read(path);
@@ -558,11 +626,16 @@ async function processOnePath(deps: ProcessDeps, path: string): Promise<void> {
 
   // A save that didn't change the chunking (the common autosave case)
   // would otherwise mark the store dirty and trigger a full-store
-  // rewrite at the next flush.
-  if (sameRecordSet(records, deps.store.recordsFor(path))) return;
+  // rewrite at the next flush. The mtime is still recorded (sidecar
+  // dirty only) so the next session-start rebuild can skip the file.
+  if (sameRecordSet(records, deps.store.recordsFor(path))) {
+    if (mtime !== undefined) deps.store.setMtime(path, mtime);
+    return;
+  }
 
   await deps.store.delete(path);
   await deps.store.upsert(records);
+  if (mtime !== undefined) deps.store.setMtime(path, mtime);
 }
 
 /**

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
@@ -500,3 +500,160 @@ describe("EmbeddingStore — recordsFor", () => {
     expect(forB[0]?.chunkId).toBe("b:0");
   });
 });
+
+describe("embedding store — mtimes sidecar", () => {
+  const A = "/p/embeddings.bin";
+  const I = "/p/embeddings.index.json";
+  const M = "/p/mtimes.json";
+
+  function rec(chunkId: string, filePath: string): EmbeddingRecord {
+    const vector = new Float32Array(DIM);
+    vector[0] = 1;
+    return {
+      chunkId,
+      filePath,
+      offset: 0,
+      heading: null,
+      contentHash: `h:${chunkId}`,
+      vector,
+    };
+  }
+
+  test("setMtime persists through flush and reloads in a new instance", async () => {
+    const mem = makeMemAdapter();
+    const store = createEmbeddingStore({
+      adapter: mem.adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+    await store.init();
+    await store.upsert([rec("a.md#0", "a.md")]);
+    store.setMtime("a.md", 111);
+    await store.flush();
+    expect(mem.files.has(M)).toBe(true);
+
+    const reloaded = createEmbeddingStore({
+      adapter: mem.adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+    await reloaded.init();
+    expect(reloaded.mtimeFor("a.md")).toBe(111);
+    expect(reloaded.hasRecords("a.md")).toBe(true);
+  });
+
+  test("mtime-only change flushes the sidecar without rewriting the bin", async () => {
+    const mem = makeMemAdapter();
+    const store = createEmbeddingStore({
+      adapter: mem.adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+    await store.init();
+    await store.upsert([rec("a.md#0", "a.md")]);
+    store.setMtime("a.md", 1);
+    await store.flush();
+    const binAfterFirst = mem.bins.get(A);
+
+    // Advance only the mtime: the record pair must not be rewritten.
+    mem.bins.delete(A); // tripwire: a bin rewrite would re-create it
+    store.setMtime("a.md", 2);
+    await store.flush();
+    expect(mem.bins.has(A)).toBe(false);
+    expect(binAfterFirst).toBeDefined();
+    expect(
+      (JSON.parse(mem.files.get(M) ?? "{}") as Record<string, number>)["a.md"],
+    ).toBe(2);
+  });
+
+  test("setMtime with an unchanged value does not dirty the sidecar", async () => {
+    const mem = makeMemAdapter();
+    const store = createEmbeddingStore({
+      adapter: mem.adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+    await store.init();
+    await store.upsert([rec("a.md#0", "a.md")]);
+    store.setMtime("a.md", 5);
+    await store.flush();
+    mem.files.delete(M); // tripwire
+    store.setMtime("a.md", 5);
+    await store.flush();
+    expect(mem.files.has(M)).toBe(false);
+  });
+
+  test("delete(path) clears the path's mtime", async () => {
+    const mem = makeMemAdapter();
+    const store = createEmbeddingStore({
+      adapter: mem.adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+    await store.init();
+    await store.upsert([rec("a.md#0", "a.md")]);
+    store.setMtime("a.md", 7);
+    await store.delete("a.md");
+    expect(store.mtimeFor("a.md")).toBeUndefined();
+    await store.flush();
+    expect(JSON.parse(mem.files.get(M) ?? "{}")).toEqual({});
+  });
+
+  test("corrupt mtimes sidecar is ignored, init succeeds", async () => {
+    const mem = makeMemAdapter();
+    const store = createEmbeddingStore({
+      adapter: mem.adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+    await store.init();
+    await store.upsert([rec("a.md#0", "a.md")]);
+    store.setMtime("a.md", 9);
+    await store.flush();
+    mem.files.set(M, "not json{");
+
+    const reloaded = createEmbeddingStore({
+      adapter: mem.adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+    await reloaded.init();
+    expect(reloaded.mtimeFor("a.md")).toBeUndefined();
+    expect(reloaded.size()).toBe(1);
+  });
+
+  test("sentinel recovery discards mtimes along with the records", async () => {
+    const mem = makeMemAdapter();
+    const store = createEmbeddingStore({
+      adapter: mem.adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+    await store.init();
+    await store.upsert([rec("a.md#0", "a.md")]);
+    store.setMtime("a.md", 13);
+    await store.flush();
+    // Simulate a crash mid-flush: sentinel left behind.
+    mem.files.set(`${I}.writing`, "1");
+
+    const reloaded = createEmbeddingStore({
+      adapter: mem.adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+    await reloaded.init();
+    expect(reloaded.size()).toBe(0);
+    // A sidecar claiming "current" over discarded records would make a
+    // session-start rebuild skip everything.
+    expect(reloaded.mtimeFor("a.md")).toBeUndefined();
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
@@ -53,6 +53,19 @@ export interface EmbeddingStore {
   delete(filePath: string): Promise<void>;
   /** O(chunks-in-file) lookup via secondary index. Use instead of scan()+filter for per-path access. */
   recordsFor(filePath: string): Iterable<EmbeddingRecord>;
+  /** O(1): true when the path has at least one record. */
+  hasRecords(filePath: string): boolean;
+  /**
+   * Last successfully indexed mtime for the path, persisted in the
+   * `mtimes.json` sidecar. Lets a session-start rebuild skip unchanged
+   * files without reading them. Accepted risk: a sync tool that
+   * preserves mtime while changing content defeats the skip — same
+   * exposure as the low-power indexer's in-memory map; the manual
+   * "Rebuild index" button forces a full pass.
+   */
+  mtimeFor(filePath: string): number | undefined;
+  /** Record the mtime for a successfully indexed path (sidecar-dirty only). */
+  setMtime(filePath: string, mtime: number): void;
   scan(): AsyncIterable<EmbeddingRecord>;
   flush(): Promise<void>;
   close(): Promise<void>;
@@ -92,6 +105,11 @@ class EmbeddingStoreImpl implements EmbeddingStore {
   private records = new Map<string, EmbeddingRecord>();
   private fileIndex = new Map<string, Set<string>>();
   private dirty = false;
+  // Per-file mtimes live in their own sidecar with their own dirty
+  // flag: an autosave that only advances mtime must cost one small
+  // JSON write, never the full bin+index rewrite.
+  private fileMtimes = new Map<string, number>();
+  private mtimeDirty = false;
   private initialized = false;
   private readonly vectorDim: number;
   // Dirty-sentinel: written before the bin/index pair, removed only
@@ -101,9 +119,14 @@ class EmbeddingStoreImpl implements EmbeddingStore {
   // from indexPath so no extra opt is needed.
   private readonly sentinelPath: string;
 
+  /** Sidecar next to the index file, e.g. `<dir>/mtimes.json`. */
+  private readonly mtimesPath: string;
+
   constructor(private opts: EmbeddingStoreOpts) {
     this.vectorDim = opts.vectorDim ?? DEFAULT_VECTOR_DIM;
     this.sentinelPath = `${opts.indexPath}.writing`;
+    const dir = opts.indexPath.split("/").slice(0, -1).join("/");
+    this.mtimesPath = dir ? `${dir}/mtimes.json` : "mtimes.json";
   }
 
   async init(): Promise<void> {
@@ -119,6 +142,10 @@ class EmbeddingStoreImpl implements EmbeddingStore {
       await this.removeSentinel();
       this.initialized = true;
       this.dirty = true; // next flush rewrites a clean bin/index pair
+      // Discard mtimes too: a sidecar claiming "current" while the
+      // records are gone would make the rebuild skip everything.
+      this.fileMtimes.clear();
+      this.mtimeDirty = true;
       return;
     }
 
@@ -212,10 +239,43 @@ class EmbeddingStoreImpl implements EmbeddingStore {
 
     this.initialized = true;
     this.dirty = skippedAny;
+    await this.loadMtimes();
+  }
+
+  /** Best-effort load of the mtimes sidecar; absent/corrupt → empty map. */
+  private async loadMtimes(): Promise<void> {
+    try {
+      if (!(await this.opts.adapter.exists(this.mtimesPath))) return;
+      const parsed = JSON.parse(
+        await this.opts.adapter.read(this.mtimesPath),
+      ) as Record<string, unknown>;
+      for (const [path, mtime] of Object.entries(parsed)) {
+        if (typeof mtime === "number") this.fileMtimes.set(path, mtime);
+      }
+    } catch (error) {
+      logger.warn("mtimes sidecar unreadable, ignoring", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   size(): number {
     return this.records.size;
+  }
+
+  hasRecords(filePath: string): boolean {
+    const set = this.fileIndex.get(filePath);
+    return set !== undefined && set.size > 0;
+  }
+
+  mtimeFor(filePath: string): number | undefined {
+    return this.fileMtimes.get(filePath);
+  }
+
+  setMtime(filePath: string, mtime: number): void {
+    if (this.fileMtimes.get(filePath) === mtime) return;
+    this.fileMtimes.set(filePath, mtime);
+    this.mtimeDirty = true;
   }
 
   async upsert(records: EmbeddingRecord[]): Promise<void> {
@@ -249,6 +309,7 @@ class EmbeddingStoreImpl implements EmbeddingStore {
 
   async delete(filePath: string): Promise<void> {
     if (!this.initialized) await this.init();
+    if (this.fileMtimes.delete(filePath)) this.mtimeDirty = true;
     const chunkIds = this.fileIndex.get(filePath);
     if (!chunkIds || chunkIds.size === 0) return;
     for (const chunkId of chunkIds) {
@@ -277,7 +338,13 @@ class EmbeddingStoreImpl implements EmbeddingStore {
   }
 
   async flush(): Promise<void> {
-    if (!this.dirty) return;
+    if (!this.dirty) {
+      // mtime-only change (the common autosave case): one small JSON
+      // write, no sentinel needed — the sidecar is advisory and the
+      // record pair is untouched.
+      if (this.mtimeDirty) await this.flushMtimes();
+      return;
+    }
 
     // Ensure the parent directory exists before writing — on a fresh
     // install the per-providerKey subdirectory may not exist yet.
@@ -330,9 +397,23 @@ class EmbeddingStoreImpl implements EmbeddingStore {
       JSON.stringify(indexFile),
     );
 
+    // After the pair, inside the sentinel window: a crash here leaves
+    // the sentinel up, so init() discards records AND mtimes together.
+    if (this.mtimeDirty) await this.flushMtimes();
+
     // Both writes succeeded — the pair is consistent, clear the sentinel.
     await this.removeSentinel();
     this.dirty = false;
+  }
+
+  private async flushMtimes(): Promise<void> {
+    const dir = this.mtimesPath.split("/").slice(0, -1).join("/");
+    if (dir) await this.opts.adapter.mkdir(dir);
+    await this.opts.adapter.write(
+      this.mtimesPath,
+      JSON.stringify(Object.fromEntries(this.fileMtimes)),
+    );
+    this.mtimeDirty = false;
   }
 
   /** Remove the sentinel, tolerating it already being gone. */
@@ -354,7 +435,9 @@ class EmbeddingStoreImpl implements EmbeddingStore {
     await this.flush();
     this.records.clear();
     this.fileIndex.clear();
+    this.fileMtimes.clear();
     this.dirty = false;
+    this.mtimeDirty = false;
     this.initialized = false;
   }
 }

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -327,6 +327,10 @@ export default class McpToolsPlugin extends Plugin {
           }
           return this.app.vault.cachedRead(f);
         },
+        getFileMtime: (path) => {
+          const f = this.app.vault.getAbstractFileByPath(path);
+          return f instanceof TFile ? f.stat?.mtime : undefined;
+        },
         on: (event, handler) => {
           // Obsidian's vault.on signatures are event-specific. The
           // unsubscribe is offref(EventRef). Wrap so our VaultLike
@@ -399,6 +403,7 @@ export default class McpToolsPlugin extends Plugin {
             await ssAdapter
               .remove(`${dirPath}/embeddings.index.json.writing`)
               .catch(() => {});
+            await ssAdapter.remove(`${dirPath}/mtimes.json`).catch(() => {});
           } catch (err) {
             logger.warn(
               "semantic-search: failed to wipe stale index directory",


### PR DESCRIPTION
PR 2 of 3 of the semantic-search perf pack. Stacked on #279 (base retargets to main once it merges).

**Problem**

Nothing persisted which files were already indexed, so the first `search_vault_smart` of every session kicked off a background pass that re-read, re-chunked and re-hashed every markdown file (embeds were skipped via hash reuse, but the I/O and hashing were O(vault bytes) per session).

**Changes**

1. `store.ts` gains a `mtimes.json` sidecar with its own dirty flag. An autosave that only advances an mtime costs one small JSON write, never the full bin+index rewrite (deliberately NOT inside `IndexFile`: that would have re-introduced the full-store rewrite that the `sameRecordSet` no-op skip just eliminated). The sidecar flushes inside the sentinel window after the record pair, so a crash discards records and mtimes together; sentinel recovery clears both. No `FORMAT_VERSION` bump.
2. `rebuildAll(opts?: { force?: boolean })` defaults to `force: true`, preserving the manual "Rebuild index" button, `startRebuildFor`, and the existing low-power contract test untouched. `start()` calls `rebuildAll({ force: false })`, which skips a file only when its mtime matches the sidecar AND records exist (the `hasRecords` guard makes any stale-sidecar window self-healing).
3. mtime is captured BEFORE the read (snapshot value during rebuilds, `VaultLike.getFileMtime` for live events), so a file changing mid-process can only cause a redundant re-process, never a silently stale index. Transient read failures record nothing; success paths (including the no-op skip) record the mtime.
4. The low-power indexer seeds its in-memory `lastSeenMtime` from the sidecar, so the first 5-minute cycle after a restart is cheap too; a forced rebuild bypasses the sidecar for that cycle.

Accepted risk (documented in `mtimeFor`'s jsdoc): a sync tool that preserves mtime while changing content defeats the skip, same exposure as the existing in-memory map; the Rebuild button is the escape hatch.

**Verification**

- `bun test`: 1139 pass / 0 fail (11 new: sidecar round-trip, mtime-only flush leaves the bin untouched, unchanged-value no-op, delete clears the entry, corrupt sidecar ignored, sentinel recovery discards mtimes, session-start skip with zero reads, forced rebuild re-processes, crash-heal guard, transient-failure no-record, low-power restart skip + forced pass)
- `tsc --noEmit` clean, prettier clean