### PR TITLE
perf(semantic-search): lazy store init behind a cheap readiness probe

### DIFF
--- a/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
+++ b/packages/obsidian-plugin/src/features/semantic-search/components/SemanticSettingsSection.svelte
@@ -49,14 +49,25 @@
     const state = plugin.semanticSearchState;
     const provider = state?.settings?.provider;
     const registry = state?.registry;
+    // Stores load lazily: size() is 0 until the first indexer/search
+    // use. Fall back to the plugin-load probe counts so a settings-only
+    // session still shows the persisted chunk count.
+    const probed = state?.probedCounts ?? {};
     // For DLC providers, read chunk count from their own store.
     // state.store always points to the native MiniLM store.
     if (provider === "embedding-gemma" && registry) {
-      storeSize = registry.storeFor("embedding-gemma-300m", 768).size();
+      storeSize =
+        registry.storeFor("embedding-gemma-300m", 768).size() ||
+        probed["embedding-gemma-300m"] ||
+        0;
     } else if (provider === "multilingual-e5-base" && registry) {
-      storeSize = registry.storeFor("multilingual-e5-base", 768).size();
+      storeSize =
+        registry.storeFor("multilingual-e5-base", 768).size() ||
+        probed["multilingual-e5-base"] ||
+        0;
     } else {
-      storeSize = state?.store?.size?.() ?? 0;
+      storeSize =
+        (state?.store?.size?.() ?? 0) || probed["native-minilm-l6-v2"] || 0;
     }
     pendingProvider = state?.pendingProvider ?? null;
     autoSuggestProvider = state?.autoSuggestProvider ?? null;

