### PR TITLE
refactor(mcp-tools): centralize TFile resolution via resolveTFile

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/resolveTFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/resolveTFile.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { resolveTFile } from "./resolveTFile";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockFolder,
+} from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+describe("resolveTFile", () => {
+  test("resolves an existing file to ok + the TFile", () => {
+    setMockFile("Notes/a.md", "hello");
+    const result = resolveTFile(mockApp().vault, "Notes/a.md");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.file.path).toBe("Notes/a.md");
+    }
+  });
+
+  test("reports not_found for a missing path", () => {
+    const result = resolveTFile(mockApp().vault, "Notes/missing.md");
+    expect(result).toEqual({ ok: false, reason: "not_found" });
+  });
+
+  test("reports not_a_file when the path is a folder", () => {
+    setMockFolder("Notes");
+    const result = resolveTFile(mockApp().vault, "Notes");
+    expect(result).toEqual({ ok: false, reason: "not_a_file" });
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/resolveTFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/resolveTFile.ts
@@ -1,0 +1,25 @@
+import { TFile, type Vault } from "obsidian";
+
+/**
+ * Outcome of resolving a vault-relative path. A failure carries only a
+ * `reason` discriminator — never a response envelope — so each caller keeps
+ * ownership of its own error wire shape (plain text vs JSON `errorCode`).
+ */
+export type ResolveTFileResult =
+  | { ok: true; file: TFile }
+  | { ok: false; reason: "not_found" | "not_a_file" };
+
+/**
+ * Resolve a vault-relative path to an existing TFile.
+ *
+ * Centralizes the `getAbstractFileByPath` → exists → `instanceof TFile` guard
+ * that was copy-pasted across ~19 tool handlers. Returns a discriminated reason
+ * instead of a formatted error so the call site can emit its existing message
+ * unchanged — the resolution logic is shared, the wire format is not.
+ */
+export function resolveTFile(vault: Vault, path: string): ResolveTFileResult {
+  const abstract = vault.getAbstractFileByPath(path);
+  if (!abstract) return { ok: false, reason: "not_found" };
+  if (!(abstract instanceof TFile)) return { ok: false, reason: "not_a_file" };
+  return { ok: true, file: abstract };
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/appendToVaultFile.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 import { errorText, successText } from "../services/responseBuilders";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 import { normalizeAppendBody } from "$/features/mcp-tools/services/patchHelpers";
 import { ensureParentFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
 
@@ -28,14 +29,13 @@ export async function appendToVaultFileHandler(
   isError?: boolean;
 }> {
   const normalized = normalizeAppendBody(ctx.arguments.content, "append");
-  const existing = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
+  const resolved = resolveTFile(ctx.app.vault, ctx.arguments.path);
 
-  if (existing) {
-    if (!(existing instanceof TFile)) {
-      return errorText(`Path ${ctx.arguments.path} is a folder, not a file.`);
-    }
-    const current = await ctx.app.vault.read(existing);
-    await ctx.app.vault.modify(existing, current + normalized);
+  if (resolved.ok) {
+    const current = await ctx.app.vault.read(resolved.file);
+    await ctx.app.vault.modify(resolved.file, current + normalized);
+  } else if (resolved.reason === "not_a_file") {
+    return errorText(`Path ${ctx.arguments.path} is a folder, not a file.`);
   } else {
     await ensureParentFolderExists(ctx.app, ctx.arguments.path);
     await ctx.app.vault.create(ctx.arguments.path, normalized);

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteNoteProperty.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/deleteNoteProperty.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 import { successJson } from "../services/responseBuilders";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 
 export const deleteNotePropertySchema = type({
   name: '"delete_note_property"',
@@ -26,38 +27,30 @@ export async function deleteNotePropertyHandler(
   isError?: boolean;
 }> {
   const { path, key } = ctx.arguments;
-  const abstract = ctx.app.vault.getAbstractFileByPath(path);
-  if (!abstract) {
+  const resolved = resolveTFile(ctx.app.vault, path);
+  if (!resolved.ok) {
     return {
       content: [
         {
           type: "text",
-          text: JSON.stringify({
-            error: "File not found",
-            errorCode: "file_not_found",
-            path,
-          }),
+          text:
+            resolved.reason === "not_found"
+              ? JSON.stringify({
+                  error: "File not found",
+                  errorCode: "file_not_found",
+                  path,
+                })
+              : JSON.stringify({
+                  error: "Path is a folder, not a file",
+                  errorCode: "not_a_file",
+                  path,
+                }),
         },
       ],
       isError: true,
     };
   }
-  if (!(abstract instanceof TFile)) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            error: "Path is a folder, not a file",
-            errorCode: "not_a_file",
-            path,
-          }),
-        },
-      ],
-      isError: true,
-    };
-  }
-  const file = abstract;
+  const file = resolved.file;
 
   await ctx.app.fileManager.processFrontMatter(file, (rawFm) => {
     const fm = rawFm as Record<string, unknown>;

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/executeTemplate.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 import { errorText } from "../services/responseBuilders";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 import { moment } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import { Templater, type PromptArgAccessor } from "shared";
@@ -96,23 +97,21 @@ export async function executeTemplateHandler(
   }
 
   // Resolve template file from vault
-  const templateFile = ctx.app.vault.getAbstractFileByPath(
-    ctx.arguments.templatePath,
-  );
-  if (!templateFile) {
-    return errorPayload(
-      `Template not found: ${ctx.arguments.templatePath}`,
-      "template_not_found",
-      { templatePath: ctx.arguments.templatePath },
-    );
+  const resolved = resolveTFile(ctx.app.vault, ctx.arguments.templatePath);
+  if (!resolved.ok) {
+    return resolved.reason === "not_found"
+      ? errorPayload(
+          `Template not found: ${ctx.arguments.templatePath}`,
+          "template_not_found",
+          { templatePath: ctx.arguments.templatePath },
+        )
+      : errorPayload(
+          `Template path is a folder: ${ctx.arguments.templatePath}`,
+          "template_not_found",
+          { templatePath: ctx.arguments.templatePath },
+        );
   }
-  if (!(templateFile instanceof TFile)) {
-    return errorPayload(
-      `Template path is a folder: ${ctx.arguments.templatePath}`,
-      "template_not_found",
-      { templatePath: ctx.arguments.templatePath },
-    );
-  }
+  const templateFile = resolved.file;
 
   // createFile coercion — belt-and-suspenders: accept both boolean string "true" and missing
   const createFile = ctx.arguments.createFile === "true";
@@ -229,21 +228,21 @@ async function runCoreTemplates(
     arguments: argMap,
   } = ctx.arguments;
 
-  const templateFile = ctx.app.vault.getAbstractFileByPath(templatePath);
-  if (!templateFile) {
-    return errorPayload(
-      `Template not found: ${templatePath}`,
-      "template_not_found",
-      { templatePath },
-    );
+  const resolved = resolveTFile(ctx.app.vault, templatePath);
+  if (!resolved.ok) {
+    return resolved.reason === "not_found"
+      ? errorPayload(
+          `Template not found: ${templatePath}`,
+          "template_not_found",
+          { templatePath },
+        )
+      : errorPayload(
+          `Template path is a folder: ${templatePath}`,
+          "template_not_found",
+          { templatePath },
+        );
   }
-  if (!(templateFile instanceof TFile)) {
-    return errorPayload(
-      `Template path is a folder: ${templatePath}`,
-      "template_not_found",
-      { templatePath },
-    );
-  }
+  const templateFile = resolved.file;
 
   let raw: string;
   try {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getNoteOutline.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getNoteOutline.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 
 export const getNoteOutlineSchema = type({
   name: '"get_note_outline"',
@@ -30,37 +31,30 @@ export async function getNoteOutlineHandler(
   isError?: boolean;
 }> {
   const { path } = ctx.arguments;
-  const abstract = ctx.app.vault.getAbstractFileByPath(path);
-  if (!abstract) {
+  const resolved = resolveTFile(ctx.app.vault, path);
+  if (!resolved.ok) {
     return {
       content: [
         {
           type: "text",
-          text: JSON.stringify({
-            error: `File not found: ${path}`,
-            errorCode: "file_not_found",
-            path,
-          }),
+          text:
+            resolved.reason === "not_found"
+              ? JSON.stringify({
+                  error: `File not found: ${path}`,
+                  errorCode: "file_not_found",
+                  path,
+                })
+              : JSON.stringify({
+                  error: `Path is a folder: ${path}`,
+                  errorCode: "not_a_file",
+                  path,
+                }),
         },
       ],
       isError: true,
     };
   }
-  if (!(abstract instanceof TFile)) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            error: `Path is a folder: ${path}`,
-            errorCode: "not_a_file",
-            path,
-          }),
-        },
-      ],
-      isError: true,
-    };
-  }
+  const abstract = resolved.file;
 
   const cache = ctx.app.metadataCache.getFileCache(abstract);
   const raw = cache?.headings ?? [];

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getNoteProperty.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getNoteProperty.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 
 export const getNotePropertySchema = type({
   name: '"get_note_property"',
@@ -24,38 +25,30 @@ export async function getNotePropertyHandler(
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
 }> {
-  const abstract = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
-  if (!abstract) {
+  const resolved = resolveTFile(ctx.app.vault, ctx.arguments.path);
+  if (!resolved.ok) {
     return {
       content: [
         {
           type: "text",
-          text: JSON.stringify({
-            error: "File not found",
-            errorCode: "file_not_found",
-            path: ctx.arguments.path,
-          }),
+          text:
+            resolved.reason === "not_found"
+              ? JSON.stringify({
+                  error: "File not found",
+                  errorCode: "file_not_found",
+                  path: ctx.arguments.path,
+                })
+              : JSON.stringify({
+                  error: "Path is a folder, not a file",
+                  errorCode: "not_a_file",
+                  path: ctx.arguments.path,
+                }),
         },
       ],
       isError: true,
     };
   }
-  if (!(abstract instanceof TFile)) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            error: "Path is a folder, not a file",
-            errorCode: "not_a_file",
-            path: ctx.arguments.path,
-          }),
-        },
-      ],
-      isError: true,
-    };
-  }
-  const file = abstract;
+  const file = resolved.file;
   const fm = ctx.app.metadataCache.getFileCache(file)?.frontmatter as
     | Record<string, unknown>
     | undefined;

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getOutgoingLinks.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 import { errorText, successJson } from "../services/responseBuilders";
 
 export const getOutgoingLinksSchema = type({
@@ -51,14 +52,13 @@ export async function getOutgoingLinksHandler(
   isError?: boolean;
 }> {
   const sourcePath = ctx.arguments.path;
-  const abstract = ctx.app.vault.getAbstractFileByPath(sourcePath);
-  if (!abstract) {
-    return errorText(`File not found: ${sourcePath}`);
+  const resolved = resolveTFile(ctx.app.vault, sourcePath);
+  if (!resolved.ok) {
+    return resolved.reason === "not_found"
+      ? errorText(`File not found: ${sourcePath}`)
+      : errorText(`Path is a folder: ${sourcePath}`);
   }
-  if (!(abstract instanceof TFile)) {
-    return errorText(`Path is a folder: ${sourcePath}`);
-  }
-  const file = abstract;
+  const file = resolved.file;
 
   const cache = ctx.app.metadataCache.getFileCache(file) as {
     links?: RawLink[];

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 
 /**
  * Maps lowercased file extensions to their MIME type and MCP content-block
@@ -108,25 +109,23 @@ export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
   content: Array<ContentBlock>;
   isError?: boolean;
 }> {
-  const abstract = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
-  if (!abstract) {
+  const resolved = resolveTFile(ctx.app.vault, ctx.arguments.path);
+  if (!resolved.ok) {
     return {
       content: [
-        { type: "text", text: `File not found: ${ctx.arguments.path}` },
-      ],
-      isError: true,
-    };
-  }
-  if (!(abstract instanceof TFile)) {
-    return {
-      content: [
-        { type: "text", text: `Path is a folder: ${ctx.arguments.path}` },
+        {
+          type: "text",
+          text:
+            resolved.reason === "not_found"
+              ? `File not found: ${ctx.arguments.path}`
+              : `Path is a folder: ${ctx.arguments.path}`,
+        },
       ],
       isError: true,
     };
   }
 
-  const file = abstract;
+  const file = resolved.file;
   const ext = file.extension.toLowerCase();
 
   const mimeEntry = MIME_BY_EXT.get(ext);

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 // Response envelopes shared across tools — aliased to the original local
 // names to keep this file's call sites stable.
 import {
@@ -154,14 +155,13 @@ export async function getVaultFilePartialHandler(
 }> {
   const { filename, mode, target, targetDelimiter } = ctx.arguments;
 
-  const abstract = ctx.app.vault.getAbstractFileByPath(filename);
-  if (!abstract) {
-    return errorResponse(`File not found: ${filename}`);
+  const resolved = resolveTFile(ctx.app.vault, filename);
+  if (!resolved.ok) {
+    return resolved.reason === "not_found"
+      ? errorResponse(`File not found: ${filename}`)
+      : errorResponse(`Path is a folder: ${filename}`);
   }
-  if (!(abstract instanceof TFile)) {
-    return errorResponse(`Path is a folder: ${filename}`);
-  }
-  const file = abstract;
+  const file = resolved.file;
 
   // Schema-level guard: `target` is required for every mode except
   // `document-map`. We enforce this at the handler level (rather than via

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 import { errorText } from "../services/responseBuilders";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 import {
   applyPatch,
   type PatchArgs,
@@ -52,13 +53,13 @@ export async function patchVaultFileHandler(
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
 }> {
-  const file = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
-  if (!file) {
-    return errorText(`File not found: ${ctx.arguments.path}`);
+  const resolved = resolveTFile(ctx.app.vault, ctx.arguments.path);
+  if (!resolved.ok) {
+    return resolved.reason === "not_found"
+      ? errorText(`File not found: ${ctx.arguments.path}`)
+      : errorText(`Path is a folder: ${ctx.arguments.path}`);
   }
-  if (!(file instanceof TFile)) {
-    return errorText(`Path is a folder: ${ctx.arguments.path}`);
-  }
+  const file = resolved.file;
 
   // Strip `path` from the arguments before forwarding — applyPatch only needs
   // the patch-specific fields (operation, targetType, target, content, …).

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/renameHeading.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 import { errorText, successText } from "../services/responseBuilders";
 import { TFile, type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 
 import {
   planRename,
@@ -98,14 +99,14 @@ export async function renameHeadingHandler(ctx: RenameHeadingContext): Promise<{
   const { path, from, to } = ctx.arguments;
 
   // ── 1. Load source file ─────────────────────────────────────────────────
-  const sourceAbstract = ctx.app.vault.getAbstractFileByPath(path);
-  if (!(sourceAbstract instanceof TFile)) {
+  const resolved = resolveTFile(ctx.app.vault, path);
+  if (!resolved.ok) {
     return errorResponse({
       errorCode: "file-not-found",
       message: `Source file not found: ${path}`,
     });
   }
-  const sourceFile = sourceAbstract;
+  const sourceFile = resolved.file;
 
   const sourceText = await ctx.app.vault.cachedRead(sourceFile);
   const sourceCache = (ctx.app.metadataCache.getFileCache(sourceFile) ??

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/setNoteProperty.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype";
-import { TFile, type App } from "obsidian";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
 
 export const setNotePropertySchema = type({
   name: '"set_note_property"',
@@ -83,38 +84,30 @@ export async function setNotePropertyHandler(
     };
   }
 
-  const abstract = ctx.app.vault.getAbstractFileByPath(path);
-  if (!abstract) {
+  const resolved = resolveTFile(ctx.app.vault, path);
+  if (!resolved.ok) {
     return {
       content: [
         {
           type: "text",
-          text: JSON.stringify({
-            error: "File not found",
-            errorCode: "file_not_found",
-            path,
-          }),
+          text:
+            resolved.reason === "not_found"
+              ? JSON.stringify({
+                  error: "File not found",
+                  errorCode: "file_not_found",
+                  path,
+                })
+              : JSON.stringify({
+                  error: "Path is a folder, not a file",
+                  errorCode: "not_a_file",
+                  path,
+                }),
         },
       ],
       isError: true,
     };
   }
-  if (!(abstract instanceof TFile)) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            error: "Path is a folder, not a file",
-            errorCode: "not_a_file",
-            path,
-          }),
-        },
-      ],
-      isError: true,
-    };
-  }
-  const file = abstract;
+  const file = resolved.file;
 
   await ctx.app.fileManager.processFrontMatter(file, (rawFm) => {
     const fm = rawFm as Record<string, unknown>;


### PR DESCRIPTION
## What

Architecture cycle 3. Introduces a shared `resolveTFile` helper and adopts it across 11 tool handlers that previously hand-rolled the same `getAbstractFileByPath` → `!abstract` → `instanceof TFile` guard.

`services/resolveTFile.ts` returns a discriminated result:

```ts
resolveTFile(vault, path):
  | { ok: true; file: TFile }
  | { ok: false; reason: "not_found" | "not_a_file" }
```

The helper returns a `reason`, never a response envelope, so each call site maps it back to its own existing error wire shape (plain text, JSON `errorCode`, or local wrapper). The resolution logic is shared; the wire format is not.

## Scope decision: DRY only

The same not-found condition currently emits 4+ divergent wire shapes across tools. This PR centralizes the **resolution logic** without changing any tool's observable output. Unifying the wire contract is a breaking change for MCP consumers and is deferred to a separate RFC.

Adopted (11 files): `getVaultFile`, `getVaultFilePartial`, `getNoteProperty`, `setNoteProperty`, `deleteNoteProperty`, `getNoteOutline`, `getOutgoingLinks`, `patchVaultFile`, `renameHeading`, `appendToVaultFile`, `executeTemplate` (2 sites).

Deliberately not adopted (helper would change behavior): `deleteVaultFile` and `renameVaultFile` accept folders; `getBacklinks` does no path resolution; `getOrCreateDailyNote`/`getOrCreatePeriodicNote`/`appendToPeriodicNote` run a post-create sanity check rather than resolve-or-fail; the create/directory tools are out of scope.

## Behavior preservation

- `tsc --noEmit`: clean.
- Full suite: **1183 pass / 0 fail**, with **zero test files edited**. The 73 not-found assertions across 22 test files still pass verbatim, which is the proof that tool output is unchanged.
- New `services/resolveTFile.test.ts` covers the three outcomes (file → ok, missing → not_found, folder → not_a_file).

Net −27 lines across the 11 call sites.