### PR TITLE
chore(typecheck): include test files in tsc

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "turndown": "^7.2.0",
       },
       "devDependencies": {
+        "@types/bun": "1.3.14",
         "@types/fs-extra": "^11.0.4",
         "@types/json-logic-js": "^2.0.8",
         "@types/node": "^16.11.6",

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -32,13 +32,14 @@
 		"turndown": "^7.2.0"
 	},
 	"devDependencies": {
+		"@types/bun": "1.3.14",
 		"@types/fs-extra": "^11.0.4",
 		"@types/json-logic-js": "^2.0.8",
 		"@types/node": "^16.11.6",
 		"@types/turndown": "^5.0.5",
+		"archiver": "^8.0.0",
 		"fs-extra": "^11.2.0",
 		"moment": "^2.30.1",
-		"archiver": "^8.0.0",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "^5.7.2"

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.test.ts
@@ -220,7 +220,7 @@ describe("detectNode — canonical-path fallback (launchctl PATH gotcha)", () =>
     // A maliciously-named path must reach the runner as a literal file
     // argument (no `/bin/sh -c "..."`), so `; rm -rf ~` cannot execute.
     const evil = "/opt/homebrew/bin/node; rm -rf ~";
-    let received: { file: string; args: string[] } | null = null;
+    let received = null as { file: string; args: string[] } | null;
     const runner: ExecRunner = async (file, args) => {
       if (file === "node") throw new Error("spawn node ENOENT");
       received = { file, args };

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.test.ts
@@ -80,7 +80,7 @@ describe("preWarm — success path", () => {
     // A path with a shell metacharacter must reach the runner verbatim
     // as the file argument — never concatenated into a `/bin/sh -c` line.
     const evilNpx = "/Users/a b/npx; touch /tmp/pwned";
-    let received: { file: string; args: string[] } | null = null;
+    let received = null as { file: string; args: string[] } | null;
     const runner: ExecRunner = async (file, args) => {
       received = { file, args };
       return { stdout: "mcp-remote 1.0.0", stderr: "" };

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.test.ts
@@ -94,7 +94,7 @@ describe("findBlockPositionFromCache", () => {
     const cache = {};
     expect(
       findBlockPositionFromCache(
-        cache as { blocks?: Record<string, unknown> },
+        cache as Parameters<typeof findBlockPositionFromCache>[0],
         "x",
       ),
     ).toBeNull();

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/findBrokenLinks.test.ts
@@ -189,7 +189,7 @@ describe("find_broken_links tool", () => {
     // scanned_files is incremented before the cache check — file counts as scanned
     expect(data.scanned_files).toBe(1);
     expect(data.total_broken_links).toBe(0);
-    expect(r.isError).toBeUndefined();
+    expect((r as { isError?: boolean }).isError).toBeUndefined();
   });
 
   test("caps output at limit and reports truncated+total (applied after scope)", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.test.ts
@@ -24,7 +24,7 @@ describe("get_vault_file tool", () => {
     });
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe("text");
-    expect(result.content[0].text).toBe("# Hello");
+    expect((result.content[0] as { text: string }).text).toBe("# Hello");
   });
 
   test("returns JSON shape when format=json with frontmatter+tags+stat", async () => {
@@ -37,7 +37,7 @@ describe("get_vault_file tool", () => {
       arguments: { path: "a.md", format: "json" },
       app: mockApp(),
     });
-    const parsed = JSON.parse(result.content[0].text as string);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
     expect(parsed.path).toBe("a.md");
     expect(parsed.frontmatter).toEqual({ tags: ["foo"] });
     expect(parsed.tags).toEqual(["foo"]);
@@ -84,7 +84,7 @@ describe("get_vault_file tool", () => {
     });
     // Unsupported binary returns text content describing the file
     expect(result.content[0].type).toBe("text");
-    const parsed = JSON.parse(result.content[0].text as string);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
     expect(parsed.path ?? parsed.filename).toBe("doc/file.pdf");
     expect(parsed.hint).toBeDefined();
   });
@@ -95,6 +95,6 @@ describe("get_vault_file tool", () => {
       app: mockApp(),
     });
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/not found/i);
+    expect((result.content[0] as { text: string }).text).toMatch(/not found/i);
   });
 });

--- a/packages/obsidian-plugin/tsconfig.json
+++ b/packages/obsidian-plugin/tsconfig.json
@@ -20,6 +20,6 @@
       "$/*": ["./src/*"]
     }
   },
-  "include": ["src/*.ts", "bun.config.ts"],
+  "include": ["src/**/*.ts", "bun.config.ts"],
   "exclude": ["node_modules", "playground"]
 }


### PR DESCRIPTION
PR 4 of 4, closes the remaining audit S-items cycle.

**Problem**

`tsconfig.json` had `"include": ["src/*.ts", "bun.config.ts"]`, top-level files only. Feature sources were still checked transitively (main.ts imports them), but the 92 `*.test.ts` files never passed through `tsc`; only the editor LSP saw their errors. A real bug shipped this way during PR #280: a test store wrapper missing new interface methods sailed through `tsc --noEmit` clean.

**Changes**

- `include` widened to `src/**/*.ts`. From this PR on, `tsc --noEmit` covers the tests too.
- `@types/bun` pinned at 1.3.14 as an explicit devDependency: it resolved `bun:test` only as a transitive until now, one lockfile shuffle away from breaking the new checks.
- The 8 latent errors the widened check surfaced, all in tests: two `let received = null` spy holders that TS narrows to `null` at the assertion site (typed initializer cast), a fixture cast in `patchHelpers.test.ts` aligned to the function's parameter type, an `isError` access on a response type without it in `findBrokenLinks.test.ts` (the exact class of bug this PR exists to catch), and four `ContentBlock` union accesses in `getVaultFile.test.ts`.

**Verification**

- `bun test`: 1147 pass / 0 fail (no behavior changes, type-level fixes only)
- `tsc --noEmit` clean over sources AND tests, prettier clean