### PR TITLE
refactor(command-permissions): extract checkCommandPermission service

### DIFF
--- a/packages/obsidian-plugin/src/features/command-permissions/services/checkCommandPermission.test.ts
+++ b/packages/obsidian-plugin/src/features/command-permissions/services/checkCommandPermission.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import type { App } from "obsidian";
+import { SettingsStore } from "$/shared/settingsStore";
+import { createMutex } from "$/shared/settingsLock";
+import { createRuntimeRateCounter } from "../utils";
+import {
+  checkCommandPermission,
+  type PermissionModalFactory,
+} from "./checkCommandPermission";
+import type { ModalDecision } from "./commandPermissionModal";
+
+/** In-memory plugin data with a save counter. */
+function makeStore(initial: Record<string, unknown> = {}) {
+  let data: Record<string, unknown> = structuredClone(initial);
+  let saves = 0;
+  const plugin = {
+    loadData: async () => structuredClone(data),
+    saveData: async (next: unknown) => {
+      saves++;
+      data = structuredClone(next as Record<string, unknown>);
+    },
+  };
+  // Fresh mutex per test for isolation.
+  const store = new SettingsStore(plugin, createMutex());
+  return { store, snapshot: () => structuredClone(data), saves: () => saves };
+}
+
+/** Modal stub: resolves to `decision`, or never resolves for "never". */
+function stubModal(decision: ModalDecision | "never") {
+  let opened = false;
+  const factory: PermissionModalFactory = () => ({
+    open: () => {
+      opened = true;
+    },
+    close: () => {},
+    waitForDecision: () =>
+      decision === "never"
+        ? new Promise<ModalDecision>(() => {})
+        : Promise.resolve(decision),
+  });
+  return { factory, opened: () => opened };
+}
+
+const app = {} as App;
+
+function permsOf(snapshot: Record<string, unknown>) {
+  return (snapshot.commandPermissions ?? {}) as {
+    allowlist?: string[];
+    recentInvocations?: { decision: string; commandId: string }[];
+  };
+}
+
+describe("checkCommandPermission", () => {
+  test("fast path: master toggle off → deny, audit written", async () => {
+    const { store, snapshot, saves } = makeStore({
+      commandPermissions: { enabled: false },
+    });
+    const result = await checkCommandPermission(
+      { app, store, rateCounter: createRuntimeRateCounter() },
+      "app:reload",
+    );
+    expect(result.outcome).toBe("deny");
+    expect(saves()).toBe(1); // fast-path audit write
+    expect(permsOf(snapshot()).recentInvocations?.at(-1)?.decision).toBe(
+      "deny",
+    );
+  });
+
+  test("fast path: enabled + in allowlist → allow, audit written", async () => {
+    const { store, snapshot } = makeStore({
+      commandPermissions: { enabled: true, allowlist: ["app:reload"] },
+    });
+    const result = await checkCommandPermission(
+      { app, store, rateCounter: createRuntimeRateCounter() },
+      "app:reload",
+    );
+    expect(result.outcome).toBe("allow");
+    expect(permsOf(snapshot()).recentInvocations?.at(-1)?.decision).toBe(
+      "allow",
+    );
+  });
+
+  test("trims the command id before deciding", async () => {
+    const { store } = makeStore({
+      commandPermissions: { enabled: true, allowlist: ["app:reload"] },
+    });
+    const result = await checkCommandPermission(
+      { app, store, rateCounter: createRuntimeRateCounter() },
+      "  app:reload  ",
+    );
+    expect(result.outcome).toBe("allow");
+  });
+
+  test("needs-modal path performs NO write in Phase A", async () => {
+    const { store, saves } = makeStore({
+      commandPermissions: { enabled: true, allowlist: [] },
+    });
+    const { factory, opened } = stubModal("deny");
+    await checkCommandPermission(
+      {
+        app,
+        store,
+        rateCounter: createRuntimeRateCounter(),
+        modalFactory: factory,
+      },
+      "app:reload",
+    );
+    expect(opened()).toBe(true);
+    // Phase A wrote nothing (NO_CHANGE); only Phase B persists the outcome.
+    expect(saves()).toBe(1);
+  });
+
+  test("modal allow-always appends the command to the allowlist", async () => {
+    const { store, snapshot } = makeStore({
+      commandPermissions: { enabled: true, allowlist: [] },
+    });
+    const { factory } = stubModal("allow-always");
+    const result = await checkCommandPermission(
+      {
+        app,
+        store,
+        rateCounter: createRuntimeRateCounter(),
+        modalFactory: factory,
+      },
+      "app:reload",
+    );
+    expect(result.outcome).toBe("allow");
+    expect(permsOf(snapshot()).allowlist).toEqual(["app:reload"]);
+  });
+
+  test("modal allow-once does not touch the allowlist", async () => {
+    const { store, snapshot } = makeStore({
+      commandPermissions: { enabled: true, allowlist: [] },
+    });
+    const { factory } = stubModal("allow-once");
+    const result = await checkCommandPermission(
+      {
+        app,
+        store,
+        rateCounter: createRuntimeRateCounter(),
+        modalFactory: factory,
+      },
+      "app:reload",
+    );
+    expect(result.outcome).toBe("allow");
+    expect(permsOf(snapshot()).allowlist).toEqual([]);
+  });
+
+  test("modal deny → deny with a reason", async () => {
+    const { store } = makeStore({
+      commandPermissions: { enabled: true, allowlist: [] },
+    });
+    const { factory } = stubModal("deny");
+    const result = await checkCommandPermission(
+      {
+        app,
+        store,
+        rateCounter: createRuntimeRateCounter(),
+        modalFactory: factory,
+      },
+      "app:reload",
+    );
+    expect(result.outcome).toBe("deny");
+    expect(result.reason).toMatch(/confirmation modal/);
+  });
+
+  test("modal timeout → deny with timeout reason", async () => {
+    const { store } = makeStore({
+      commandPermissions: { enabled: true, allowlist: [] },
+    });
+    const { factory } = stubModal("never");
+    const result = await checkCommandPermission(
+      {
+        app,
+        store,
+        rateCounter: createRuntimeRateCounter(),
+        modalFactory: factory,
+        timeoutMs: 20,
+      },
+      "app:reload",
+    );
+    expect(result.outcome).toBe("deny");
+    expect(result.reason).toMatch(/did not respond/);
+  });
+});

