### PR TITLE
feat(mcp-tools): add canvas read and write tools

### DIFF
--- a/docs/architecture/ADR-0008-canvas-tools.md
+++ b/docs/architecture/ADR-0008-canvas-tools.md
@@ -1,0 +1,214 @@
+# ADR-0008: Canvas Tools (v1)
+
+- **Status**: Accepted
+- **Date**: 2026-06-13
+- **Target release**: 0.18.0
+- **Scope**: 3 new MCP tools: `get_canvas`, `add_canvas_node`, `connect_canvas_nodes`. Tool count +3.
+
+---
+
+## Context
+
+`.canvas` files are JSON documents following the open JSON Canvas spec
+(`{ nodes: [], edges: [] }`). Today they are accessible only as raw text
+via `get_vault_file`. No tool exposes the graph structure or allows
+structured mutations (adding nodes and edges). An agent that wants to
+build or inspect a canvas must parse the raw JSON itself, generate valid
+ids, avoid coordinate collisions, and serialize back. That work belongs
+in the server.
+
+v1 adds the minimum useful read + write surface:
+
+- `get_canvas`: read a canvas as a structured graph.
+- `add_canvas_node`: append one `text`, `file`, or `link` node; creates
+  the canvas file if it does not exist.
+- `connect_canvas_nodes`: append one edge between two existing node ids.
+
+Group nodes, node update/delete, edge delete, and a dedicated
+`create_canvas` tool are deferred to v2 (the SPEC documents the exact
+out-of-scope list).
+
+Three design questions required explicit decisions before implementation:
+
+1. **Round-trip fidelity**: how are unknown/extra fields on existing nodes
+   and edges handled across a write cycle?
+2. **Auto-placement**: when `x`/`y` are omitted from `add_canvas_node`,
+   how is the new node positioned?
+3. **Service boundary**: where does canvas parse/serialize/id logic live?
+
+---
+
+## Decision
+
+### Architecture: service + three colocated tool pairs
+
+```
+packages/obsidian-plugin/src/features/mcp-tools/
+  services/
+    canvasDocument.ts        ← new service: parse, serialize, id-gen, placement
+    canvasDocument.test.ts   ← unit tests for service in isolation
+  tools/
+    getCanvas.ts             ← new tool
+    getCanvas.test.ts
+    addCanvasNode.ts         ← new tool
+    addCanvasNode.test.ts
+    connectCanvasNodes.ts    ← new tool
+    connectCanvasNodes.ts
+```
+
+One edit to `index.ts` (5 imports + 3 `registry.register` calls under a
+new `// Canvas` comment block). One edit to `toolAnnotations.ts` (3 new
+entries). No new external dependencies; the JSON Canvas spec is
+implemented directly against the vault JSON.
+
+### Decision 1 (round-trip fidelity): spread-preserve, never re-model
+
+**Decision:** parse with `JSON.parse`; treat the document as a plain
+object tree. When mutating (add node, add edge), spread the existing node
+array and append the new entry. Never re-serialize by reconstructing
+objects from modeled fields. Serialize back with `JSON.stringify(doc, null, 2)`
+(2-space indent, matching Obsidian's on-disk format).
+
+**Rationale:** re-modeling would silently drop any field not listed in the
+v1 schema: styling, custom extensions, future spec additions. A canvas
+hand-made in Obsidian must survive a tool write unchanged except for the
+appended node or edge. This is the same constraint the SPEC states
+explicitly ("modeled-only re-serialization is rejected").
+
+**Consequence:** the TypeScript type for a node is an intersection of the
+modeled fields and an index signature (`Record<string, unknown>`) so the
+spread is typed correctly without casting. The service never touches
+unknown fields; they ride through opaque.
+
+### Decision 2 (auto-placement): right-of-extent, row-wrap at 3200 px
+
+**Decision:** compute the bounding box of all existing nodes (max `x +
+width`). Place the new node immediately to the right with a fixed gap of
+32 px. When no nodes exist (empty canvas), place at `(0, 0)`. When the
+accumulated row width exceeds 3200 px, start a new row below the current
+tallest node (gap 32 px vertically). Vertical center-alignment to the
+tallest node in the current row is not attempted (v1 simplicity). Explicit
+`x`/`y` in the request bypass all placement logic.
+
+Per-type default sizes: `text` 400×200, `file` 400×300, `link` 400×200.
+These match Obsidian's default canvas node dimensions.
+
+**Rationale for row-wrap threshold:** Obsidian renders the canvas on a
+2D infinite plane; 3200 px covers ~8 default-width nodes per row before
+wrapping, which keeps a growing canvas scannable without manual reflow.
+The value is a named constant (`CANVAS_ROW_WRAP_WIDTH`) in the service so
+it can be adjusted without hunting through logic.
+
+**Alternative considered (grid):** place nodes in a fixed grid (n
+columns, auto-row). Rejected because the column count is arbitrary and
+produces awkward layouts when a canvas already has manually positioned
+nodes that don't align to the grid origin.
+
+### Decision 3 (service boundary): `canvasDocument.ts` owns all canvas logic
+
+**Decision:** a single new service `canvasDocument.ts` exposes five pure
+or near-pure functions:
+
+- `parseCanvas(raw: string): CanvasDocument | null`: parse and validate
+  top-level shape; returns `null` on malformed JSON or missing required
+  fields.
+- `generateNodeId(existing: string[]): string`: 16-char lowercase hex,
+  retry until unique.
+- `computePlacement(nodes: CanvasNode[], opts: PlacementOpts): Rect`:
+  auto-placement logic.
+- `buildEmptyCanvas(): CanvasDocument`: `{ nodes: [], edges: [] }`.
+- `serializeCanvas(doc: CanvasDocument): string`: `JSON.stringify` with
+  2-space indent.
+
+Tool handlers do: resolve file, read, call `parseCanvas`, mutate, call
+`serializeCanvas`, write. They do not contain any JSON or placement logic.
+This mirrors the `patchHelpers.ts` / `headingRename.ts` pattern.
+
+**Alternative considered (inline in handler):** put parse/placement in
+each handler. Rejected: the three handlers share parse, id-gen, and
+serialize; inlining triplicates it and makes the logic untestable in
+isolation.
+
+---
+
+## Alternatives considered
+
+### Alternative A: Operate on raw JSON string in handlers (no service)
+
+Each handler calls `JSON.parse` / `JSON.stringify` and runs placement
+inline. No new service file.
+
+**Rejected.** Parse + id-gen + auto-placement are shared by at minimum
+two of the three handlers. Inlining duplicates logic that is
+independently unit-testable. The existing codebase already extracts
+shared helpers into services for this reason (`patchHelpers`, `headingRename`,
+`periodicNotesDetector`). Consistency and testability both point to a service.
+
+### Alternative B: Typed canvas model with strict schema (no index signature)
+
+Parse canvas JSON into a typed `CanvasNode` union discriminated by `type`,
+dropping unknown fields at parse time. Re-serialize from the typed model.
+
+**Rejected.** Dropping unknown fields violates round-trip fidelity. A
+canvas that has been styled in Obsidian (e.g. custom `color`, or fields
+from a future spec revision) would silently lose data after any write.
+The SPEC explicitly rejects this approach.
+
+### Alternative C: Add a `create_canvas` tool instead of implicit creation
+
+Make `add_canvas_node` require the canvas to already exist, and add a
+separate `create_canvas` tool.
+
+**Rejected.** The SPEC explicitly defers `create_canvas` to v2 and
+requires `add_canvas_node` to create-if-missing (consistent with
+`append_to_vault_file`'s create-if-missing behaviour). A two-step
+create-then-add is worse UX for an MCP client and adds a round-trip
+without benefit.
+
+---
+
+## Consequences
+
+### Positive
+
+- Agents can inspect canvas graphs and extend them without raw JSON
+  manipulation.
+- Round-trip fidelity means tool-written canvases open in the Obsidian
+  Canvas editor without data loss.
+- The service is independently unit-testable; placement, id-gen, and
+  parse/serialize can be exercised without a vault mock.
+- Follows the existing tool/test/service pattern exactly; the codebase
+  stays consistent.
+
+### Negative
+
+- `add_canvas_node` is non-idempotent by spec decision: calling it twice
+  with the same arguments produces two nodes. Clients must track returned
+  ids if they need to de-duplicate.
+- Last-write-wins on concurrent edits (consistent with all other vault
+  write tools, but worth documenting).
+- Auto-placement is intentionally simple (right-of-extent, row-wrap). It
+  may produce suboptimal layouts for canvases with many manually
+  repositioned nodes; no reflow of existing nodes is done.
+- `group` node type is readable (passed through in `get_canvas`) but not
+  creatable. An `add_canvas_node` call with `type: "group"` is rejected
+  by the ArkType schema (union excludes `"group"`), which is intentional
+  but may surprise users of the raw API.
+
+### Neutral
+
+- `get_canvas` truncates long `text`-node content with a `textTruncated:
+  true` flag. The truncation cap is a named constant; the full text is
+  accessible via `get_vault_file` on the same path.
+- The three tools add 3 entries to `TOOL_ANNOTATIONS` and 3
+  `registry.register` calls; no structural changes to the registry or
+  composition root.
+
+---
+
+## References
+
+- JSON Canvas open spec: <https://jsoncanvas.org/>
+- SPEC.md (this repo): `SPEC.md`, Canvas tools v1
+- Existing pattern reference: `appendToVaultFile.ts`, `patchHelpers.ts`
+- MCP tool annotations: `toolAnnotations.ts` (PR #276)

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -160,6 +160,15 @@ import {
   listBookmarksHandler,
   listBookmarksSchema,
 } from "./tools/listBookmarks";
+import { getCanvasHandler, getCanvasSchema } from "./tools/getCanvas";
+import {
+  addCanvasNodeHandler,
+  addCanvasNodeSchema,
+} from "./tools/addCanvasNode";
+import {
+  connectCanvasNodesHandler,
+  connectCanvasNodesSchema,
+} from "./tools/connectCanvasNodes";
 
 export type RegisterToolsContext = {
   app: App;
@@ -293,6 +302,17 @@ export async function registerTools(
   );
   registry.register(listBookmarksSchema, async ({ arguments: args }) =>
     listBookmarksHandler({ arguments: args, app: ctx.app }),
+  );
+
+  // Canvas
+  registry.register(getCanvasSchema, async ({ arguments: args }) =>
+    getCanvasHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(addCanvasNodeSchema, async ({ arguments: args }) =>
+    addCanvasNodeHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(connectCanvasNodesSchema, async ({ arguments: args }) =>
+    connectCanvasNodesHandler({ arguments: args, app: ctx.app }),
   );
 
   // Search

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/canvasDocument.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/canvasDocument.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseCanvas,
+  buildEmptyCanvas,
+  serializeCanvas,
+  generateNodeId,
+  computePlacement,
+  CANVAS_ROW_WRAP_WIDTH,
+  CANVAS_GAP,
+  NODE_DEFAULT_SIZES,
+} from "./canvasDocument";
+import type { CanvasNode } from "./canvasDocument";
+
+describe("parseCanvas", () => {
+  test("returns null on empty string", () => {
+    expect(parseCanvas("")).toBeNull();
+  });
+
+  test("returns null on non-JSON", () => {
+    expect(parseCanvas("not json at all")).toBeNull();
+  });
+
+  test("returns null on {} (missing nodes/edges)", () => {
+    expect(parseCanvas("{}")).toBeNull();
+  });
+
+  test("returns null when nodes is missing but edges present", () => {
+    expect(parseCanvas(JSON.stringify({ edges: [] }))).toBeNull();
+  });
+
+  test("returns null when edges is missing but nodes present", () => {
+    expect(parseCanvas(JSON.stringify({ nodes: [] }))).toBeNull();
+  });
+
+  test("returns null when nodes is not an array", () => {
+    expect(parseCanvas(JSON.stringify({ nodes: null, edges: [] }))).toBeNull();
+  });
+
+  test("returns null when edges is not an array", () => {
+    expect(parseCanvas(JSON.stringify({ nodes: [], edges: null }))).toBeNull();
+  });
+
+  test("returns the document on { nodes: [], edges: [] }", () => {
+    const raw = JSON.stringify({ nodes: [], edges: [] });
+    const doc = parseCanvas(raw);
+    expect(doc).not.toBeNull();
+    expect(doc!.nodes).toEqual([]);
+    expect(doc!.edges).toEqual([]);
+  });
+
+  test("preserves unknown field color on a node verbatim", () => {
+    const raw = JSON.stringify({
+      nodes: [
+        {
+          id: "abc1",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: "hello",
+          color: "1",
+        },
+      ],
+      edges: [],
+    });
+    const doc = parseCanvas(raw);
+    expect(doc).not.toBeNull();
+    const node = doc!.nodes[0] as Record<string, unknown>;
+    expect(node["color"]).toBe("1");
+  });
+
+  test("preserves extra top-level fields", () => {
+    const raw = JSON.stringify({ nodes: [], edges: [], version: "1.0" });
+    const doc = parseCanvas(raw);
+    expect(doc).not.toBeNull();
+    expect((doc as Record<string, unknown>)["version"]).toBe("1.0");
+  });
+});
+
+describe("buildEmptyCanvas", () => {
+  test("returns { nodes: [], edges: [] }", () => {
+    expect(buildEmptyCanvas()).toEqual({ nodes: [], edges: [] });
+  });
+
+  test("returns a fresh object on each call", () => {
+    const a = buildEmptyCanvas();
+    const b = buildEmptyCanvas();
+    a.nodes.push({
+      id: "x",
+      type: "text",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    });
+    expect(b.nodes).toHaveLength(0);
+  });
+});
+
+describe("serializeCanvas", () => {
+  test("uses 2-space indent", () => {
+    const doc = buildEmptyCanvas();
+    const out = serializeCanvas(doc);
+    expect(out).toBe(JSON.stringify(doc, null, 2));
+  });
+
+  test("round-trips a well-formed canvas", () => {
+    const raw =
+      JSON.stringify({ nodes: [], edges: [], version: "1.0" }, null, 2) + "\n";
+    // Obsidian may or may not write trailing newline; normalize for comparison
+    const doc = parseCanvas(raw.trim());
+    expect(doc).not.toBeNull();
+    expect(serializeCanvas(doc!)).toBe(
+      JSON.stringify(JSON.parse(raw), null, 2),
+    );
+  });
+
+  test("serializeCanvas(parseCanvas(raw)) equals re-stringified raw", () => {
+    const original = {
+      nodes: [
+        {
+          id: "n1",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: "hi",
+        },
+      ],
+      edges: [{ id: "e1", fromNode: "n1", toNode: "n1" }],
+    };
+    const raw = JSON.stringify(original, null, 2);
+    const doc = parseCanvas(raw);
+    expect(doc).not.toBeNull();
+    expect(serializeCanvas(doc!)).toBe(raw);
+  });
+});
+
+describe("generateNodeId", () => {
+  test("returns a 16-char lowercase hex string", () => {
+    const id = generateNodeId([]);
+    expect(id).toHaveLength(16);
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("retries when first candidate is in existing list", () => {
+    // Supply a custom generator that returns a known collision on the first
+    // call and a fresh id on the second, verifying the retry path.
+    const collision = "aaaaaaaaaaaaaaaa";
+    let callCount = 0;
+    const gen = () => {
+      callCount++;
+      return callCount === 1 ? collision : "bbbbbbbbbbbbbbbb";
+    };
+    const id = generateNodeId([collision], gen);
+    expect(id).toBe("bbbbbbbbbbbbbbbb");
+    expect(callCount).toBe(2);
+  });
+
+  test("does not collide with existing ids", () => {
+    const existing: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      const id = generateNodeId(existing);
+      expect(existing).not.toContain(id);
+      existing.push(id);
+    }
+  });
+});
+
+describe("computePlacement", () => {
+  const W = NODE_DEFAULT_SIZES.text.width;
+  const H = NODE_DEFAULT_SIZES.text.height;
+
+  test("empty nodes returns { x: 0, y: 0, width, height }", () => {
+    const rect = computePlacement([], { width: W, height: H });
+    expect(rect).toEqual({ x: 0, y: 0, width: W, height: H });
+  });
+
+  test("places second node to the right of the first with CANVAS_GAP gap", () => {
+    const first: CanvasNode = {
+      id: "n1",
+      type: "text",
+      x: 0,
+      y: 0,
+      width: W,
+      height: H,
+    };
+    const rect = computePlacement([first], { width: W, height: H });
+    expect(rect.x).toBe(W + CANVAS_GAP);
+    expect(rect.y).toBe(0);
+    expect(rect.width).toBe(W);
+    expect(rect.height).toBe(H);
+  });
+
+  test("wraps to a new row when right edge would exceed CANVAS_ROW_WRAP_WIDTH", () => {
+    // Fill up the row with nodes so the next one must wrap.
+    const nodes: CanvasNode[] = [];
+    let x = 0;
+    while (x + W + CANVAS_GAP <= CANVAS_ROW_WRAP_WIDTH) {
+      nodes.push({
+        id: `n${nodes.length}`,
+        type: "text",
+        x,
+        y: 0,
+        width: W,
+        height: H,
+      });
+      x += W + CANVAS_GAP;
+    }
+    // The last node's right edge is x (x was incremented past the wrap limit).
+    // Now adding one more should wrap.
+    const rect = computePlacement(nodes, { width: W, height: H });
+    // Wrapped: x should reset to 0, y should be at H + CANVAS_GAP
+    expect(rect.x).toBe(0);
+    expect(rect.y).toBe(H + CANVAS_GAP);
+  });
+
+  test("returns explicit x/y verbatim when supplied", () => {
+    const first: CanvasNode = {
+      id: "n1",
+      type: "text",
+      x: 0,
+      y: 0,
+      width: W,
+      height: H,
+    };
+    const rect = computePlacement([first], {
+      width: W,
+      height: H,
+      explicitX: 999,
+      explicitY: 777,
+    });
+    expect(rect.x).toBe(999);
+    expect(rect.y).toBe(777);
+    expect(rect.width).toBe(W);
+    expect(rect.height).toBe(H);
+  });
+
+  test("explicit x/y with no existing nodes", () => {
+    const rect = computePlacement([], {
+      width: 200,
+      height: 100,
+      explicitX: 50,
+      explicitY: 60,
+    });
+    expect(rect).toEqual({ x: 50, y: 60, width: 200, height: 100 });
+  });
+
+  test("honors explicit x alone, auto-placing y", () => {
+    const first: CanvasNode = {
+      id: "n1",
+      type: "text",
+      x: 0,
+      y: 0,
+      width: W,
+      height: H,
+    };
+    const rect = computePlacement([first], {
+      width: W,
+      height: H,
+      explicitX: 1234,
+    });
+    expect(rect.x).toBe(1234);
+    expect(rect.y).toBe(0);
+  });
+
+  test("honors explicit y alone, auto-placing x", () => {
+    const first: CanvasNode = {
+      id: "n1",
+      type: "text",
+      x: 0,
+      y: 0,
+      width: W,
+      height: H,
+    };
+    const rect = computePlacement([first], {
+      width: W,
+      height: H,
+      explicitY: 555,
+    });
+    expect(rect.x).toBe(W + CANVAS_GAP);
+    expect(rect.y).toBe(555);
+  });
+
+  test("non-wrapping placement uses the top edge of existing nodes, not y=0", () => {
+    const first: CanvasNode = {
+      id: "n1",
+      type: "text",
+      x: 0,
+      y: 500,
+      width: W,
+      height: H,
+    };
+    const rect = computePlacement([first], { width: W, height: H });
+    expect(rect.x).toBe(W + CANVAS_GAP);
+    expect(rect.y).toBe(500);
+  });
+});
+
+describe("constants", () => {
+  test("CANVAS_ROW_WRAP_WIDTH is 3200", () => {
+    expect(CANVAS_ROW_WRAP_WIDTH).toBe(3200);
+  });
+
+  test("CANVAS_GAP is 32", () => {
+    expect(CANVAS_GAP).toBe(32);
+  });
+
+  test("NODE_DEFAULT_SIZES has text, file, link entries", () => {
+    expect(NODE_DEFAULT_SIZES.text).toEqual({ width: 400, height: 200 });
+    expect(NODE_DEFAULT_SIZES.file).toEqual({ width: 400, height: 300 });
+    expect(NODE_DEFAULT_SIZES.link).toEqual({ width: 400, height: 200 });
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/services/canvasDocument.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/canvasDocument.ts
@@ -1,0 +1,187 @@
+/**
+ * Canvas document service — parse, serialize, id generation, and node placement.
+ *
+ * Pure logic; no vault interaction. All functions here are usable in tests
+ * without any Obsidian mock. Tool handlers call into this service and handle
+ * their own vault I/O.
+ */
+
+export type CanvasNode = {
+  id: string;
+  type: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} & Record<string, unknown>;
+
+export type CanvasEdge = {
+  id: string;
+  fromNode: string;
+  toNode: string;
+} & Record<string, unknown>;
+
+export type CanvasDocument = {
+  nodes: CanvasNode[];
+  edges: CanvasEdge[];
+} & Record<string, unknown>;
+
+export type Rect = { x: number; y: number; width: number; height: number };
+
+export type PlacementOpts = {
+  width: number;
+  height: number;
+  explicitX?: number;
+  explicitY?: number;
+};
+
+/** Column width (px) at which the auto-placer starts a new row. */
+export const CANVAS_ROW_WRAP_WIDTH = 3200;
+
+/** Pixel gap between auto-placed nodes (horizontal and vertical). */
+export const CANVAS_GAP = 32;
+
+/**
+ * Default node dimensions by type, matching Obsidian's canvas editor defaults.
+ * Exported so tool handlers can pass the right size to `computePlacement`.
+ */
+export const NODE_DEFAULT_SIZES: Record<
+  string,
+  { width: number; height: number }
+> = {
+  text: { width: 400, height: 200 },
+  file: { width: 400, height: 300 },
+  link: { width: 400, height: 200 },
+};
+
+/**
+ * Parse a raw canvas JSON string into a `CanvasDocument`.
+ *
+ * Returns `null` when the input is not valid JSON, or when the top-level
+ * object is missing `nodes` or `edges` arrays. Unknown fields on the
+ * document and on individual nodes/edges are preserved intact (index
+ * signature on the types), so a round-trip write never drops data that
+ * came from a hand-edited canvas.
+ */
+export function parseCanvas(raw: string): CanvasDocument | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (!Array.isArray(obj["nodes"]) || !Array.isArray(obj["edges"])) {
+    return null;
+  }
+  return obj as unknown as CanvasDocument;
+}
+
+/** Return a fresh empty canvas document. */
+export function buildEmptyCanvas(): CanvasDocument {
+  return { nodes: [], edges: [] };
+}
+
+/**
+ * Serialize a canvas document to a pretty-printed JSON string (2-space
+ * indent), matching Obsidian's on-disk canvas format.
+ */
+export function serializeCanvas(doc: CanvasDocument): string {
+  return JSON.stringify(doc, null, 2);
+}
+
+/**
+ * Generate a unique 16-character lowercase hex node id.
+ *
+ * Retries until it produces an id not already present in `existing`.
+ * An optional `gen` argument overrides the random source — useful in
+ * tests to inject a deterministic sequence and exercise the retry path.
+ */
+export function generateNodeId(existing: string[], gen?: () => string): string {
+  const existingSet = new Set(existing);
+  const defaultGen = (): string => {
+    const bytes = new Uint8Array(8);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  };
+  const generator = gen ?? defaultGen;
+  while (true) {
+    const candidate = generator();
+    if (!existingSet.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * Compute the position of a new node given the current set of canvas nodes.
+ *
+ * Each axis is resolved independently: an explicit `explicitX` or `explicitY`
+ * overrides the auto-computed value for that axis only, so a caller can pin one
+ * coordinate (e.g. a fixed `x`) while letting the other auto-place.
+ *
+ * Auto-placement rules:
+ *  1. When no nodes exist, place at (0, 0).
+ *  2. Otherwise place immediately to the right of the widest bounding-box extent,
+ *     with `CANVAS_GAP` px of horizontal spacing.
+ *  3. When the right edge of the candidate position exceeds `CANVAS_ROW_WRAP_WIDTH`,
+ *     start a new row below the tallest node in the current layout (gap: `CANVAS_GAP`).
+ */
+export function computePlacement(
+  nodes: CanvasNode[],
+  opts: PlacementOpts,
+): Rect {
+  const { width, height, explicitX, explicitY } = opts;
+
+  const auto = computeAutoPosition(nodes, width);
+
+  return {
+    x: explicitX ?? auto.x,
+    y: explicitY ?? auto.y,
+    width,
+    height,
+  };
+}
+
+/**
+ * Compute the auto-placement origin for a new node of the given width.
+ *
+ * Returns (0, 0) on an empty canvas; otherwise the slot to the right of the
+ * current bounding box, wrapping to a new row when the candidate would exceed
+ * `CANVAS_ROW_WRAP_WIDTH`. Within a row the new node shares the top edge of the
+ * existing nodes (`minY`) rather than assuming the layout is anchored at y=0.
+ */
+function computeAutoPosition(
+  nodes: CanvasNode[],
+  width: number,
+): { x: number; y: number } {
+  if (nodes.length === 0) {
+    return { x: 0, y: 0 };
+  }
+
+  // Compute the bounding box of all existing nodes.
+  let maxRight = -Infinity;
+  let maxBottom = -Infinity;
+  let minY = Infinity;
+
+  for (const n of nodes) {
+    const right = n.x + n.width;
+    const bottom = n.y + n.height;
+    if (right > maxRight) maxRight = right;
+    if (bottom > maxBottom) maxBottom = bottom;
+    if (n.y < minY) minY = n.y;
+  }
+
+  const candidateX = maxRight + CANVAS_GAP;
+
+  // Wrap to a new row when the new node's right edge would exceed the wrap threshold.
+  if (candidateX + width > CANVAS_ROW_WRAP_WIDTH) {
+    return { x: 0, y: maxBottom + CANVAS_GAP };
+  }
+
+  return { x: candidateX, y: minY };
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
@@ -101,6 +101,11 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   get_or_create_periodic_note: { ...SAFE_WRITE, idempotentHint: true },
   append_to_periodic_note: SAFE_WRITE,
 
+  // Canvas
+  get_canvas: READ_ONLY,
+  add_canvas_node: SAFE_WRITE,
+  connect_canvas_nodes: SAFE_WRITE,
+
   // Adaptive-loading meta-tools (registered in mcpServer.ts; lookup is
   // name-keyed at list() time, so the entry can live here regardless).
   tool_catalog: READ_ONLY,

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/addCanvasNode.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/addCanvasNode.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { addCanvasNodeHandler, addCanvasNodeSchema } from "./addCanvasNode";
+import {
+  getMockFolders,
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockFolder,
+} from "$/test-setup";
+import { serializeCanvas, buildEmptyCanvas } from "../services/canvasDocument";
+
+beforeEach(() => resetMockVault());
+
+describe("add_canvas_node tool", () => {
+  test("schema declares the tool name", () => {
+    expect(addCanvasNodeSchema.get("name")?.toString()).toContain(
+      "add_canvas_node",
+    );
+  });
+
+  test("adds a text node to an existing canvas; returns id, coords, created:false", async () => {
+    const canvas = serializeCanvas(buildEmptyCanvas());
+    setMockFile("boards/work.canvas", canvas);
+    const r = await addCanvasNodeHandler({
+      arguments: { path: "boards/work.canvas", type: "text", text: "hello" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const data = JSON.parse(r.content[0].text as string);
+    expect(typeof data.id).toBe("string");
+    expect(data.id).toHaveLength(16);
+    expect(typeof data.x).toBe("number");
+    expect(typeof data.y).toBe("number");
+    expect(typeof data.width).toBe("number");
+    expect(typeof data.height).toBe("number");
+    expect(data.created).toBe(false);
+  });
+
+  test("auto-places a second node to the right of the first", async () => {
+    const canvas = {
+      nodes: [
+        {
+          id: "aaaa000000000001",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 400,
+          height: 200,
+        },
+      ],
+      edges: [],
+    };
+    setMockFile("boards/auto.canvas", JSON.stringify(canvas, null, 2));
+    const app = mockApp();
+    const r = await addCanvasNodeHandler({
+      arguments: { path: "boards/auto.canvas", type: "text", text: "second" },
+      app,
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    // Should be placed to the right: x = 0 + 400 + 32 = 432
+    expect(data.x).toBe(432);
+    expect(data.y).toBe(0);
+  });
+
+  test("explicit x/y are used verbatim", async () => {
+    const canvas = serializeCanvas(buildEmptyCanvas());
+    setMockFile("boards/explicit.canvas", canvas);
+    const r = await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/explicit.canvas",
+        type: "text",
+        text: "hi",
+        x: 100,
+        y: 200,
+      },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.x).toBe(100);
+    expect(data.y).toBe(200);
+  });
+
+  test("adds a file node when the embed target exists", async () => {
+    setMockFile("boards/board.canvas", serializeCanvas(buildEmptyCanvas()));
+    setMockFile("Notes/ref.md", "# Reference");
+    const r = await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/board.canvas",
+        type: "file",
+        file: "Notes/ref.md",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const data = JSON.parse(r.content[0].text as string);
+    expect(typeof data.id).toBe("string");
+    expect(data.created).toBe(false);
+  });
+
+  test("returns embed_target_not_found when file target does not exist", async () => {
+    setMockFile("boards/board.canvas", serializeCanvas(buildEmptyCanvas()));
+    const r = await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/board.canvas",
+        type: "file",
+        file: "Notes/missing.md",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("embed_target_not_found");
+  });
+
+  test("adds a link node", async () => {
+    setMockFile("boards/board.canvas", serializeCanvas(buildEmptyCanvas()));
+    const r = await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/board.canvas",
+        type: "link",
+        url: "https://example.com",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const data = JSON.parse(r.content[0].text as string);
+    expect(typeof data.id).toBe("string");
+  });
+
+  test("returns missing_argument when type is link but url is omitted", async () => {
+    setMockFile("boards/board.canvas", serializeCanvas(buildEmptyCanvas()));
+    const r = await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/board.canvas",
+        type: "link",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("missing_argument");
+  });
+
+  test("returns missing_argument when type is file but file is omitted", async () => {
+    setMockFile("boards/board.canvas", serializeCanvas(buildEmptyCanvas()));
+    const r = await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/board.canvas",
+        type: "file",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("missing_argument");
+  });
+
+  test("creates the canvas file when the path is missing; response has created:true", async () => {
+    const app = mockApp();
+    const r = await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/new.canvas",
+        type: "text",
+        text: "first node",
+      },
+      app,
+    });
+    expect(r.isError).toBeUndefined();
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.created).toBe(true);
+    // The file must now exist in the vault
+    const file = app.vault.getAbstractFileByPath("boards/new.canvas");
+    expect(file).not.toBeNull();
+  });
+
+  test("creates parent folders when canvas path is nested and missing", async () => {
+    const app = mockApp();
+    await addCanvasNodeHandler({
+      arguments: { path: "deep/nested/board.canvas", type: "text", text: "x" },
+      app,
+    });
+    const folders = getMockFolders();
+    expect(folders).toContain("deep");
+    expect(folders).toContain("deep/nested");
+  });
+
+  test("preserves unknown fields on existing nodes after write", async () => {
+    const canvas = {
+      nodes: [
+        {
+          id: "bbbb000000000001",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: "existing",
+          customExtension: "preserved",
+        },
+      ],
+      edges: [],
+    };
+    setMockFile("boards/custom.canvas", JSON.stringify(canvas, null, 2));
+    const app = mockApp();
+    await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/custom.canvas",
+        type: "text",
+        text: "new node",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/custom.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.nodes[0].customExtension).toBe("preserved");
+  });
+
+  test("written canvas is pretty-printed with 2-space indent", async () => {
+    setMockFile("boards/pretty.canvas", serializeCanvas(buildEmptyCanvas()));
+    const app = mockApp();
+    await addCanvasNodeHandler({
+      arguments: { path: "boards/pretty.canvas", type: "text", text: "hi" },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/pretty.canvas") as never,
+    );
+    // A pretty-printed JSON has lines starting with spaces
+    expect(written).toMatch(/^\{/);
+    expect(written).toMatch(/\n  /);
+  });
+
+  test("returns not_a_file when path is a folder", async () => {
+    setMockFolder("boards");
+    const r = await addCanvasNodeHandler({
+      arguments: { path: "boards", type: "text", text: "x" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("not_a_file");
+  });
+
+  test("returns malformed_canvas when canvas JSON is invalid", async () => {
+    setMockFile("boards/bad.canvas", "{ not valid json }");
+    const r = await addCanvasNodeHandler({
+      arguments: { path: "boards/bad.canvas", type: "text", text: "x" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("malformed_canvas");
+  });
+
+  test("optional color field is written onto the new node", async () => {
+    setMockFile("boards/colored.canvas", serializeCanvas(buildEmptyCanvas()));
+    const app = mockApp();
+    await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/colored.canvas",
+        type: "text",
+        text: "node",
+        color: "5",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/colored.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.nodes[0].color).toBe("5");
+  });
+
+  test("node is written with correct type-specific fields for text", async () => {
+    setMockFile("boards/types.canvas", serializeCanvas(buildEmptyCanvas()));
+    const app = mockApp();
+    await addCanvasNodeHandler({
+      arguments: { path: "boards/types.canvas", type: "text", text: "content" },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/types.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.nodes[0].type).toBe("text");
+    expect(parsed.nodes[0].text).toBe("content");
+  });
+
+  test("node is written with correct type-specific fields for file with subpath", async () => {
+    setMockFile("boards/file.canvas", serializeCanvas(buildEmptyCanvas()));
+    setMockFile("Notes/ref.md", "# Ref");
+    const app = mockApp();
+    await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/file.canvas",
+        type: "file",
+        file: "Notes/ref.md",
+        subpath: "#heading",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/file.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.nodes[0].type).toBe("file");
+    expect(parsed.nodes[0].file).toBe("Notes/ref.md");
+    expect(parsed.nodes[0].subpath).toBe("#heading");
+  });
+
+  test("node is written with correct type-specific fields for link", async () => {
+    setMockFile("boards/link.canvas", serializeCanvas(buildEmptyCanvas()));
+    const app = mockApp();
+    await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/link.canvas",
+        type: "link",
+        url: "https://example.com",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/link.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.nodes[0].type).toBe("link");
+    expect(parsed.nodes[0].url).toBe("https://example.com");
+  });
+
+  test("returns an error when type is link but url is absent; canvas is not written", async () => {
+    setMockFile("boards/board.canvas", serializeCanvas(buildEmptyCanvas()));
+    const app = mockApp();
+    const r = await addCanvasNodeHandler({
+      arguments: { path: "boards/board.canvas", type: "link" },
+      app,
+    });
+    expect(r.isError).toBe(true);
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/board.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.nodes).toHaveLength(0);
+  });
+
+  test("explicit width/height override defaults", async () => {
+    setMockFile("boards/sizing.canvas", serializeCanvas(buildEmptyCanvas()));
+    const r = await addCanvasNodeHandler({
+      arguments: {
+        path: "boards/sizing.canvas",
+        type: "text",
+        text: "x",
+        width: 800,
+        height: 400,
+      },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.width).toBe(800);
+    expect(data.height).toBe(400);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/addCanvasNode.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/addCanvasNode.ts
@@ -1,0 +1,184 @@
+import { type } from "arktype";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
+import { ensureParentFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
+import {
+  buildEmptyCanvas,
+  computePlacement,
+  generateNodeId,
+  NODE_DEFAULT_SIZES,
+  parseCanvas,
+  serializeCanvas,
+} from "../services/canvasDocument";
+import { errorJson, successJson } from "../services/responseBuilders";
+
+export const addCanvasNodeSchema = type({
+  name: '"add_canvas_node"',
+  arguments: {
+    path: "string>0",
+    type: '"text" | "file" | "link"',
+    "text?": "string",
+    "file?": "string>0",
+    "subpath?": "string",
+    "url?": "string>0",
+    "color?": "string",
+    "x?": "number",
+    "y?": "number",
+    "width?": "number",
+    "height?": "number",
+  },
+}).describe(
+  "Adds a node (text, file, or link) to a canvas. Creates the canvas if it does not exist.",
+);
+
+export type AddCanvasNodeContext = {
+  arguments: {
+    path: string;
+    type: "text" | "file" | "link";
+    text?: string;
+    file?: string;
+    subpath?: string;
+    url?: string;
+    color?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+  };
+  app: App;
+};
+
+export async function addCanvasNodeHandler(ctx: AddCanvasNodeContext): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const { path, type: nodeType, color, x, y, width, height } = ctx.arguments;
+
+  // Resolve the canvas file — or detect a folder collision early.
+  const resolved = resolveTFile(ctx.app.vault, path);
+  if (!resolved.ok && resolved.reason === "not_a_file") {
+    return errorJson(`Path is a folder: ${path}`, "not_a_file", { path });
+  }
+
+  let doc;
+  let created = false;
+  // Retain the TFile reference so the modify call below remains type-safe
+  // after the narrowing from the resolved.ok branch is no longer in scope.
+  let existingFile: import("obsidian").TFile | null = null;
+
+  if (resolved.ok) {
+    existingFile = resolved.file;
+    const raw = await ctx.app.vault.read(resolved.file);
+    doc = parseCanvas(raw);
+    if (!doc) {
+      return errorJson(
+        `Canvas file is malformed: ${path}`,
+        "malformed_canvas",
+        { path },
+      );
+    }
+  } else {
+    // not_found — create a new canvas document.
+    doc = buildEmptyCanvas();
+    created = true;
+  }
+
+  // Validate file-type embed target before mutating the canvas.
+  if (nodeType === "file") {
+    const embedPath = ctx.arguments.file;
+    if (!embedPath) {
+      return errorJson(
+        'The "file" argument is required when type is "file".',
+        "missing_argument",
+        { path },
+      );
+    }
+    const embedResolved = resolveTFile(ctx.app.vault, embedPath);
+    if (!embedResolved.ok) {
+      return errorJson(
+        `Embed target not found: ${embedPath}`,
+        "embed_target_not_found",
+        { path: embedPath },
+      );
+    }
+  }
+
+  // Determine node dimensions.
+  const defaults = NODE_DEFAULT_SIZES[nodeType] ?? { width: 400, height: 200 };
+  const nodeWidth = width ?? defaults.width;
+  const nodeHeight = height ?? defaults.height;
+
+  // Compute placement.
+  const rect = computePlacement(doc.nodes, {
+    width: nodeWidth,
+    height: nodeHeight,
+    explicitX: x,
+    explicitY: y,
+  });
+
+  // Generate a unique node id.
+  const existingIds = doc.nodes.map((n) => n.id);
+  const id = generateNodeId(existingIds);
+
+  // Build the node payload based on type.
+  const baseNode = {
+    id,
+    type: nodeType,
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+    ...(color !== undefined ? { color } : {}),
+  };
+
+  let newNode: Record<string, unknown>;
+
+  if (nodeType === "text") {
+    newNode = { ...baseNode, text: ctx.arguments.text ?? "" };
+  } else if (nodeType === "file") {
+    newNode = {
+      ...baseNode,
+      file: ctx.arguments.file!,
+      ...(ctx.arguments.subpath !== undefined
+        ? { subpath: ctx.arguments.subpath }
+        : {}),
+    };
+  } else if (nodeType === "link") {
+    if (!ctx.arguments.url) {
+      return errorJson(
+        'The "url" argument is required when type is "link".',
+        "missing_argument",
+        { path },
+      );
+    }
+    newNode = { ...baseNode, url: ctx.arguments.url };
+  } else {
+    return errorJson(
+      `Unsupported node type: ${nodeType}`,
+      "invalid_node_type",
+      {
+        nodeType,
+      },
+    );
+  }
+
+  doc.nodes.push(newNode as never);
+
+  const serialized = serializeCanvas(doc);
+
+  if (created) {
+    await ensureParentFolderExists(ctx.app, path);
+    await ctx.app.vault.create(path, serialized);
+  } else {
+    await ctx.app.vault.modify(existingFile!, serialized);
+  }
+
+  return successJson({
+    id,
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+    created,
+  });
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/connectCanvasNodes.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/connectCanvasNodes.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  connectCanvasNodesHandler,
+  connectCanvasNodesSchema,
+} from "./connectCanvasNodes";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockFolder,
+} from "$/test-setup";
+import { serializeCanvas } from "../services/canvasDocument";
+
+const CANVAS_WITH_TWO_NODES = {
+  nodes: [
+    {
+      id: "aaaa000000000001",
+      type: "text",
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 200,
+      text: "node A",
+    },
+    {
+      id: "bbbb000000000002",
+      type: "text",
+      x: 432,
+      y: 0,
+      width: 400,
+      height: 200,
+      text: "node B",
+    },
+  ],
+  edges: [],
+};
+
+beforeEach(() => resetMockVault());
+
+describe("connect_canvas_nodes tool", () => {
+  test("schema declares the tool name", () => {
+    expect(connectCanvasNodesSchema.get("name")?.toString()).toContain(
+      "connect_canvas_nodes",
+    );
+  });
+
+  test("adds an edge between two existing nodes; returns { id }", async () => {
+    setMockFile(
+      "boards/work.canvas",
+      JSON.stringify(CANVAS_WITH_TWO_NODES, null, 2),
+    );
+    const r = await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/work.canvas",
+        fromNode: "aaaa000000000001",
+        toNode: "bbbb000000000002",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const data = JSON.parse(r.content[0].text as string);
+    expect(typeof data.id).toBe("string");
+    expect(data.id).toHaveLength(16);
+  });
+
+  test("default sides are right and left when omitted", async () => {
+    const app = mockApp();
+    setMockFile(
+      "boards/work.canvas",
+      JSON.stringify(CANVAS_WITH_TWO_NODES, null, 2),
+    );
+    await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/work.canvas",
+        fromNode: "aaaa000000000001",
+        toNode: "bbbb000000000002",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/work.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.edges[0].fromSide).toBe("right");
+    expect(parsed.edges[0].toSide).toBe("left");
+  });
+
+  test("explicit fromSide/toSide override defaults", async () => {
+    const app = mockApp();
+    setMockFile(
+      "boards/work.canvas",
+      JSON.stringify(CANVAS_WITH_TWO_NODES, null, 2),
+    );
+    await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/work.canvas",
+        fromNode: "aaaa000000000001",
+        toNode: "bbbb000000000002",
+        fromSide: "top",
+        toSide: "bottom",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/work.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.edges[0].fromSide).toBe("top");
+    expect(parsed.edges[0].toSide).toBe("bottom");
+  });
+
+  test("label and color are written onto the edge when provided", async () => {
+    const app = mockApp();
+    setMockFile(
+      "boards/work.canvas",
+      JSON.stringify(CANVAS_WITH_TWO_NODES, null, 2),
+    );
+    await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/work.canvas",
+        fromNode: "aaaa000000000001",
+        toNode: "bbbb000000000002",
+        label: "my edge",
+        color: "1",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/work.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.edges[0].label).toBe("my edge");
+    expect(parsed.edges[0].color).toBe("1");
+  });
+
+  test("returns node_not_found with nodeId when fromNode id is absent", async () => {
+    setMockFile(
+      "boards/work.canvas",
+      JSON.stringify(CANVAS_WITH_TWO_NODES, null, 2),
+    );
+    const r = await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/work.canvas",
+        fromNode: "doesnotexist0000",
+        toNode: "bbbb000000000002",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("node_not_found");
+    expect(data.nodeId).toBe("doesnotexist0000");
+  });
+
+  test("returns node_not_found with nodeId when toNode id is absent", async () => {
+    setMockFile(
+      "boards/work.canvas",
+      JSON.stringify(CANVAS_WITH_TWO_NODES, null, 2),
+    );
+    const r = await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/work.canvas",
+        fromNode: "aaaa000000000001",
+        toNode: "doesnotexist0000",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("node_not_found");
+    expect(data.nodeId).toBe("doesnotexist0000");
+  });
+
+  test("returns canvas_not_found when the canvas file does not exist", async () => {
+    const r = await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/missing.canvas",
+        fromNode: "aaaa000000000001",
+        toNode: "bbbb000000000002",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("canvas_not_found");
+  });
+
+  test("returns not_a_file when path is a folder", async () => {
+    setMockFolder("boards");
+    const r = await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards",
+        fromNode: "aaaa000000000001",
+        toNode: "bbbb000000000002",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("not_a_file");
+  });
+
+  test("returns malformed_canvas on invalid JSON", async () => {
+    setMockFile("boards/bad.canvas", "{ not valid json }");
+    const r = await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/bad.canvas",
+        fromNode: "aaaa000000000001",
+        toNode: "bbbb000000000002",
+      },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("malformed_canvas");
+  });
+
+  test("edge is written with correct fromNode and toNode ids", async () => {
+    const app = mockApp();
+    setMockFile(
+      "boards/work.canvas",
+      JSON.stringify(CANVAS_WITH_TWO_NODES, null, 2),
+    );
+    await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/work.canvas",
+        fromNode: "aaaa000000000001",
+        toNode: "bbbb000000000002",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/work.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.edges[0].fromNode).toBe("aaaa000000000001");
+    expect(parsed.edges[0].toNode).toBe("bbbb000000000002");
+  });
+
+  test("written canvas is pretty-printed with 2-space indent", async () => {
+    const app = mockApp();
+    setMockFile(
+      "boards/pretty.canvas",
+      serializeCanvas({
+        nodes: [
+          {
+            id: "aaaa000000000001",
+            type: "text",
+            x: 0,
+            y: 0,
+            width: 400,
+            height: 200,
+            text: "A",
+          },
+          {
+            id: "bbbb000000000002",
+            type: "text",
+            x: 432,
+            y: 0,
+            width: 400,
+            height: 200,
+            text: "B",
+          },
+        ],
+        edges: [],
+      }),
+    );
+    await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/pretty.canvas",
+        fromNode: "aaaa000000000001",
+        toNode: "bbbb000000000002",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/pretty.canvas") as never,
+    );
+    expect(written).toMatch(/^\{/);
+    expect(written).toMatch(/\n  /);
+  });
+
+  test("existing edges are preserved after adding a new edge", async () => {
+    const canvasWithEdge = {
+      nodes: [
+        {
+          id: "aaaa000000000001",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: "A",
+        },
+        {
+          id: "bbbb000000000002",
+          type: "text",
+          x: 432,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: "B",
+        },
+        {
+          id: "cccc000000000003",
+          type: "text",
+          x: 864,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: "C",
+        },
+      ],
+      edges: [
+        {
+          id: "eeee000000000001",
+          fromNode: "aaaa000000000001",
+          toNode: "bbbb000000000002",
+          fromSide: "right",
+          toSide: "left",
+        },
+      ],
+    };
+    const app = mockApp();
+    setMockFile("boards/multi.canvas", JSON.stringify(canvasWithEdge, null, 2));
+    await connectCanvasNodesHandler({
+      arguments: {
+        path: "boards/multi.canvas",
+        fromNode: "bbbb000000000002",
+        toNode: "cccc000000000003",
+      },
+      app,
+    });
+    const written = await app.vault.read(
+      app.vault.getAbstractFileByPath("boards/multi.canvas") as never,
+    );
+    const parsed = JSON.parse(written);
+    expect(parsed.edges).toHaveLength(2);
+    expect(parsed.edges[0].id).toBe("eeee000000000001");
+    expect(parsed.edges[1].fromNode).toBe("bbbb000000000002");
+    expect(parsed.edges[1].toNode).toBe("cccc000000000003");
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/connectCanvasNodes.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/connectCanvasNodes.ts
@@ -1,0 +1,100 @@
+import { type } from "arktype";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
+import {
+  generateNodeId,
+  parseCanvas,
+  serializeCanvas,
+} from "../services/canvasDocument";
+import { errorJson, successJson } from "../services/responseBuilders";
+
+export const connectCanvasNodesSchema = type({
+  name: '"connect_canvas_nodes"',
+  arguments: {
+    path: "string>0",
+    fromNode: "string>0",
+    toNode: "string>0",
+    "fromSide?": '"top" | "right" | "bottom" | "left"',
+    "toSide?": '"top" | "right" | "bottom" | "left"',
+    "label?": "string",
+    "color?": "string",
+  },
+}).describe(
+  "Adds an edge between two existing nodes in a canvas. Both node ids must exist.",
+);
+
+export type ConnectCanvasNodesContext = {
+  arguments: {
+    path: string;
+    fromNode: string;
+    toNode: string;
+    fromSide?: "top" | "right" | "bottom" | "left";
+    toSide?: "top" | "right" | "bottom" | "left";
+    label?: string;
+    color?: string;
+  };
+  app: App;
+};
+
+export async function connectCanvasNodesHandler(
+  ctx: ConnectCanvasNodesContext,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const { path, fromNode, toNode, fromSide, toSide, label, color } =
+    ctx.arguments;
+
+  const resolved = resolveTFile(ctx.app.vault, path);
+  if (!resolved.ok) {
+    return resolved.reason === "not_found"
+      ? errorJson(`Canvas file not found: ${path}`, "canvas_not_found", {
+          path,
+        })
+      : errorJson(`Path is a folder: ${path}`, "not_a_file", { path });
+  }
+
+  const raw = await ctx.app.vault.read(resolved.file);
+  const doc = parseCanvas(raw);
+  if (!doc) {
+    return errorJson(`Canvas file is malformed: ${path}`, "malformed_canvas", {
+      path,
+    });
+  }
+
+  // Verify both node ids exist before mutating.
+  const nodeIds = new Set(doc.nodes.map((n) => n.id));
+  if (!nodeIds.has(fromNode)) {
+    return errorJson(`Node not found: ${fromNode}`, "node_not_found", {
+      nodeId: fromNode,
+    });
+  }
+  if (!nodeIds.has(toNode)) {
+    return errorJson(`Node not found: ${toNode}`, "node_not_found", {
+      nodeId: toNode,
+    });
+  }
+
+  // Generate a unique edge id from the combined existing node and edge id pool.
+  const existingIds = [
+    ...doc.nodes.map((n) => n.id),
+    ...doc.edges.map((e) => e.id),
+  ];
+  const id = generateNodeId(existingIds);
+
+  const edge: Record<string, unknown> = {
+    id,
+    fromNode,
+    fromSide: fromSide ?? "right",
+    toNode,
+    toSide: toSide ?? "left",
+    ...(label !== undefined ? { label } : {}),
+    ...(color !== undefined ? { color } : {}),
+  };
+
+  doc.edges.push(edge as never);
+
+  await ctx.app.vault.modify(resolved.file, serializeCanvas(doc));
+
+  return successJson({ id });
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getCanvas.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getCanvas.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { getCanvasHandler, getCanvasSchema } from "./getCanvas";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockFolder,
+} from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+describe("get_canvas tool", () => {
+  test("schema declares the tool name", () => {
+    expect(getCanvasSchema.get("name")?.toString()).toContain("get_canvas");
+  });
+
+  test("returns structured result for an empty canvas", async () => {
+    const raw = JSON.stringify({ nodes: [], edges: [] });
+    setMockFile("boards/empty.canvas", raw);
+    const r = await getCanvasHandler({
+      arguments: { path: "boards/empty.canvas" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.path).toBe("boards/empty.canvas");
+    expect(data.nodeCount).toBe(0);
+    expect(data.edgeCount).toBe(0);
+    expect(data.nodes).toEqual([]);
+    expect(data.edges).toEqual([]);
+  });
+
+  test("returns structured nodes and edges for a canvas with content", async () => {
+    const canvas = {
+      nodes: [
+        {
+          id: "a1b2c3d4e5f6a1b2",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: "hello",
+        },
+      ],
+      edges: [
+        {
+          id: "0011223344556677",
+          fromNode: "a1b2c3d4e5f6a1b2",
+          toNode: "a1b2c3d4e5f6a1b2",
+        },
+      ],
+    };
+    setMockFile("boards/work.canvas", JSON.stringify(canvas));
+    const r = await getCanvasHandler({
+      arguments: { path: "boards/work.canvas" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBeUndefined();
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.nodeCount).toBe(1);
+    expect(data.edgeCount).toBe(1);
+    expect(data.nodes[0].id).toBe("a1b2c3d4e5f6a1b2");
+    expect(data.nodes[0].text).toBe("hello");
+    expect(data.edges[0].fromNode).toBe("a1b2c3d4e5f6a1b2");
+  });
+
+  test("unknown field on a node is present in the response (round-trip fidelity)", async () => {
+    const canvas = {
+      nodes: [
+        {
+          id: "aabbccdd11223344",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: "hi",
+          color: "5",
+          customExtension: "preserved",
+        },
+      ],
+      edges: [],
+    };
+    setMockFile("boards/custom.canvas", JSON.stringify(canvas));
+    const r = await getCanvasHandler({
+      arguments: { path: "boards/custom.canvas" },
+      app: mockApp(),
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.nodes[0].color).toBe("5");
+    expect(data.nodes[0].customExtension).toBe("preserved");
+  });
+
+  test("long text node content is truncated and textTruncated flag is set", async () => {
+    const longText = "x".repeat(600);
+    const canvas = {
+      nodes: [
+        {
+          id: "1234567890abcdef",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: longText,
+        },
+      ],
+      edges: [],
+    };
+    setMockFile("boards/long.canvas", JSON.stringify(canvas));
+    const app = mockApp();
+    const r = await getCanvasHandler({
+      arguments: { path: "boards/long.canvas" },
+      app,
+    });
+    const data = JSON.parse(r.content[0].text as string);
+    const node = data.nodes[0];
+    expect(node.text.length).toBe(500);
+    expect(node.textTruncated).toBe(true);
+  });
+
+  test("file on disk is unchanged after truncation (read-only)", async () => {
+    const longText = "y".repeat(600);
+    const canvas = {
+      nodes: [
+        {
+          id: "fedcba0987654321",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 400,
+          height: 200,
+          text: longText,
+        },
+      ],
+      edges: [],
+    };
+    const originalContent = JSON.stringify(canvas);
+    setMockFile("boards/ro.canvas", originalContent);
+    const app = mockApp();
+    await getCanvasHandler({
+      arguments: { path: "boards/ro.canvas" },
+      app,
+    });
+    // Verify the vault content is still the original serialization
+    const file = app.vault.getAbstractFileByPath("boards/ro.canvas");
+    if (!file) throw new Error("expected file");
+    const diskContent = await app.vault.read(file as never);
+    expect(diskContent).toBe(originalContent);
+  });
+
+  test("returns isError with canvas_not_found for a missing path", async () => {
+    const r = await getCanvasHandler({
+      arguments: { path: "missing.canvas" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("canvas_not_found");
+  });
+
+  test("returns isError with not_a_file when path is a folder", async () => {
+    setMockFolder("boards");
+    const r = await getCanvasHandler({
+      arguments: { path: "boards" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("not_a_file");
+  });
+
+  test("returns isError with malformed_canvas for invalid JSON", async () => {
+    setMockFile("boards/bad.canvas", "{ not valid json }");
+    const r = await getCanvasHandler({
+      arguments: { path: "boards/bad.canvas" },
+      app: mockApp(),
+    });
+    expect(r.isError).toBe(true);
+    const data = JSON.parse(r.content[0].text as string);
+    expect(data.errorCode).toBe("malformed_canvas");
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getCanvas.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getCanvas.ts
@@ -1,0 +1,70 @@
+import { type } from "arktype";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
+import { parseCanvas, type CanvasNode } from "../services/canvasDocument";
+import { errorJson, successJson } from "../services/responseBuilders";
+
+export const getCanvasSchema = type({
+  name: '"get_canvas"',
+  arguments: {
+    path: type("string>0").describe("Vault-relative path to the .canvas file."),
+  },
+}).describe(
+  "Reads a canvas file and returns its nodes and edges as structured JSON.",
+);
+
+export type GetCanvasContext = {
+  arguments: { path: string };
+  app: App;
+};
+
+/** Maximum characters of text-node content returned inline. */
+const TEXT_NODE_CAP = 500;
+
+export async function getCanvasHandler(ctx: GetCanvasContext): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const { path } = ctx.arguments;
+
+  const resolved = resolveTFile(ctx.app.vault, path);
+  if (!resolved.ok) {
+    return resolved.reason === "not_found"
+      ? errorJson(`Canvas file not found: ${path}`, "canvas_not_found", {
+          path,
+        })
+      : errorJson(`Path is a folder: ${path}`, "not_a_file", { path });
+  }
+
+  const raw = await ctx.app.vault.read(resolved.file);
+  const doc = parseCanvas(raw);
+  if (!doc) {
+    return errorJson(`Canvas file is malformed: ${path}`, "malformed_canvas", {
+      path,
+    });
+  }
+
+  // Truncate long text-node content in-memory only; the file is never modified.
+  const nodes = doc.nodes.map((node: CanvasNode) => {
+    if (
+      node.type === "text" &&
+      typeof node.text === "string" &&
+      node.text.length > TEXT_NODE_CAP
+    ) {
+      return {
+        ...node,
+        text: node.text.slice(0, TEXT_NODE_CAP),
+        textTruncated: true as const,
+      };
+    }
+    return node;
+  });
+
+  return successJson({
+    path,
+    nodeCount: doc.nodes.length,
+    edgeCount: doc.edges.length,
+    nodes,
+    edges: doc.edges,
+  });
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -107,9 +107,11 @@ describe("end-to-end: HTTP → McpServer", () => {
         .sort();
       expect(names).toEqual([
         "activate_tool",
+        "add_canvas_node",
         "append_to_active_file",
         "append_to_periodic_note",
         "append_to_vault_file",
+        "connect_canvas_nodes",
         "create_vault_directory",
         "create_vault_file",
         "delete_active_file",
@@ -124,6 +126,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "find_orphaned_notes",
         "get_active_file",
         "get_backlinks",
+        "get_canvas",
         "get_files_by_tag",
         "get_note_outline",
         "get_note_property",
@@ -152,7 +155,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "tool_catalog",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(45);
+      expect(names).toHaveLength(48);
 
       // Annotations completeness: every exposed tool must carry MCP
       // annotations with an explicit readOnlyHint and openWorldHint.


### PR DESCRIPTION
## Summary

Adds three MCP tools for Obsidian `.canvas` files (JSON Canvas spec), read and written through the vault API. Tool count 45 to 48.

- `get_canvas`: read a canvas as structured nodes and edges. Long text-node content is truncated with a `textTruncated` flag to bound token cost. Read-only.
- `add_canvas_node`: append a `text`, `file`, or `link` node with auto-placement. Creates the canvas (and parent folders) when the path is missing, validates `file`-node embed targets. Safe write.
- `connect_canvas_nodes`: append an edge between two existing node ids with default or explicit sides. Safe write.

A new `canvasDocument` service owns the shared logic: parse, serialize, 16-char hex id generation, and right-of-extent auto-placement with row wrap at 3200 px. Tool handlers stay thin and resolve through `resolveTFile` and the existing response builders.

## Design

Round-trip fidelity is the key decision: parsing preserves every field on a node or edge, including unmodeled ones (styling, future spec fields). Writes mutate only the targeted entry and serialize back as 2-space JSON matching Obsidian's on-disk format, so a canvas hand-made in Obsidian survives a tool write unchanged and produces clean diffs. Full rationale and the alternatives considered are in `docs/architecture/ADR-0008-canvas-tools.md`.

## Tests

- 1255 pass / 0 fail (+65 from the canvas service and tool suites; baseline 1183).
- `tsc -p packages/obsidian-plugin/tsconfig.json --noEmit`: zero errors.
- Each tool covers success plus every error path (`canvas_not_found`, `not_a_file`, `malformed_canvas`, `node_not_found`, `embed_target_not_found`, `missing_argument`) against the mock vault.

## Out of scope (v2)

Group-node creation, `update_canvas_node` / `delete_canvas_node`, `delete_canvas_edge`, a dedicated `create_canvas` tool, and any auto-layout that reflows existing nodes.