### PR TITLE
refactor(mcp-client-config): adopt SettingsStore in autoWrite and preWarm

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/autoWrite.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/autoWrite.ts
@@ -1,6 +1,6 @@
-import { globalSettingsMutex } from "$/features/command-permissions";
 import { logger } from "$/shared/logger";
 import type { PluginDataLike } from "$/shared/types";
+import { SettingsStore } from "$/shared/settingsStore";
 import { updateClaudeDesktopConfig } from "./claudeDesktop";
 
 /**
@@ -55,9 +55,7 @@ export async function getAutoWriteEnabled(
   plugin: PluginLike,
 ): Promise<boolean> {
   try {
-    const data = (await plugin.loadData()) as Record<string, unknown> | null;
-    if (!data || typeof data !== "object") return false;
-    const slice = data[DATA_KEY];
+    const slice = await new SettingsStore(plugin).readSlice(DATA_KEY);
     if (!slice || typeof slice !== "object") return false;
     const flag = (slice as Record<string, unknown>)[FLAG_KEY];
     return flag === true;
@@ -70,25 +68,19 @@ export async function getAutoWriteEnabled(
 }
 
 /**
- * Persist the flag. Reads the current `data.json`, mutates only the
- * `mcpClientConfig.autoWriteClaudeDesktopConfig` field, writes the
- * merged object back. Other keys are preserved. Serialized through
- * the shared `globalSettingsMutex` so this write cannot clobber a
- * concurrent settings write from another feature (data.json is not
- * atomic).
+ * Persist the flag. `SettingsStore.updateSlice` mutates only the
+ * `mcpClientConfig.autoWriteClaudeDesktopConfig` field under the shared
+ * settings mutex, preserving every other key, so this write cannot
+ * clobber a concurrent settings write from another feature (data.json
+ * is not atomic).
  */
 export async function setAutoWriteEnabled(
   plugin: PluginLike,
   enabled: boolean,
 ): Promise<void> {
-  await globalSettingsMutex.run(async () => {
-    const data =
-      ((await plugin.loadData()) as Record<string, unknown> | null) ?? {};
-    const slice = (data[DATA_KEY] as Record<string, unknown> | undefined) ?? {};
-    await plugin.saveData({
-      ...data,
-      [DATA_KEY]: { ...slice, [FLAG_KEY]: enabled },
-    });
+  await new SettingsStore(plugin).updateSlice(DATA_KEY, (current) => {
+    const slice = (current as Record<string, unknown> | undefined) ?? {};
+    return { ...slice, [FLAG_KEY]: enabled };
   });
 }
 

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/preWarm.ts
@@ -1,7 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import type { PluginDataLike } from "$/shared/types";
-import { globalSettingsMutex } from "$/features/command-permissions";
+import { SettingsStore } from "$/shared/settingsStore";
 import { logger } from "$/shared/logger";
 import {
   detectNode,
@@ -72,9 +72,7 @@ const defaultRunner: ExecRunner = (file, args, options) => {
 export async function getPreWarmCache(
   plugin: PluginDataLike,
 ): Promise<PreWarmCacheEntry | null> {
-  const data = (await plugin.loadData()) as Record<string, unknown> | null;
-  if (!data || typeof data !== "object") return null;
-  const slice = data[DATA_KEY];
+  const slice = await new SettingsStore(plugin).readSlice(DATA_KEY);
   if (!slice || typeof slice !== "object") return null;
   const entry = (slice as Record<string, unknown>)[SLICE_KEY];
   if (!entry || typeof entry !== "object") return null;
@@ -90,16 +88,9 @@ async function persistPreWarmCache(
   plugin: PluginDataLike,
   entry: PreWarmCacheEntry,
 ): Promise<void> {
-  // Serialized through the shared settings mutex: data.json is not
-  // atomic and is shared across features.
-  await globalSettingsMutex.run(async () => {
-    const data =
-      ((await plugin.loadData()) as Record<string, unknown> | null) ?? {};
-    const slice = (data[DATA_KEY] as Record<string, unknown> | undefined) ?? {};
-    await plugin.saveData({
-      ...data,
-      [DATA_KEY]: { ...slice, [SLICE_KEY]: entry },
-    });
+  await new SettingsStore(plugin).updateSlice(DATA_KEY, (current) => {
+    const slice = (current as Record<string, unknown> | undefined) ?? {};
+    return { ...slice, [SLICE_KEY]: entry };
   });
 }
 


### PR DESCRIPTION
PR 3 of 3 of cycle 1 (architecture foundations). Behavior-preserving.

**Changes**

Moved the `mcpClientConfig` slice access in `mcp-client-config` onto `SettingsStore`: `getAutoWriteEnabled` and `getPreWarmCache` use `readSlice`, `setAutoWriteEnabled` and `persistPreWarmCache` use `updateSlice`. The hand-rolled `globalSettingsMutex.run` plus spread-and-save is gone from both.

**Scope (narrower than the cycle-1 plan, deliberately)**

- `applyFilter` and `toolCatalog` stay raw: they are read-only `PluginReadLike` consumers, and constructing a `SettingsStore` requires `PluginDataLike`, so adopting it would widen their contract to gain nothing (the read is unlocked either way, no race).
- The Svelte settings writers, `checkCommandPermission`, `main.ts`'s settings read, the `mcp-transport` token write, and the `toolToggle` delete-key branch stay raw. They move in cycle 2 alongside the `main.ts` split, where the eslint guard against raw `saveData` outside the store will land (it can only land once the last raw consumer is migrated).

**Verification**

- `bun test`: 1172 pass / 0 fail (the 68 mcp-client-config tests pass unchanged)
- `tsc --noEmit` clean, `format:check` clean