--- a/packages/obsidian-plugin/src/features/semantic-search/index.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/index.ts
@@ -96,6 +96,13 @@ export type SemanticSearchState = {
    */
   registry?: EmbeddingStoreRegistry | null;
   /**
+   * Per-providerKey record counts from the plugin-load probe pass.
+   * With lazy store init, `store.size()` reports 0 until something
+   * initializes the store; the settings UI falls back to these counts
+   * so "chunks indexed" stays truthful in settings-only sessions.
+   */
+  probedCounts?: Partial<Record<string, number>> | null;
+  /**
    * providerKey of the provider currently being built (download +
    * index). Set when the user switches to a provider whose store is
    * not yet ready. Cleared once `onProviderReady` fires.

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.test.ts
@@ -508,6 +508,7 @@ function wrapStoreWithFlushSpy(store: Awaited<ReturnType<typeof makeStore>>): {
     hasRecords: (path) => store.hasRecords(path),
     mtimeFor: (path) => store.mtimeFor(path),
     setMtime: (path, mtime) => store.setMtime(path, mtime),
+    probe: () => store.probe(),
     upsert: (records) => store.upsert(records),
     delete: (path) => store.delete(path),
     close: () => store.close(),
@@ -1110,6 +1111,7 @@ function wrapStoreWithWriteSpy(store: Awaited<ReturnType<typeof makeStore>>): {
     hasRecords: (path) => store.hasRecords(path),
     mtimeFor: (path) => store.mtimeFor(path),
     setMtime: (path, mtime) => store.setMtime(path, mtime),
+    probe: () => store.probe(),
     upsert: (records) => {
       upserts++;
       return store.upsert(records);
@@ -1443,5 +1445,106 @@ describe("indexer — persisted mtime skip", () => {
     // The manual rebuild still forces a full pass.
     await lp2.rebuildAll();
     expect(v2.reads()).toBe(1);
+  });
+});
+
+describe("indexer — lazy store init", () => {
+  const BIN = "/p/embeddings.bin";
+  const IDX = "/p/embeddings.index.json";
+
+  function lazyStorePair() {
+    const adapter = memAdapter();
+    const make = () =>
+      createEmbeddingStore({
+        adapter,
+        binPath: BIN,
+        indexPath: IDX,
+        vectorDim: DIM,
+      });
+    return { make };
+  }
+
+  test("start() on an UN-initialized store does not re-embed unchanged files", async () => {
+    const { make } = lazyStorePair();
+    const vaultData = { "a.md": { content: "alpha", mtime: 100 } };
+
+    // Session 1.
+    const store1 = make();
+    await store1.init();
+    const { vault: v1 } = makeMtimeVault(vaultData);
+    const { embedder: e1 } = fakeEmbeddingProvider();
+    const idx1 = createLiveIndexer({
+      vault: v1,
+      chunker: fakeChunker,
+      embedder: e1,
+      store: store1,
+      debounceMs: 10,
+    });
+    await idx1.start();
+    await idx1.stop();
+
+    // Session 2: NO explicit store.init() — the indexer must init it
+    // before reading recordsFor, or it would silently re-embed the
+    // whole vault against an empty in-memory view.
+    const store2 = make();
+    const { vault: v2 } = makeMtimeVault(vaultData);
+    const { embedder: e2, embedCalls } = fakeEmbeddingProvider();
+    const idx2 = createLiveIndexer({
+      vault: v2,
+      chunker: fakeChunker,
+      embedder: e2,
+      store: store2,
+      debounceMs: 10,
+    });
+    await idx2.start();
+    expect(embedCalls()).toEqual([]);
+    expect(store2.size()).toBe(1);
+    await idx2.stop();
+  });
+
+  test("start({initialRebuild:false}) + modify event reuses hashes from the lazily-loaded store", async () => {
+    const { make } = lazyStorePair();
+
+    const store1 = make();
+    await store1.init();
+    const { vault: v1 } = makeVault({ "a.md": "keep---CHUNK---old" });
+    const { embedder: e1 } = fakeEmbeddingProvider();
+    const idx1 = createLiveIndexer({
+      vault: v1,
+      chunker: fakeChunker,
+      embedder: e1,
+      store: store1,
+      debounceMs: 10,
+    });
+    await idx1.start();
+    await idx1.stop();
+
+    // DLC auto-subscribe pattern: un-inited store, no initial rebuild.
+    const store2 = make();
+    const {
+      vault: v2,
+      files,
+      emit,
+    } = makeVault({
+      "a.md": "keep---CHUNK---old",
+    });
+    const { embedder: e2, embedCalls } = fakeEmbeddingProvider();
+    const idx2 = createLiveIndexer({
+      vault: v2,
+      chunker: fakeChunker,
+      embedder: e2,
+      store: store2,
+      debounceMs: 10,
+    });
+    await idx2.start({ initialRebuild: false });
+
+    files.set("a.md", "keep---CHUNK---NEW");
+    emit("modify", "a.md");
+    await new Promise((r) => setTimeout(r, 60));
+
+    // Only the changed chunk embeds; "keep" reuses the persisted hash.
+    expect(embedCalls()).toEqual([["keep\nNEW"]]);
+    expect(store2.size()).toBe(2);
+    await idx2.stop();
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/indexer.ts
@@ -140,6 +140,12 @@ class LiveIndexerImpl implements SemanticIndexer {
     if (this.running) return;
     this.running = true;
 
+    // With lazy store loading the store may not be initialized yet.
+    // processOnePath reads recordsFor() (sync, no defensive init): on
+    // an un-inited store it would see zero records and silently
+    // re-embed the whole vault. Idempotent, cheap when already inited.
+    await this.opts.store.init();
+
     this.unsubs.push(
       this.opts.vault.on("modify", (p) => this.schedule(p)),
       this.opts.vault.on("create", (p) => this.schedule(p)),
@@ -179,6 +185,8 @@ class LiveIndexerImpl implements SemanticIndexer {
       );
       return;
     }
+    // See start(): guard against recordsFor() on an un-inited store.
+    await this.opts.store.init();
     const files = this.opts.vault
       .getMarkdownFiles()
       .filter((f) => !this.isExcluded(f.path));
@@ -457,6 +465,9 @@ class LowPowerIndexerImpl implements SemanticIndexer {
       return;
     }
     const cycle = (async () => {
+      // Guard against recordsFor()/mtimeFor() on an un-inited store
+      // (lazy loading); idempotent.
+      await this.opts.store.init();
       const files = this.opts.vault.getMarkdownFiles();
       const seenPaths = new Set<string>();
 

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.test.ts
@@ -657,3 +657,147 @@ describe("embedding store — mtimes sidecar", () => {
     expect(reloaded.mtimeFor("a.md")).toBeUndefined();
   });
 });
+
+describe("embedding store — probe() and meta sidecar", () => {
+  const A = "/p/embeddings.bin";
+  const I = "/p/embeddings.index.json";
+  const META = "/p/embeddings.meta.json";
+
+  function rec2(chunkId: string, filePath: string): EmbeddingRecord {
+    const vector = new Float32Array(DIM);
+    vector[0] = 1;
+    return {
+      chunkId,
+      filePath,
+      offset: 0,
+      heading: null,
+      contentHash: `h:${chunkId}`,
+      vector,
+    };
+  }
+
+  function makeOn(adapter: VaultAdapter) {
+    return createEmbeddingStore({
+      adapter,
+      binPath: A,
+      indexPath: I,
+      vectorDim: DIM,
+    });
+  }
+
+  /** Adapter wrapper logging every write path in order + readBinary calls. */
+  function spying(adapter: VaultAdapter): {
+    adapter: VaultAdapter;
+    writes: string[];
+    binReads: () => number;
+  } {
+    const writes: string[] = [];
+    let binReads = 0;
+    return {
+      writes,
+      binReads: () => binReads,
+      adapter: {
+        ...adapter,
+        write: async (p, d) => {
+          writes.push(p);
+          return adapter.write(p, d);
+        },
+        writeBinary: async (p, d) => {
+          writes.push(p);
+          return adapter.writeBinary(p, d);
+        },
+        readBinary: async (p) => {
+          binReads++;
+          return adapter.readBinary(p);
+        },
+      },
+    };
+  }
+
+  test("flush writes the meta sidecar last, with version and recordCount", async () => {
+    const mem = makeMemAdapter();
+    const spy = spying(mem.adapter);
+    const store = makeOn(spy.adapter);
+    await store.init();
+    await store.upsert([rec2("a.md#0", "a.md"), rec2("a.md#1", "a.md")]);
+    store.setMtime("a.md", 1);
+    await store.flush();
+
+    expect(JSON.parse(mem.files.get(META) ?? "{}")).toEqual({
+      version: FORMAT_VERSION,
+      recordCount: 2,
+    });
+    // Meta is the commit marker: nothing may be written after it
+    // except nothing (sentinel removal is a remove, not a write).
+    expect(spy.writes[spy.writes.length - 1]).toBe(META);
+  });
+
+  test("probe() on a fresh store returns null without touching the bin", async () => {
+    const mem = makeMemAdapter();
+    const spy = spying(mem.adapter);
+    const store = makeOn(spy.adapter);
+    expect(await store.probe()).toBeNull();
+    expect(spy.binReads()).toBe(0);
+  });
+
+  test("probe() reads the meta sidecar and never the bin", async () => {
+    const mem = makeMemAdapter();
+    const store = makeOn(mem.adapter);
+    await store.init();
+    await store.upsert([rec2("a.md#0", "a.md")]);
+    await store.flush();
+
+    const spy = spying(mem.adapter);
+    const probing = makeOn(spy.adapter);
+    expect(await probing.probe()).toEqual({
+      version: FORMAT_VERSION,
+      recordCount: 1,
+    });
+    expect(spy.binReads()).toBe(0);
+  });
+
+  test("probe() falls back to the index JSON when the meta sidecar is absent or corrupt", async () => {
+    const mem = makeMemAdapter();
+    const store = makeOn(mem.adapter);
+    await store.init();
+    await store.upsert([rec2("a.md#0", "a.md")]);
+    await store.flush();
+
+    // Pre-sidecar store: meta missing.
+    mem.files.delete(META);
+    const spy1 = spying(mem.adapter);
+    expect(await makeOn(spy1.adapter).probe()).toEqual({
+      version: FORMAT_VERSION,
+      recordCount: 1,
+    });
+    expect(spy1.binReads()).toBe(0);
+
+    // Corrupt meta: same fallback.
+    mem.files.set(META, "{broken");
+    expect(await makeOn(mem.adapter).probe()).toEqual({
+      version: FORMAT_VERSION,
+      recordCount: 1,
+    });
+  });
+
+  test("probe() returns null while the dirty sentinel is present", async () => {
+    const mem = makeMemAdapter();
+    const store = makeOn(mem.adapter);
+    await store.init();
+    await store.upsert([rec2("a.md#0", "a.md")]);
+    await store.flush();
+
+    // Crash window: sentinel up. A probe trusting the healthy-looking
+    // meta would mark ready a store that init() is about to discard.
+    mem.files.set(`${I}.writing`, "1");
+    expect(await makeOn(mem.adapter).probe()).toBeNull();
+  });
+
+  test("close() on a never-initialized store performs zero writes", async () => {
+    const mem = makeMemAdapter();
+    const spy = spying(mem.adapter);
+    const store = makeOn(spy.adapter);
+    await store.close();
+    expect(spy.writes).toEqual([]);
+  });
+});