--- a/packages/obsidian-plugin/src/features/command-permissions/services/checkCommandPermission.ts
+++ b/packages/obsidian-plugin/src/features/command-permissions/services/checkCommandPermission.ts
@@ -1,0 +1,218 @@
+/**
+ * In-process command-permission check for the `execute_obsidian_command`
+ * MCP tool. Extracted from the plugin class so the two-phase decision
+ * logic is testable without a live Obsidian app.
+ *
+ * Two-phase mutex policy: Phase A (decide + fast-path audit write) and
+ * Phase B (persist the final outcome) each run as one atomic slice
+ * update through `SettingsStore.updateSlice`; the modal wait happens
+ * BETWEEN them, outside any lock, so the fast path stays fast and
+ * concurrent modals coexist.
+ */
+
+import type { App } from "obsidian";
+import type { SettingsStore } from "$/shared/settingsStore";
+import {
+  appendAuditEntry,
+  createRuntimeRateCounter,
+  decidePermission,
+  isDestructiveCommand,
+  SOFT_RATE_LIMIT_PER_MINUTE,
+  type RuntimeRateCounter,
+} from "../utils";
+import type { CommandAuditEntry } from "../types";
+import {
+  CommandPermissionModal,
+  type CommandPermissionModalOptions,
+  type ModalDecision,
+} from "./commandPermissionModal";
+
+const SLICE = "commandPermissions";
+const DEFAULT_MODAL_TIMEOUT_MS = 30_000;
+
+/** Local view of the `commandPermissions` data.json slice. */
+type CommandPermissionsSlice = {
+  enabled?: boolean;
+  allowlist?: string[];
+  recentInvocations?: CommandAuditEntry[];
+  softRateLimit?: number;
+};
+
+/** Minimal modal surface the permission check needs. */
+export interface PermissionModalLike {
+  open(): void;
+  close(): void;
+  waitForDecision(): Promise<ModalDecision>;
+}
+
+export type PermissionModalFactory = (
+  app: App,
+  options: CommandPermissionModalOptions,
+) => PermissionModalLike;
+
+const defaultModalFactory: PermissionModalFactory = (app, options) =>
+  new CommandPermissionModal(app, options);
+
+/**
+ * Process-wide soft-rate counter for the in-process check path (UI
+ * warning only; the hard limiter lives in services/rateLimit.ts).
+ * Module-level so the count persists across calls.
+ */
+const inProcessRateCounter = createRuntimeRateCounter();
+
+export type CheckCommandPermissionDeps = {
+  app: App;
+  store: SettingsStore;
+  /** Defaults to the module-level process-wide counter. */
+  rateCounter?: RuntimeRateCounter;
+  /** Defaults to the real CommandPermissionModal. */
+  modalFactory?: PermissionModalFactory;
+  /** Defaults to 30s. */
+  timeoutMs?: number;
+};
+
+export async function checkCommandPermission(
+  deps: CheckCommandPermissionDeps,
+  rawCommandId: string,
+): Promise<{ outcome: "allow" | "deny"; reason?: string }> {
+  const rateCounter = deps.rateCounter ?? inProcessRateCounter;
+  const modalFactory = deps.modalFactory ?? defaultModalFactory;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_MODAL_TIMEOUT_MS;
+
+  // Allowlist entries are exact ids; a stray leading/trailing space in
+  // the request must not cause a spurious deny. Trim only — ids are
+  // case-sensitive by Obsidian convention, so no lowercasing.
+  const commandId = rawCommandId.trim();
+
+  rateCounter.record();
+
+  type PhaseAResult =
+    | { kind: "done"; outcome: "allow" | "deny"; reason?: string }
+    | { kind: "needs-modal"; softRateLimit: number };
+
+  let phaseA!: PhaseAResult;
+  await deps.store.updateSlice(SLICE, (current): CommandPermissionsSlice => {
+    const perms = (current as CommandPermissionsSlice | undefined) ?? {};
+    const pureOutcome = decidePermission(
+      commandId,
+      perms.enabled,
+      perms.allowlist,
+    );
+    const inAllowlist = (perms.allowlist ?? []).includes(commandId);
+    const needsModal =
+      perms.enabled === true && pureOutcome.decision === "deny" && !inAllowlist;
+
+    if (needsModal) {
+      phaseA = {
+        kind: "needs-modal",
+        softRateLimit: perms.softRateLimit ?? SOFT_RATE_LIMIT_PER_MINUTE,
+      };
+      return perms; // NO_CHANGE: no write on the modal path
+    }
+
+    // Fast path: write the audit entry and return the decision.
+    const auditEntry: CommandAuditEntry = {
+      timestamp: new Date().toISOString(),
+      commandId,
+      decision: pureOutcome.decision,
+      ...(pureOutcome.reason ? { reason: pureOutcome.reason } : {}),
+    };
+    phaseA = {
+      kind: "done",
+      outcome: pureOutcome.decision,
+      reason: pureOutcome.reason,
+    };
+    return {
+      ...perms,
+      recentInvocations: appendAuditEntry(perms.recentInvocations, auditEntry),
+    };
+  });
+
+  if (phaseA.kind === "done") {
+    return { outcome: phaseA.outcome, reason: phaseA.reason };
+  }
+
+  // Slow path: open the confirmation modal.
+  const commandName = (
+    deps.app as unknown as {
+      commands?: {
+        commands?: Record<string, { id: string; name: string }>;
+      };
+    }
+  ).commands?.commands?.[commandId]?.name;
+
+  const isDestructive = isDestructiveCommand(commandId, commandName);
+  const rateCount = rateCounter.countInLastMinute();
+  const showRateWarning = rateCount > phaseA.softRateLimit;
+
+  const modal = modalFactory(deps.app, {
+    commandId,
+    commandName,
+    isDestructive,
+    showRateWarning,
+    rateCount,
+  });
+  modal.open();
+
+  let timeoutHandle: number | undefined;
+  type ModalOutcome =
+    | { kind: "decided"; decision: ModalDecision }
+    | { kind: "timeout" };
+
+  const outcome = await Promise.race<ModalOutcome>([
+    modal
+      .waitForDecision()
+      .then((d) => ({ kind: "decided" as const, decision: d })),
+    new Promise<ModalOutcome>((resolve) => {
+      timeoutHandle = window.setTimeout(
+        () => resolve({ kind: "timeout" }),
+        timeoutMs,
+      );
+    }),
+  ]);
+
+  if (timeoutHandle) window.clearTimeout(timeoutHandle);
+  if (outcome.kind === "timeout") modal.close();
+
+  let finalOutcome: "allow" | "deny";
+  let finalReason: string | undefined;
+  let persistAllowlistEntry = false;
+
+  if (outcome.kind === "timeout") {
+    finalOutcome = "deny";
+    finalReason = `User did not respond within ${timeoutMs / 1000} seconds.`;
+  } else {
+    const d = outcome.decision;
+    if (d === "deny") {
+      finalOutcome = "deny";
+      finalReason = `User denied permission for command '${commandId}' via the confirmation modal.`;
+    } else {
+      finalOutcome = "allow";
+      if (d === "allow-always") persistAllowlistEntry = true;
+    }
+  }
+
+  // Phase B: persist the final outcome.
+  await deps.store.updateSlice(SLICE, (current): CommandPermissionsSlice => {
+    const perms = (current as CommandPermissionsSlice | undefined) ?? {};
+    const auditEntry: CommandAuditEntry = {
+      timestamp: new Date().toISOString(),
+      commandId,
+      decision: finalOutcome,
+      ...(finalReason ? { reason: finalReason } : {}),
+    };
+    const updatedAllowlist =
+      persistAllowlistEntry && !(perms.allowlist ?? []).includes(commandId)
+        ? [...(perms.allowlist ?? []), commandId]
+        : undefined;
+    return {
+      ...perms,
+      ...(updatedAllowlist !== undefined
+        ? { allowlist: updatedAllowlist }
+        : {}),
+      recentInvocations: appendAuditEntry(perms.recentInvocations, auditEntry),
+    };
+  });
+
+  return { outcome: finalOutcome, reason: finalReason };
+}

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -1,16 +1,9 @@
 import { type EventRef, Notice, Plugin, TFile } from "obsidian";
 import { lastValueFrom } from "rxjs";
 import { type SmartConnections } from "shared";
