### PR TITLE
refactor(mcp-transport): move registry composition out of transport

### DIFF
--- a/packages/obsidian-plugin/src/composeToolRegistry.ts
+++ b/packages/obsidian-plugin/src/composeToolRegistry.ts
@@ -1,0 +1,85 @@
+/**
+ * Composition root for the tool registry.
+ *
+ * Building the populated registry orchestrates four features (mcp-tools,
+ * tool-toggle, adaptive-tool-loading, plus the prompt registry), which
+ * is policy, not transport. Keeping it here rather than inside
+ * mcp-transport leaves the HTTP layer free of feature wiring: it just
+ * consumes the registries this returns.
+ */
+
+import { Notice, type App } from "obsidian";
+import type McpToolsPlugin from "$/main";
+import {
+  ToolRegistryClass,
+  type ToolRegistry,
+} from "$/features/mcp-transport/services/toolRegistry";
+import {
+  PromptRegistryClass,
+  type PromptRegistry,
+} from "$/features/mcp-transport/services/promptRegistry";
+import { registerTools } from "$/features/mcp-tools";
+import { applyDisabledToolsFilter } from "$/features/tool-toggle";
+import { applyAdaptiveFilter } from "$/features/adaptive-tool-loading";
+import {
+  toolCatalogSchema,
+  toolCatalogHandler,
+} from "$/features/mcp-tools/tools/toolCatalog";
+import {
+  activateToolSchema,
+  activateToolHandler,
+} from "$/features/mcp-tools/tools/activateTool";
+
+export type ToolRegistryConfig = {
+  app: App;
+  plugin: McpToolsPlugin;
+  pluginVersion: string;
+};
+
+/**
+ * Build the populated tool + prompt registries: register every vault
+ * tool, add the always-active adaptive meta-tools, then apply the
+ * adaptive-profile filter and the user's disabled-tools filter (in that
+ * order, so the disable list wins).
+ */
+export async function composeToolRegistry(
+  config: ToolRegistryConfig,
+): Promise<{ toolRegistry: ToolRegistry; promptRegistry: PromptRegistry }> {
+  const toolRegistry = new ToolRegistryClass();
+  const promptRegistry = new PromptRegistryClass();
+
+  await registerTools(toolRegistry, {
+    app: config.app,
+    plugin: config.plugin,
+    pluginVersion: config.pluginVersion,
+  });
+
+  // Adaptive-loading meta-tools need the registry itself (for
+  // listing/status) and are always active regardless of profile, so
+  // they are registered here rather than in registerTools.
+  toolRegistry.register(toolCatalogSchema, () =>
+    toolCatalogHandler({ registry: toolRegistry, plugin: config.plugin }),
+  );
+  toolRegistry.register(activateToolSchema, async (request, { server }) =>
+    activateToolHandler({
+      arguments: (request as { arguments: { name: string; persist?: boolean } })
+        .arguments,
+      registry: toolRegistry,
+      plugin: config.plugin,
+      server,
+      onActivated: (name) =>
+        new Notice(`MCP Connector: "${name}" promoted to active`),
+      enableInRegistry: (name) => toolRegistry.enableByName(name),
+    }),
+  );
+
+  // Adaptive profile filter (All/Core/Adaptive) runs before toolToggle
+  // so the user-controlled disable list still wins.
+  await applyAdaptiveFilter(toolRegistry, config.plugin);
+  // Disabled tools stay registered but are flipped off the enabled set,
+  // so they no longer appear in tools/list and tools/call returns
+  // MethodNotFound. Idempotent.
+  await applyDisabledToolsFilter(toolRegistry, config.plugin);
+
+  return { toolRegistry, promptRegistry };
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -7,28 +7,16 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { Notice, type App } from "obsidian";
+import { type App } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import { logger } from "$/shared";
-import { ToolRegistryClass } from "./toolRegistry";
 import type { ToolRegistry } from "./toolRegistry";
-import { PromptRegistryClass } from "./promptRegistry";
 import type { PromptRegistry } from "./promptRegistry";
-import { registerTools } from "$/features/mcp-tools";
-import { applyDisabledToolsFilter } from "$/features/tool-toggle";
 import {
-  applyAdaptiveFilter,
   ToolLoadingManager,
   META_TOOLS,
 } from "$/features/adaptive-tool-loading";
-import {
-  toolCatalogSchema,
-  toolCatalogHandler,
-} from "$/features/mcp-tools/tools/toolCatalog";
-import {
-  activateToolSchema,
-  activateToolHandler,
-} from "$/features/mcp-tools/tools/activateTool";
+import { composeToolRegistry } from "$/composeToolRegistry";
 
 export type McpServiceConfig = {
   app: App;
@@ -68,42 +56,10 @@ export async function createMcpService(
   config: McpServiceConfig,
 ): Promise<McpService> {
   const toolLoadingManager = new ToolLoadingManager();
-  const registry = new ToolRegistryClass();
-  const promptRegistry = new PromptRegistryClass();
-  await registerTools(registry, {
-    app: config.app,
-    plugin: config.plugin,
-    pluginVersion: config.pluginVersion,
-  });
-
-  // Register adaptive-loading meta-tools. These need access to the
-  // registry itself (for listing/status) and are always active regardless
-  // of profile, so they are registered here rather than in registerTools.
-  registry.register(toolCatalogSchema, () =>
-    toolCatalogHandler({ registry, plugin: config.plugin }),
-  );
-  registry.register(activateToolSchema, async (request, { server }) =>
-    activateToolHandler({
-      arguments: (request as { arguments: { name: string; persist?: boolean } })
-        .arguments,
-      registry,
-      plugin: config.plugin,
-      server,
-      onActivated: (name) =>
-        new Notice(`MCP Connector: "${name}" promoted to active`),
-      enableInRegistry: (name) => registry.enableByName(name),
-    }),
-  );
-
-  // Apply the adaptive profile filter (All/Core/Adaptive).
-  // Runs before toolToggle so the user-controlled disable list still wins.
-  await applyAdaptiveFilter(registry, config.plugin);
-
-  // Apply the user's `toolToggle.disabled` filter.
-  // Disabled tools stay registered but are flipped off the registry's
-  // enabled set, so they no longer appear in `tools/list` and any
-  // `tools/call` against them returns MethodNotFound. Idempotent.
-  await applyDisabledToolsFilter(registry, config.plugin);
+  // The populated registry is composed outside the transport (policy
+  // lives in $/composeToolRegistry); this layer only serves it.
+  const { toolRegistry: registry, promptRegistry } =
+    await composeToolRegistry(config);
 
   const handleRequest = async (
     req: IncomingMessage,

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/setup.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/setup.ts
@@ -1,5 +1,5 @@
 import type McpToolsPlugin from "$/main";
-import { globalSettingsMutex } from "$/features/command-permissions";
+import { SettingsStore } from "$/shared/settingsStore";
 import { logger } from "$/shared";
 import {
   startHttpServer,
@@ -41,32 +41,24 @@ export type SetupResult =
  */
 export async function setup(plugin: McpToolsPlugin): Promise<SetupResult> {
   try {
-    // Serialize the load→(maybe generate)→save through the shared
-    // mutex so a first-run token write cannot clobber a concurrent
-    // settings write from another feature (data.json is not atomic).
-    const bearerToken = await globalSettingsMutex.run(async () => {
-      const settings = ((await plugin.loadData()) ?? {}) as Record<
-        string,
-        unknown
-      >;
-      const mcpTransportSettings = (settings.mcpTransport ?? {}) as Record<
-        string,
-        unknown
-      >;
-      let token = mcpTransportSettings.bearerToken as string | undefined;
+    // SettingsStore.updateSlice serializes the load→(maybe
+    // generate)→save through the shared mutex; returning the slice
+    // unchanged when a valid token exists skips the write.
+    let bearerToken!: string;
+    await new SettingsStore(plugin).updateSlice("mcpTransport", (current) => {
+      const slice = (current as Record<string, unknown> | undefined) ?? {};
+      const token = slice.bearerToken as string | undefined;
 
       // Byte length, not UTF-16 code units: the 32-byte floor is a
       // security threshold and must hold regardless of encoding.
       if (!token || Buffer.byteLength(token, "utf8") < 32) {
         // No valid token yet — generate a fresh one and persist it.
         // This only happens on the very first load after plugin install.
-        token = generateToken();
-        await plugin.saveData({
-          ...settings,
-          mcpTransport: { ...mcpTransportSettings, bearerToken: token },
-        });
+        bearerToken = generateToken();
+        return { ...slice, bearerToken };
       }
-      return token;
+      bearerToken = token;
+      return current; // NO_CHANGE: keep the existing valid token
     });
 
     const mcp = await createMcpService({


### PR DESCRIPTION
PR 3 of 3 of cycle 2 (split main.ts + composition root). Closes the cycle. Behavior-preserving.

**Changes**

- Building the populated registry orchestrates four features (mcp-tools, tool-toggle, adaptive-tool-loading, and the prompt registry), which is policy, not transport. Moved it to a top-level `composeToolRegistry` module. `createMcpService` now calls it and serves the result, so the HTTP layer carries no feature wiring (only the SDK, the per-request server, the dispatch handler, and the frequency counter remain).
- Migrated the first-run bearer-token write in `setup.ts` to `SettingsStore.updateSlice`: it returns the slice unchanged when a valid token already exists, so a reload does no write (the last meaningful `.ts` raw `saveData` is now gone).
- The `mcp-tools` to `mcp-transport` `ToolRegistry` type import stays (type-only, no runtime cycle); moving the registry class would be churn for no functional gain.

**Verification**

- `bun test`: 1184 pass / 0 fail (the 45-tool registry regression and annotations-completeness tests pass unchanged, since `createMcpService` still composes the same registry)
- `tsc --noEmit` clean, `format:check` clean, `bun run build` succeeds

**Cycle 2 recap**: `main.ts` went from 786 to 141 lines; `checkCommandPermission` and the semantic-search wiring (including the silent stale-store wipe) are now extracted and unit-tested; the transport is policy-free. Deferred with rationale: the four Svelte settings writers (already mutex-safe, weak build-only verification) and an eslint ratchet (eslint is not in CI and has no Svelte parser).