### PR TITLE
perf(mcp-tools): scan search_vault_simple without lowercasing files

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSimple.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSimple.test.ts
@@ -78,3 +78,51 @@ describe("search_vault_simple tool", () => {
     expect(data.results).toHaveLength(1);
   });
 });
+
+describe("search_vault_simple — regex-literal scan", () => {
+  test("regex metacharacters in the query match literally", async () => {
+    setMockFile("notes.md", "Version a.b(c) shipped. Also axbxcx here.");
+
+    const result = await searchVaultSimpleHandler({
+      arguments: { query: "a.b(c)" },
+      app: mockApp(),
+    });
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].matches).toHaveLength(1);
+    expect(data.results[0].matches[0].context).toContain("a.b(c)");
+  });
+
+  test("overlapping-step parity: matches advance by query length", async () => {
+    // "aaaa" with query "aa" → matches at 0 and 2 (not 1), matching
+    // the previous indexOf stepping.
+    setMockFile("steps.md", "aaaa");
+
+    const result = await searchVaultSimpleHandler({
+      arguments: { query: "aa", contextLength: 0 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(result.content[0].text as string);
+    expect(
+      data.results[0].matches.map(
+        (m: { match: { start: number } }) => m.match.start,
+      ),
+    ).toEqual([0, 2]);
+  });
+
+  test("result order is stable and limit stops across batches", async () => {
+    // 20 matching files: more than two read batches of 8.
+    for (let i = 0; i < 20; i++) {
+      setMockFile(`f${String(i).padStart(2, "0")}.md`, `target ${i}`);
+    }
+
+    const result = await searchVaultSimpleHandler({
+      arguments: { query: "target", limit: 10 },
+      app: mockApp(),
+    });
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.results).toHaveLength(10);
+    const names = data.results.map((r: { filename: string }) => r.filename);
+    expect(names).toEqual([...names].sort()); // vault order preserved
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSimple.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSimple.ts
@@ -32,11 +32,25 @@ type FileResult = {
   matches: Array<{ context: string; match: { start: number; end: number } }>;
 };
 
+/** Reads per batch: bounds memory while hiding cachedRead latency. */
+const READ_BATCH_SIZE = 8;
+
+/** Escape a literal string for use inside a RegExp source. */
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
  * Search vault files for plain-text substring matches. Iterates over all
  * markdown files, performs case-insensitive search, extracts context
  * windows around each match, and respects the client-side limit truncation
  * (fix for issue #62).
+ *
+ * The scan is a case-insensitive regex over the original content: the
+ * previous `content.toLowerCase()` allocated a full copy of every file
+ * per query. Files are read in sequential batches of 8 (parallel reads
+ * within a batch, batch order preserved) with an early stop once
+ * `limit` files have matched.
  */
 export async function searchVaultSimpleHandler(
   ctx: SearchVaultSimpleContext,
@@ -44,31 +58,50 @@ export async function searchVaultSimpleHandler(
   const query = ctx.arguments.query;
   const contextLength = ctx.arguments.contextLength ?? DEFAULT_CONTEXT;
   const limit = ctx.arguments.limit ?? DEFAULT_LIMIT;
-  const lowerQuery = query.toLowerCase();
+  const patternSource = escapeRegExp(query);
 
   const files = ctx.app.vault.getMarkdownFiles();
   const results: FileResult[] = [];
 
-  for (const file of files) {
-    if (results.length >= limit) break; // #62 fix: client-side truncation
+  for (
+    let start = 0;
+    start < files.length && results.length < limit;
+    start += READ_BATCH_SIZE
+  ) {
+    const batch = files.slice(start, start + READ_BATCH_SIZE);
+    const batchResults = await Promise.all(
+      batch.map(async (file): Promise<FileResult | null> => {
+        const content = await ctx.app.vault.cachedRead(file);
+        const matches: FileResult["matches"] = [];
 
-    const content = await ctx.app.vault.cachedRead(file);
-    const lower = content.toLowerCase();
-    const matches: FileResult["matches"] = [];
+        // Per-file scanner: files in a batch scan concurrently, so a
+        // shared regex would race on lastIndex.
+        let m: RegExpExecArray | null;
+        const scanner = new RegExp(patternSource, "gi");
+        while ((m = scanner.exec(content)) !== null) {
+          const idx = m.index;
+          const start = Math.max(0, idx - contextLength);
+          const end = Math.min(
+            content.length,
+            idx + query.length + contextLength,
+          );
+          matches.push({
+            context: content.slice(start, end),
+            match: { start: idx, end: idx + query.length },
+          });
+          // Match length equals query length (literal pattern), so this
+          // mirrors the previous `idx += query.length` stepping.
+          scanner.lastIndex = idx + query.length;
+        }
 
-    let idx = 0;
-    while ((idx = lower.indexOf(lowerQuery, idx)) !== -1) {
-      const start = Math.max(0, idx - contextLength);
-      const end = Math.min(content.length, idx + query.length + contextLength);
-      matches.push({
-        context: content.slice(start, end),
-        match: { start: idx, end: idx + query.length },
-      });
-      idx += query.length;
-    }
+        return matches.length > 0 ? { filename: file.path, matches } : null;
+      }),
+    );
 
-    if (matches.length > 0) {
-      results.push({ filename: file.path, matches });
+    for (const r of batchResults) {
+      if (r === null) continue;
+      if (results.length >= limit) break; // #62 fix: client-side truncation
+      results.push(r);
     }
   }
 


### PR DESCRIPTION
PR 1 of 4 of the remaining audit S-items cycle.

**Problem**

`search_vault_simple` read every markdown file sequentially and called `content.toLowerCase()` on each one, a full copy per file per query (2x allocation, O(vault bytes) serially for queries with few or late matches).

**Changes**

- The scan is now a case-insensitive literal regex (`escapeRegExp(query)`, `gi`) over the original content: no second copy, the regex engine handles casing. Match stepping mirrors the previous `idx += query.length` exactly (parity test on overlapping matches included).
- Files read in sequential batches of 8 with parallel `cachedRead` within a batch, batch order preserved, early stop between batches once `limit` files matched. The #62 client-side truncation behavior is unchanged.
- Each file gets its own scanner instance: a shared `g` regex would race on `lastIndex` across the concurrent reads.

**Verification**

- `bun test`: 1150 pass / 0 fail (3 new: regex metacharacters match literally, overlap stepping parity, stable order + cross-batch limit)
- `tsc --noEmit` clean, prettier clean