-import {
-  CommandPermissionModal,
-  globalSettingsMutex,
-  decidePermission,
-  appendAuditEntry,
-  createRuntimeRateCounter,
-  isDestructiveCommand,
-  SOFT_RATE_LIMIT_PER_MINUTE,
-} from "./features/command-permissions";
-import type { CommandAuditEntry } from "./features/command-permissions";
+import { globalSettingsMutex } from "./features/command-permissions";
+import { checkCommandPermission as runCommandPermissionCheck } from "./features/command-permissions/services/checkCommandPermission";
+import { SettingsStore } from "./shared/settingsStore";
 import { setup as setupCore } from "./features/core";
 import {
   setup as mcpTransportSetup,
@@ -61,13 +54,6 @@ import { loadSmartSearchAPI } from "./shared";
 import { logger } from "./shared/logger";
 import { createExclusionFilter } from "./shared/isUserIgnored";
 
-// Soft-rate counter for the in-process permission-check path. The
-// settings load/modify/save cycle is serialized through the shared
-// `globalSettingsMutex` (process-wide, see settingsLock.ts), not a
-// path-local mutex — data.json is shared across features.
-const _inProcessRateCounter = createRuntimeRateCounter();
-const IN_PROCESS_MODAL_TIMEOUT_MS = 30_000;
-
 export default class McpToolsPlugin extends Plugin {
   mcpTransportState?: McpTransportState;
 
@@ -87,190 +73,18 @@ export default class McpToolsPlugin extends Plugin {
   smartSearch?: SmartConnections.SmartSearch;
 
   /**
-   * In-process permission check for the `execute_obsidian_command`
-   * MCP tool. Two-phase mutex policy: Phase A (load + decide /
-   * detect-modal-needed + fast-path save) under the shared settings
-   * lock, modal wait OUTSIDE the lock, Phase B (re-load + persist
-   * final outcome) re-acquires it. Returns a plain
-   * `{ outcome, reason }`.
-   *
-   * Fast path: if the master toggle is off, or the command is already
-   * in the allowlist (allow) or not (deny), the decision is made under
-   * the settings mutex and returned immediately.
-   *
-   * Slow path: if the master toggle is on and the command is not in the
-   * allowlist, a modal is opened in the Obsidian UI. The method awaits
-   * the user's decision (or a 30-second timeout). Phase B then persists
-   * the outcome under the mutex.
-   *
-   * The runtime soft-rate-limit counter is updated on every call so the
-   * modal can display a warning banner when activity is high.
+   * In-process permission check for `execute_obsidian_command`,
+   * delegated to the testable service. The two-phase decision (Phase A
+   * decide + fast-path audit, modal wait, Phase B persist) lives in
+   * services/checkCommandPermission.ts.
    */
   async checkCommandPermission(
     rawCommandId: string,
   ): Promise<{ outcome: "allow" | "deny"; reason?: string }> {
-    // Allowlist entries are exact ids; a stray leading/trailing space
-    // in the request must not cause a spurious deny. Trim only — ids
-    // are case-sensitive by Obsidian convention, so no lowercasing.
-    const commandId = rawCommandId.trim();
-
-    // Record this call in the soft-rate counter (UI warning only —
-    // hard enforcement is the rate limiter in services/rateLimit.ts).
-    _inProcessRateCounter.record();
-
-    // Phase A: decide under the settings mutex.
-    type PhaseAResult =
-      | { kind: "done"; outcome: "allow" | "deny"; reason?: string }
-      | { kind: "needs-modal"; softRateLimit: number };
-
-    const phaseA: PhaseAResult = await globalSettingsMutex.run(async () => {
-      const settings = (await this.loadData()) ?? {};
-      const perms = settings.commandPermissions ?? {};
-
-      const pureOutcome = decidePermission(
-        commandId,
-        perms.enabled,
-        perms.allowlist,
-      );
-
-      const inAllowlist = (perms.allowlist ?? []).includes(commandId);
-      const needsModal =
-        perms.enabled === true &&
-        pureOutcome.decision === "deny" &&
-        !inAllowlist;
-
-      if (needsModal) {
-        return {
-          kind: "needs-modal",
-          softRateLimit: perms.softRateLimit ?? SOFT_RATE_LIMIT_PER_MINUTE,
-        };
-      }
-
-      // Fast path: write audit entry and return.
-      const auditEntry: CommandAuditEntry = {
-        timestamp: new Date().toISOString(),
-        commandId,
-        decision: pureOutcome.decision,
-        ...(pureOutcome.reason ? { reason: pureOutcome.reason } : {}),
-      };
-      settings.commandPermissions = {
-        ...perms,
-        recentInvocations: appendAuditEntry(
-          perms.recentInvocations,
-          auditEntry,
-        ),
-      };
-      await this.saveData(settings);
-
-      return {
-        kind: "done",
-        outcome: pureOutcome.decision,
-        reason: pureOutcome.reason,
-      };
-    });
-
-    if (phaseA.kind === "done") {
-      return { outcome: phaseA.outcome, reason: phaseA.reason };
-    }
-
-    // Slow path: open the confirmation modal.
-    const commandName = (
-      this.app as unknown as {
-        commands?: {
-          commands?: Record<string, { id: string; name: string }>;
-        };
-      }
-    ).commands?.commands?.[commandId]?.name;
-
-    const isDestructive = isDestructiveCommand(commandId, commandName);
-    const rateCount = _inProcessRateCounter.countInLastMinute();
-    const showRateWarning = rateCount > phaseA.softRateLimit;
-
-    const modal = new CommandPermissionModal(this.app, {
-      commandId,
-      commandName,
-      isDestructive,
-      showRateWarning,
-      rateCount,
-    });
-    modal.open();
-
-    // Race the modal decision against the timeout.
-    let timeoutHandle: number | undefined;
-    type ModalOutcome =
-      | {
-          kind: "decided";
-          decision: import("./features/command-permissions").ModalDecision;
-        }
-      | { kind: "timeout" };
-
-    const outcome = await Promise.race<ModalOutcome>([
-      modal
-        .waitForDecision()
-        .then((d) => ({ kind: "decided" as const, decision: d })),
-      new Promise<ModalOutcome>((resolve) => {
-        timeoutHandle = window.setTimeout(
-          () => resolve({ kind: "timeout" }),
-          IN_PROCESS_MODAL_TIMEOUT_MS,
-        );
-      }),
-    ]);
-
-    if (timeoutHandle) window.clearTimeout(timeoutHandle);
-    if (outcome.kind === "timeout") modal.close();
-
-    let finalOutcome: "allow" | "deny";
-    let finalReason: string | undefined;
-    let persistAllowlistEntry = false;
-
-    if (outcome.kind === "timeout") {
-      finalOutcome = "deny";
-      finalReason = `User did not respond within ${IN_PROCESS_MODAL_TIMEOUT_MS / 1000} seconds.`;
-    } else {
-      const d = outcome.decision;
-      if (d === "deny") {
-        finalOutcome = "deny";
-        finalReason = `User denied permission for command '${commandId}' via the confirmation modal.`;
-      } else {
-        finalOutcome = "allow";
-        if (d === "allow-always") persistAllowlistEntry = true;
-      }
-    }
-
-    // Phase B: persist outcome under the mutex.
-    await globalSettingsMutex.run(async () => {
-      const settings = (await this.loadData()) ?? {};
-      const perms = settings.commandPermissions ?? {};
-
-      const auditEntry: CommandAuditEntry = {
-        timestamp: new Date().toISOString(),
-        commandId,
-        decision: finalOutcome,
-        ...(finalReason ? { reason: finalReason } : {}),
-      };
-
-      let updatedAllowlist: string[] | undefined;
-      if (
-        persistAllowlistEntry &&
-        !(perms.allowlist ?? []).includes(commandId)
-      ) {
-        updatedAllowlist = [...(perms.allowlist ?? []), commandId];
-      }
-
-      settings.commandPermissions = {
-        ...perms,
-        ...(updatedAllowlist !== undefined
-          ? { allowlist: updatedAllowlist }
-          : {}),
-        recentInvocations: appendAuditEntry(
-          perms.recentInvocations,
-          auditEntry,
-        ),
-      };
-      await this.saveData(settings);
-    });
-
-    return { outcome: finalOutcome, reason: finalReason };
+    return runCommandPermissionCheck(
+      { app: this.app, store: new SettingsStore(this) },
+      rawCommandId,
+    );
   }
 
   async onload() {


### PR DESCRIPTION
PR 1 of 3 of cycle 2 (split main.ts + composition root). Behavior-preserving.

**Why**

`checkCommandPermission` was a 165-line method on the plugin class with no test coverage, one of the riskiest untested runtime paths (it gates `execute_obsidian_command`).

**Changes**

- Extracted to `command-permissions/services/checkCommandPermission.ts` as a function taking `{ app, store, rateCounter?, modalFactory?, timeoutMs? }`. The rate counter and modal factory are injectable (defaults: the module-level counter and the real `CommandPermissionModal`), which makes the modal and timeout paths testable.
- The two phases now run as `SettingsStore.updateSlice` calls. Phase A returns the current slice by reference on the needs-modal path, so no write happens there (matching the old behavior); the fast path and Phase B write.
- `main.ts` keeps the `checkCommandPermission` method (called by `executeObsidianCommand` via `ctx.plugin`) as a thin delegate. main.ts drops from 786 to 605 lines.

**Verification**

- `bun test`: 1180 pass / 0 fail (8 new tests: fast-path allow/deny with audit, no-write on the needs-modal Phase A, allow-always allowlist append, allow-once no append, modal deny, timeout deny)
- `tsc --noEmit` clean, `format:check` clean, `bun run build` succeeds
- The `executeObsidianCommand` tests (which mock the method) pass unchanged.