### PR TITLE
docs: update LICENSE copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Jack Steam
+Copyright (c) 2026 Stefano Ferri
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Sets the LICENSE copyright to Stefano Ferri. The plugin is a ground-up rebuild with no upstream-derived code, so the original fork attribution no longer applies.