--- a/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/store.ts
@@ -66,6 +66,15 @@ export interface EmbeddingStore {
   mtimeFor(filePath: string): number | undefined;
   /** Record the mtime for a successfully indexed path (sidecar-dirty only). */
   setMtime(filePath: string, mtime: number): void;
+  /**
+   * Cheap readiness probe: reads only the `embeddings.meta.json`
+   * sidecar (fallback: one parse of the index JSON, for stores written
+   * before the sidecar existed), never the bin, and never initializes
+   * the store. Returns null when nothing is persisted or the dirty
+   * sentinel is present — a pending init() would discard those records,
+   * so reporting them as ready would be a lie.
+   */
+  probe(): Promise<{ version: number; recordCount: number } | null>;
   scan(): AsyncIterable<EmbeddingRecord>;
   flush(): Promise<void>;
   close(): Promise<void>;
@@ -121,12 +130,52 @@ class EmbeddingStoreImpl implements EmbeddingStore {
 
   /** Sidecar next to the index file, e.g. `<dir>/mtimes.json`. */
   private readonly mtimesPath: string;
+  /** Tiny readiness sidecar, e.g. `<dir>/embeddings.meta.json`. */
+  private readonly metaPath: string;
 
   constructor(private opts: EmbeddingStoreOpts) {
     this.vectorDim = opts.vectorDim ?? DEFAULT_VECTOR_DIM;
     this.sentinelPath = `${opts.indexPath}.writing`;
     const dir = opts.indexPath.split("/").slice(0, -1).join("/");
     this.mtimesPath = dir ? `${dir}/mtimes.json` : "mtimes.json";
+    this.metaPath = dir
+      ? `${dir}/embeddings.meta.json`
+      : "embeddings.meta.json";
+  }
+
+  async probe(): Promise<{ version: number; recordCount: number } | null> {
+    if (await this.opts.adapter.exists(this.sentinelPath)) return null;
+    try {
+      if (await this.opts.adapter.exists(this.metaPath)) {
+        const parsed = JSON.parse(
+          await this.opts.adapter.read(this.metaPath),
+        ) as { version?: unknown; recordCount?: unknown };
+        if (
+          typeof parsed.version === "number" &&
+          typeof parsed.recordCount === "number"
+        ) {
+          return {
+            version: parsed.version,
+            recordCount: parsed.recordCount,
+          };
+        }
+      }
+    } catch {
+      // Corrupt meta: fall through to the index parse below.
+    }
+    try {
+      if (!(await this.opts.adapter.exists(this.opts.indexPath))) return null;
+      const parsed = JSON.parse(
+        await this.opts.adapter.read(this.opts.indexPath),
+      ) as IndexFile;
+      if (typeof parsed.version !== "number") return null;
+      return {
+        version: parsed.version,
+        recordCount: parsed.records?.length ?? 0,
+      };
+    } catch {
+      return null;
+    }
   }
 
   async init(): Promise<void> {
@@ -400,6 +449,17 @@ class EmbeddingStoreImpl implements EmbeddingStore {
     // After the pair, inside the sentinel window: a crash here leaves
     // the sentinel up, so init() discards records AND mtimes together.
     if (this.mtimeDirty) await this.flushMtimes();
+
+    // Meta sidecar last, still inside the window: it doubles as the
+    // commit marker probe() trusts, so it must never describe a pair
+    // that didn't finish writing.
+    await this.opts.adapter.write(
+      this.metaPath,
+      JSON.stringify({
+        version: FORMAT_VERSION,
+        recordCount: this.records.size,
+      }),
+    );
 
     // Both writes succeeded — the pair is consistent, clear the sentinel.
     await this.removeSentinel();

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -366,25 +366,35 @@ export default class McpToolsPlugin extends Plugin {
       // Migrate v1 flat store before constructing any registry entry.
       await migrateV1FlatStore(ssAdapter, pluginDir);
 
-      // Detect stale per-providerKey stores (version < FORMAT_VERSION).
-      // If any exist, show a blocking dialog before wiping them.
+      // One cheap probe per provider replaces the three eager store
+      // loads this block used to do (stale-version JSON parse, native
+      // init, DLC size checks): it reads the meta sidecar (or the index
+      // JSON once, for pre-sidecar stores), never the bin, so no vector
+      // data sits in RAM for providers that may never be queried this
+      // session. Stores init lazily on first indexer/search use.
       const embeddingsBaseDir = `${pluginDir}/embeddings`;
+      const registry = createEmbeddingStoreRegistry(
+        ssAdapter,
+        embeddingsBaseDir,
+      );
+      const PROVIDER_DIMS = {
+        "native-minilm-l6-v2": 384,
+        "embedding-gemma-300m": 768,
+        "multilingual-e5-base": 768,
+      } as const satisfies Record<ProviderKey, number>;
       const staleProviderKeys: ProviderKey[] = [];
+      const probedCounts: Partial<Record<ProviderKey, number>> = {};
       for (const key of ALL_PROVIDER_KEYS) {
-        const indexPath = `${embeddingsBaseDir}/${key}/embeddings.index.json`;
-        try {
-          if (await ssAdapter.exists(indexPath)) {
-            const text = await ssAdapter.read(indexPath);
-            const parsed = JSON.parse(text) as { version?: number };
-            if (
-              typeof parsed.version === "number" &&
-              parsed.version < FORMAT_VERSION
-            ) {
-              staleProviderKeys.push(key);
-            }
-          }
-        } catch {
-          // Unreadable index is already handled by store.init(); skip here.
+        const probed = await registry.storeFor(key, PROVIDER_DIMS[key]).probe();
+        if (!probed) continue;
+        if (probed.version < FORMAT_VERSION) {
+          staleProviderKeys.push(key);
+        } else if (
+          probed.version === FORMAT_VERSION &&
+          probed.recordCount > 0
+        ) {
+          registry.markReady(key);
+          probedCounts[key] = probed.recordCount;
         }
       }
 
@@ -404,6 +414,9 @@ export default class McpToolsPlugin extends Plugin {
               .remove(`${dirPath}/embeddings.index.json.writing`)
               .catch(() => {});
             await ssAdapter.remove(`${dirPath}/mtimes.json`).catch(() => {});
+            await ssAdapter
+              .remove(`${dirPath}/embeddings.meta.json`)
+              .catch(() => {});
           } catch (err) {
             logger.warn(
               "semantic-search: failed to wipe stale index directory",
@@ -423,12 +436,7 @@ export default class McpToolsPlugin extends Plugin {
         });
       }
 
-      const registry = createEmbeddingStoreRegistry(
-        ssAdapter,
-        `${pluginDir}/embeddings`,
-      );
-
-      // Native MiniLM — eager init; always available.
+      // Native MiniLM — always available (store loads lazily).
       const nativeDownloader = createModelDownloader({
         innerFactory: realPipelineFactory,
       });
@@ -447,7 +455,8 @@ export default class McpToolsPlugin extends Plugin {
       });
       const nativeEp = createNativeEmbeddingProvider(embedder);
       const nativeStore = registry.storeFor("native-minilm-l6-v2", 384);
-      await nativeStore.init();
+      // No eager init: the indexer/search path inits on first use. The
+      // native provider is always available, so it is always "ready".
       registry.markReady("native-minilm-l6-v2");
 
       // DLC providers — pipeline loads lazily on first embed call.
@@ -485,16 +494,9 @@ export default class McpToolsPlugin extends Plugin {
         state.downloader = nativeDownloader;
         state.store = nativeStore;
         state.registry = registry;
-
-        // Check whether DLC stores are already built from a prior session.
-        for (const [key, dim] of [
-          ["embedding-gemma-300m", 768],
-          ["multilingual-e5-base", 768],
-        ] as const) {
-          const dlcStore = registry.storeFor(key, dim);
-          await dlcStore.init();
-          if (dlcStore.size() > 0) registry.markReady(key);
-        }
+        // DLC readiness came from the probe pass above (no store init);
+        // the settings UI uses these counts while stores are still lazy.
+        state.probedCounts = probedCounts;
 
         // Native indexer — lazy start on first search tool call.
         // The chunker tracks the provider's effective max-input-tokens
@@ -657,16 +659,14 @@ export default class McpToolsPlugin extends Plugin {
           "embedding-gemma-300m",
           "multilingual-e5-base",
         ] as const) {
-          const dim = 768;
-          const dlcStore = registry.storeFor(key, dim);
           // Auto-subscribe only when the provider is currently active AND
-          // its store is ready (size > 0 was set by the earlier init loop
-          // via registry.markReady). Inactive providers stay dormant —
-          // the user can switch into them, which routes through
-          // startRebuildFor and lazily starts the indexer at that point.
+          // its store is ready (probe pass found a current store with
+          // records). Inactive providers stay dormant — the user can
+          // switch into them, which routes through startRebuildFor and
+          // lazily starts the indexer at that point.
           const isActive =
             settingToRegistryKey[state.settings.provider] === key;
-          if (isActive && dlcStore.size() > 0) {
+          if (isActive && registry.isReady(key)) {
             _autoSubscribeDlc(key);
           }
         }


### PR DESCRIPTION
PR 3 of 3, closes the semantic-search perf pack. Stacked on #280 (base retargets once it merges).

**Problem**

`onload()` read and materialized every embedding store before the plugin finished loading: the stale-version probe parsed every provider's index JSON, the native store init'd eagerly, and both 768-dim DLC stores init'd just to check `size() > 0`, so each index JSON was parsed twice and inactive DLC vectors (potentially hundreds of MB) sat resident in renderer memory for the whole session.

**Changes**

1. `store.probe()` answers `{version, recordCount}` from a tiny `embeddings.meta.json` sidecar without touching the bin and without initializing the store. The sidecar is the LAST write inside the sentinel window, so it doubles as a commit marker; `probe()` returns `null` while the sentinel is up (a healthy-looking meta over records that `init()` will discard must not mark a provider ready). Pre-sidecar stores fall back to one index-JSON parse, the exact cost of the old loop, paid only until their first flush.
2. One probe pass in `main.ts` replaces the three eager loads: it feeds the stale-version wipe (which now also removes `embeddings.meta.json`), `registry.markReady`, the DLC auto-subscribe gate (now `registry.isReady`), and `state.probedCounts`.
3. Both indexers `await store.init()` before processing (live `start()`/`rebuildAll()`, low-power `runCycle()`). This guards `recordsFor()`, which is sync with no defensive init: without it, the first search of a session would see an empty store and silently re-embed the entire vault. The new regression test fails without this line.
4. The settings UI falls back to the probed counts, so "chunks indexed" stays truthful in settings-only sessions where no store ever initializes.

**Verification**

- `bun test`: 1147 pass / 0 fail (8 new: meta written last with correct contents, probe without bin reads, index-JSON fallback for absent/corrupt meta, sentinel → null, zero writes on close of an un-inited store, fresh-dir null, un-inited-store session start with zero re-embeds, DLC-style `initialRebuild: false` + modify event reusing persisted hashes)
- `tsc --noEmit` clean, prettier clean