### PR TITLE
feat(shared): add SettingsStore for typed, race-free data.json slices

### DIFF
--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
@@ -205,6 +205,31 @@ describe("activateTool", () => {
     expect(result).toBe("already_active");
   });
 
+  test("'already_active' performs NO write (NO_CHANGE)", async () => {
+    let saves = 0;
+    const base = makePlugin({
+      toolLoading: {
+        profile: "adaptive",
+        counters: {},
+        promoted: ["search_and_replace"],
+      },
+    });
+    const plugin = {
+      loadData: base.loadData,
+      saveData: async (d: unknown) => {
+        saves++;
+        await base.saveData(d);
+      },
+    };
+    const result = await mgr.activateTool(
+      "search_and_replace",
+      ALL_NAMES,
+      plugin,
+    );
+    expect(result).toBe("already_active");
+    expect(saves).toBe(0);
+  });
+
   test("returns 'activated' and writes to promoted list", async () => {
     const plugin = makePlugin();
     const result = await mgr.activateTool(

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
@@ -1,4 +1,4 @@
-import { globalSettingsMutex } from "$/shared/settingsLock";
+import { SettingsStore } from "$/shared/settingsStore";
 import type { PluginDataLike } from "$/shared/types";
 import {
   ADAPTIVE_META_TOOLS,
@@ -20,28 +20,25 @@ const DEFAULTS: ToolLoadingState = {
   promoted: [],
 };
 
-function mergeState(raw: unknown): ToolLoadingState {
-  const slice =
-    raw && typeof raw === "object"
-      ? ((raw as Record<string, unknown>).toolLoading as
-          | Partial<ToolLoadingState>
-          | undefined)
+/** Normalize a raw `toolLoading` slice value into a well-formed state. */
+function mergeState(slice: unknown): ToolLoadingState {
+  const s =
+    slice && typeof slice === "object"
+      ? (slice as Partial<ToolLoadingState>)
       : undefined;
   return {
     ...DEFAULTS,
-    ...(slice ?? {}),
-    counters:
-      slice?.counters && typeof slice.counters === "object"
-        ? slice.counters
-        : {},
-    promoted: Array.isArray(slice?.promoted) ? slice.promoted : [],
+    ...(s ?? {}),
+    counters: s?.counters && typeof s.counters === "object" ? s.counters : {},
+    promoted: Array.isArray(s?.promoted) ? s.promoted : [],
   };
 }
 
+const SLICE = "toolLoading";
+
 export class ToolLoadingManager {
   async loadState(plugin: PluginDataLike): Promise<ToolLoadingState> {
-    const raw = await plugin.loadData();
-    return mergeState(raw);
+    return mergeState(await new SettingsStore(plugin).readSlice(SLICE));
   }
 
   getActiveToolNames(allNames: string[], state: ToolLoadingState): Set<string> {
@@ -57,15 +54,15 @@ export class ToolLoadingManager {
     return base;
   }
 
-  // All mutating methods serialize their load→modify→save cycle through
-  // globalSettingsMutex: data.json is shared with every other feature, so
-  // an unserialized read-modify-write here can clobber another feature's
-  // slice (or lose a concurrent counter increment). See settingsLock.ts.
+  // All mutating methods go through SettingsStore.updateSlice, which
+  // serializes the load→modify→save cycle through the process-wide
+  // settings mutex: data.json is shared with every other feature, so an
+  // unserialized read-modify-write here can clobber another feature's
+  // slice (or lose a concurrent counter increment). See settingsStore.ts.
 
   async recordCall(toolName: string, plugin: PluginDataLike): Promise<void> {
-    await globalSettingsMutex.run(async () => {
-      const raw = (await plugin.loadData()) as Record<string, unknown> | null;
-      const state = mergeState(raw);
+    await new SettingsStore(plugin).updateSlice(SLICE, (current) => {
+      const state = mergeState(current);
       state.counters[toolName] = (state.counters[toolName] ?? 0) + 1;
       if (
         state.profile === "adaptive" &&
@@ -75,7 +72,7 @@ export class ToolLoadingManager {
       ) {
         state.promoted = [...state.promoted, toolName];
       }
-      await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+      return state;
     });
   }
 
@@ -85,32 +82,33 @@ export class ToolLoadingManager {
     plugin: PluginDataLike,
   ): Promise<"activated" | "already_active" | "not_found"> {
     if (!allNames.includes(name)) return "not_found";
-    return globalSettingsMutex.run(async () => {
-      const raw = (await plugin.loadData()) as Record<string, unknown> | null;
-      const state = mergeState(raw);
-      if (state.promoted.includes(name)) return "already_active" as const;
+    let outcome: "activated" | "already_active" = "activated";
+    await new SettingsStore(plugin).updateSlice(SLICE, (current) => {
+      const state = mergeState(current);
+      if (state.promoted.includes(name)) {
+        outcome = "already_active";
+        return current; // NO_CHANGE: no write
+      }
       state.promoted = [...state.promoted, name];
-      await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
-      return "activated" as const;
+      return state;
     });
+    return outcome;
   }
 
   async deactivateTool(name: string, plugin: PluginDataLike): Promise<void> {
-    await globalSettingsMutex.run(async () => {
-      const raw = (await plugin.loadData()) as Record<string, unknown> | null;
-      const state = mergeState(raw);
+    await new SettingsStore(plugin).updateSlice(SLICE, (current) => {
+      const state = mergeState(current);
       state.promoted = state.promoted.filter((n) => n !== name);
-      await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+      return state;
     });
   }
 
   async resetAll(plugin: PluginDataLike): Promise<void> {
-    await globalSettingsMutex.run(async () => {
-      const raw = (await plugin.loadData()) as Record<string, unknown> | null;
-      const state = mergeState(raw);
+    await new SettingsStore(plugin).updateSlice(SLICE, (current) => {
+      const state = mergeState(current);
       state.counters = {};
       state.promoted = [];
-      await plugin.saveData({ ...(raw ?? {}), toolLoading: state });
+      return state;
     });
   }
 }

--- a/packages/obsidian-plugin/src/features/semantic-search/index.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/index.ts
@@ -1,10 +1,9 @@
-import { type } from "arktype";
 import type McpToolsPlugin from "$/main";
 import {
   globalSettingsMutex,
   type Mutex,
 } from "$/features/command-permissions";
-import { logger } from "$/shared/logger";
+import { SettingsStore } from "$/shared/settingsStore";
 import {
   DEFAULT_SEMANTIC_SETTINGS,
   semanticSearchSettingsSchema,
@@ -170,44 +169,16 @@ async function loadAndPersistSettings(
   plugin: McpToolsPlugin,
   mutex: Mutex,
 ): Promise<SemanticSearchSettings> {
-  return mutex.run(async () => {
-    const data = ((await plugin.loadData()) as Record<string, unknown>) ?? {};
-    const stored = data.semanticSearch as
-      | Partial<SemanticSearchSettings>
-      | undefined;
-
-    const merged: SemanticSearchSettings = {
-      ...DEFAULT_SEMANTIC_SETTINGS,
-      ...(stored ?? {}),
-    };
-
-    const validated = semanticSearchSettingsSchema(merged);
-    if (validated instanceof type.errors) {
-      // Settings on disk are malformed — fall back to defaults but log
-      // so the user can find out via plugin logs why their tweaks were
-      // ignored. Never throw: a corrupt settings field must not crash
-      // the plugin onload.
-      logger.warn("semantic-search settings invalid, using defaults", {
-        summary: validated.summary,
-        stored,
-      });
-      const defaults = { ...DEFAULT_SEMANTIC_SETTINGS };
-      data.semanticSearch = defaults;
-      await plugin.saveData(data);
-      return defaults;
-    }
-
-    // Persist iff the merge added defaults that weren't on disk.
-    const needsPersist =
-      stored === undefined ||
-      JSON.stringify(stored) !== JSON.stringify(validated);
-    if (needsPersist) {
-      data.semanticSearch = validated;
-      await plugin.saveData(data);
-    }
-
-    return validated;
-  });
+  // SettingsStore.loadSlice owns the merge-defaults + arktype-validate
+  // + persist-iff-changed cycle under the mutex. Invalid on-disk data
+  // falls back to defaults (persisted, warned) without throwing.
+  return new SettingsStore(plugin, mutex).loadSlice<SemanticSearchSettings>(
+    "semanticSearch",
+    {
+      schema: semanticSearchSettingsSchema,
+      defaults: DEFAULT_SEMANTIC_SETTINGS,
+    },
+  );
 }
 
 class NoopProvider implements SemanticSearchProvider {
@@ -305,11 +276,10 @@ export async function applySettings(
   state: SemanticSearchState,
   next: SemanticSearchSettings,
 ): Promise<void> {
-  await state.settingsMutex.run(async () => {
-    const data = ((await plugin.loadData()) as Record<string, unknown>) ?? {};
-    data.semanticSearch = next;
-    await plugin.saveData(data);
-  });
+  await new SettingsStore(plugin, state.settingsMutex).updateSlice(
+    "semanticSearch",
+    () => next,
+  );
   state.settings = next;
 
   const pendingKey = DOWNLOADABLE_PROVIDER_KEYS[next.provider];

--- a/packages/obsidian-plugin/src/shared/settingsStore.test.ts
+++ b/packages/obsidian-plugin/src/shared/settingsStore.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import { type } from "arktype";
+import { SettingsStore } from "./settingsStore";
+import { createMutex, globalSettingsMutex } from "./settingsLock";
+
+/**
+ * In-memory plugin data mock. `saveData` forces a microtask gap so the
+ * lost-update race is observable without the mutex (mirrors
+ * settingsLock.test.ts).
+ */
+function makePlugin(initial: Record<string, unknown> = {}) {
+  let data: Record<string, unknown> = structuredClone(initial);
+  let saves = 0;
+  return {
+    plugin: {
+      loadData: async () => structuredClone(data),
+      saveData: async (next: unknown) => {
+        await Promise.resolve();
+        saves++;
+        data = structuredClone(next as Record<string, unknown>);
+      },
+    },
+    snapshot: () => structuredClone(data),
+    saves: () => saves,
+  };
+}
+
+describe("SettingsStore.updateSlice", () => {
+  test("writes only its key, preserving siblings", async () => {
+    const { plugin, snapshot } = makePlugin({ other: { keep: 1 } });
+    const store = new SettingsStore(plugin);
+    await store.updateSlice("mine", () => ({ v: 2 }));
+    expect(snapshot()).toEqual({ other: { keep: 1 }, mine: { v: 2 } });
+  });
+
+  test("returning the same reference skips the write (NO_CHANGE)", async () => {
+    const { plugin, saves } = makePlugin({ mine: { v: 1 } });
+    const store = new SettingsStore(plugin);
+    const ret = await store.updateSlice("mine", (current) => current);
+    expect(saves()).toBe(0);
+    expect(ret).toEqual({ v: 1 });
+  });
+
+  test("returning a new object always writes and propagates the value", async () => {
+    const { plugin, saves } = makePlugin({ mine: { v: 1 } });
+    const store = new SettingsStore(plugin);
+    const ret = await store.updateSlice("mine", () => ({ v: 2 }));
+    expect(saves()).toBe(1);
+    expect(ret).toEqual({ v: 2 });
+  });
+
+  test("a corrupt sibling slice is preserved untouched", async () => {
+    const { plugin, snapshot } = makePlugin({ broken: "not-an-object" });
+    const store = new SettingsStore(plugin);
+    await store.updateSlice("mine", () => ({ ok: true }));
+    expect(snapshot()).toEqual({ broken: "not-an-object", mine: { ok: true } });
+  });
+
+  test("N concurrent writers on two keys through the singleton lose no slice", async () => {
+    // Uses the DEFAULT globalSettingsMutex (not a fresh one): this is
+    // what proves cross-feature safety, since every feature shares it.
+    let data: Record<string, unknown> = {};
+    const plugin = {
+      loadData: async () => structuredClone(data),
+      saveData: async (next: unknown) => {
+        await Promise.resolve();
+        data = structuredClone(next as Record<string, unknown>);
+      },
+    };
+    const store = new SettingsStore(plugin, globalSettingsMutex);
+    const push = (key: "a" | "b", value: number) =>
+      store.updateSlice(key, (cur) => {
+        const arr = Array.isArray(cur) ? [...(cur as number[])] : [];
+        arr.push(value);
+        return arr;
+      });
+
+    const N = 20;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) => [push("a", i), push("b", i)]).flat(),
+    );
+    expect((data.a as number[]).slice().sort((x, y) => x - y)).toEqual(
+      Array.from({ length: N }, (_, i) => i),
+    );
+    expect((data.b as number[]).slice().sort((x, y) => x - y)).toEqual(
+      Array.from({ length: N }, (_, i) => i),
+    );
+  });
+
+  test("a fresh mutex does not serialize against the global singleton", async () => {
+    // Per-instance isolation: a store built with createMutex() runs
+    // independently of globalSettingsMutex (mirrors settingsLock's
+    // distinct-instances test).
+    const order: string[] = [];
+    const slow = globalSettingsMutex.run(async () => {
+      order.push("global-start");
+      await new Promise((r) => setTimeout(r, 30));
+      order.push("global-end");
+    });
+    const { plugin } = makePlugin();
+    const isolated = new SettingsStore(plugin, createMutex());
+    await isolated.updateSlice("x", () => {
+      order.push("isolated");
+      return 1;
+    });
+    await slow;
+    // isolated ran before global finished — not serialized behind it.
+    expect(order.indexOf("isolated")).toBeLessThan(order.indexOf("global-end"));
+  });
+});
+
+describe("SettingsStore.loadSlice", () => {
+  const schema = type({ provider: "string", count: "number" });
+  const defaults = { provider: "native", count: 0 };
+
+  test("merges defaults for missing keys and persists when changed", async () => {
+    const { plugin, snapshot, saves } = makePlugin({
+      semanticSearch: { provider: "auto" },
+    });
+    const store = new SettingsStore(plugin);
+    const out = await store.loadSlice("semanticSearch", { schema, defaults });
+    expect(out).toEqual({ provider: "auto", count: 0 });
+    expect(saves()).toBe(1);
+    expect(snapshot().semanticSearch).toEqual({ provider: "auto", count: 0 });
+  });
+
+  test("does NOT persist when disk already equals the merged result", async () => {
+    const { plugin, saves } = makePlugin({
+      semanticSearch: { provider: "native", count: 0 },
+    });
+    const store = new SettingsStore(plugin);
+    await store.loadSlice("semanticSearch", { schema, defaults });
+    expect(saves()).toBe(0);
+  });
+
+  test("invalid data falls back to defaults, persists them, does not throw", async () => {
+    const { plugin, snapshot } = makePlugin({
+      semanticSearch: { provider: 123, count: "nope" },
+    });
+    const store = new SettingsStore(plugin);
+    const out = await store.loadSlice("semanticSearch", { schema, defaults });
+    expect(out).toEqual(defaults);
+    expect(snapshot().semanticSearch).toEqual(defaults);
+  });
+
+  test("no schema: merges defaults without validation", async () => {
+    const { plugin } = makePlugin({ s: { a: 1 } });
+    const store = new SettingsStore(plugin);
+    const out = await store.loadSlice("s", { defaults: { a: 0, b: 9 } });
+    expect(out).toEqual({ a: 1, b: 9 });
+  });
+});
+
+describe("SettingsStore.readSlice", () => {
+  test("returns the slice value without acquiring the write lock", async () => {
+    const order: string[] = [];
+    let data: Record<string, unknown> = { s: { v: 1 } };
+    const plugin = {
+      loadData: async () => structuredClone(data),
+      // Slow save keeps the mutex held while the write is in flight.
+      saveData: async (next: unknown) => {
+        await new Promise((r) => setTimeout(r, 30));
+        order.push("write-done");
+        data = structuredClone(next as Record<string, unknown>);
+      },
+    };
+    const store = new SettingsStore(plugin, globalSettingsMutex);
+
+    const writing = store.updateSlice("s", () => ({ v: 2 }));
+    // readSlice must resolve WITHOUT waiting for the in-flight write.
+    const value = await store.readSlice("s");
+    order.push("read-done");
+    expect(order[0]).toBe("read-done");
+    expect(value).toEqual({ v: 1 });
+    await writing;
+  });
+
+  test("returns undefined for a missing slice", async () => {
+    const { plugin } = makePlugin({});
+    const store = new SettingsStore(plugin);
+    expect(await store.readSlice("nope")).toBeUndefined();
+  });
+});

--- a/packages/obsidian-plugin/src/shared/settingsStore.ts
+++ b/packages/obsidian-plugin/src/shared/settingsStore.ts
@@ -1,0 +1,130 @@
+/**
+ * Typed accessor over the plugin's `data.json` slices.
+ *
+ * Every read-modify-write of a slice must serialize through the
+ * process-wide `globalSettingsMutex`: `loadData`/`saveData` are not
+ * atomic, so two features writing different slices concurrently would
+ * each save "before + my slice" and the last writer would clobber the
+ * other (cross-feature lost update). This store owns that discipline so
+ * call sites stop hand-rolling `mutex.run(...)` + `{ ...raw, [key]: x }`.
+ *
+ * Imported by direct path (`$/shared/settingsStore`), never via the
+ * `$/shared` barrel — the barrel pulls in `src/main` and would cycle.
+ */
+
+import { type } from "arktype";
+import { globalSettingsMutex, type Mutex } from "./settingsLock";
+import type { PluginDataLike } from "./types";
+import { logger } from "./logger";
+
+/** Deep structural equality for plain JSON values. */
+function jsonEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((v, i) => jsonEqual(v, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const aKeys = Object.keys(ao);
+    const bKeys = Object.keys(bo);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(
+      (k) =>
+        Object.prototype.hasOwnProperty.call(bo, k) && jsonEqual(ao[k], bo[k]),
+    );
+  }
+  return false;
+}
+
+export class SettingsStore {
+  constructor(
+    private readonly plugin: PluginDataLike,
+    private readonly mutex: Mutex = globalSettingsMutex,
+  ) {}
+
+  /**
+   * Atomic read-modify-write of one slice. `recipe` receives the
+   * current slice value and returns the next one; every other key is
+   * preserved. Returning the SAME reference `recipe` was given signals
+   * "no change" and skips the write — so a conditional writer (e.g.
+   * "already active, nothing to do") costs no disk I/O. Returns the
+   * recipe's value.
+   */
+  updateSlice<T>(key: string, recipe: (current: unknown) => T): Promise<T> {
+    return this.mutex.run(async () => {
+      const raw =
+        ((await this.plugin.loadData()) as Record<string, unknown> | null) ??
+        {};
+      const current = raw[key];
+      const next = recipe(current);
+      if ((next as unknown) !== current) {
+        await this.plugin.saveData({ ...raw, [key]: next });
+      }
+      return next;
+    });
+  }
+
+  /**
+   * Load a slice merged over `defaults`, optionally arktype-validated,
+   * persisting only when the merged result differs from what is on disk
+   * (deep equality, not stringify — arktype may reorder keys, which a
+   * stringify compare would treat as a change and re-persist on every
+   * load). Data that fails the schema falls back to `defaults` (which
+   * are persisted) with a warning; never throws.
+   */
+  loadSlice<T>(
+    key: string,
+    // schema is any arktype `Type` (callable, returns the parsed value
+    // or `type.errors`); typed as a bare validator so the generic T is
+    // anchored by `defaults`, not by arktype's complex Type<> form.
+    opts: { schema?: (data: unknown) => unknown; defaults: T },
+  ): Promise<T> {
+    return this.mutex.run(async () => {
+      const raw =
+        ((await this.plugin.loadData()) as Record<string, unknown> | null) ??
+        {};
+      const stored = raw[key];
+      const merged = {
+        ...(opts.defaults as object),
+        ...((stored && typeof stored === "object" ? stored : {}) as object),
+      } as T;
+
+      let resolved: T = merged;
+      if (opts.schema) {
+        const validated = opts.schema(merged);
+        if (validated instanceof type.errors) {
+          logger.warn(`settings slice "${key}" invalid, using defaults`, {
+            summary: validated.summary,
+          });
+          resolved = opts.defaults;
+        } else {
+          resolved = validated as T;
+        }
+      }
+
+      if (!jsonEqual(stored, resolved)) {
+        await this.plugin.saveData({ ...raw, [key]: resolved });
+      }
+      return resolved;
+    });
+  }
+
+  /**
+   * Read one slice without acquiring the write lock. `loadData` is a
+   * single atomic read+parse, so a concurrent in-flight write can only
+   * make this return the pre- or post-write snapshot, never a torn one.
+   */
+  async readSlice(key: string): Promise<unknown> {
+    const raw = (await this.plugin.loadData()) as Record<
+      string,
+      unknown
+    > | null;
+    return raw?.[key];
+  }
+}


### PR DESCRIPTION
PR 2 of 3 of cycle 1 (architecture foundations). Additive plus two migrations; behavior-preserving.

**Why**

Every `data.json` write hand-rolled `globalSettingsMutex.run(...)` + `{ ...raw, [slice]: next }`, with validation only in semantic-search. The mutex discipline was convention, not enforced by types: nothing stopped a contributor from a raw `saveData` that clobbers another feature's slice.

**SettingsStore** (`src/shared/settingsStore.ts`, imported by direct path to stay out of the `$/shared` barrel and avoid a `src/main` cycle):

- `updateSlice(key, recipe)` runs an atomic read-modify-write of one slice through the settings mutex. Returning the same reference the recipe was handed signals no-change and skips the write, so a conditional writer (for example "already active") costs no disk I/O.
- `loadSlice(key, {schema?, defaults})` merges defaults, optionally validates with arktype (falling back to defaults plus a warning on invalid data), and persists only when the result differs from disk by deep equality (not stringify, so arktype key reordering does not trigger a spurious write every load).
- `readSlice(key)` does an unlocked single-slice read; `loadData` is one atomic read+parse, so a concurrent write can only yield the pre- or post-write snapshot, never a torn one.

**Migrations**: `toolLoadingManager`'s four mutating methods plus `loadState`, and semantic-search's `loadAndPersistSettings` (now a thin `loadSlice` wrapper) and `applySettings`. `mergeState` was refactored to take the slice value directly.

**Verification**

- `bun test`: 1172 pass / 0 fail (13 new store tests: cross-feature no-clobber via the singleton, NO_CHANGE skip, persist-iff-changed with key-reorder guard, invalid-to-defaults, unlocked read, per-instance mutex isolation; plus a guard that `activate_tool`'s already-active path does no second write)
- `tsc --noEmit` clean, `format:check` clean
- The existing toolLoadingManager and semantic-search tests pass unchanged.