### PR TITLE
docs: refresh project-architecture for 0.20.0

### DIFF
--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -1,64 +1,58 @@
-> Reflects the 0.4.x in-process architecture. Authoritative contract: CLAUDE.md / .clinerules.
+> Reflects the current in-process architecture (0.20.0 line). For exact versions, the tool list, and release detail, see README.md and CHANGELOG.md.
 
 # Project Architecture
 
-Use the following structure and conventions for all new features.
+Use this structure and these conventions for new features.
 
 ## Monorepo Structure
 
-This project uses a monorepo with multiple packages:
+The project is a Bun monorepo:
 
-- `packages/obsidian-plugin` - The Obsidian plugin (hosts the in-process HTTP MCP server)
-- `packages/shared` - Shared code between packages
-- `docs/` - Project documentation
-- `docs/features` - Feature requirements
+- `packages/obsidian-plugin`: the Obsidian plugin, which hosts the in-process HTTP MCP server
+- `packages/shared`: code shared across packages
+- `docs/`: project documentation, including the architecture decision records under `docs/architecture/`
+- root `manifest.json`, `versions.json`, `package.json`: plugin metadata and build config
 
 ### Package Organization
 
 ```
-packages/
-├── obsidian-plugin/     # Obsidian plugin (in-process MCP server, 0.4.x)
-│   ├── src/
-│   │   ├── features/   # Feature modules
-│   │   └── main.ts     # Plugin entry point
-│   └── manifest.json   # Plugin metadata
-│
-└── shared/             # Shared utilities and types
-    └── src/
-        ├── types/      # Common interfaces
-        ├── utils/      # Common utilities
-        └── constants/  # Shared configuration
+.
+├── manifest.json          # Plugin metadata (id, version, minAppVersion) — read by Obsidian
+├── versions.json          # Plugin version → minAppVersion map
+├── package.json           # Build scripts and dependencies
+└── packages/
+    ├── obsidian-plugin/   # Obsidian plugin (in-process MCP server)
+    │   └── src/
+    │       ├── features/  # Feature modules
+    │       └── main.ts    # Plugin entry point
+    └── shared/            # Shared utilities and types
+        └── src/
+            ├── types/     # Common interfaces
+            ├── logger.ts  # Shared logger
+            └── index.ts   # Public API
 ```
 
 ## Feature-Based Architecture
 
-The Obsidian plugin uses a feature-based architecture where each feature is a self-contained module.
+The plugin is organized by feature. Each feature is a self-contained module that sets itself up, owns its dependencies, and keeps running even if another feature fails.
 
-### Feature Structure
+Current features: core (plugin initialization and settings), mcp-transport (the in-process HTTP MCP server), mcp-tools (MCP tool handlers for vault, fetch, commands, Canvas, and more), prompts (vault-driven MCP prompts, tag-gated), semantic-search (native semantic search via Transformers.js), command-permissions (gated execution of Obsidian commands), adaptive-tool-loading (profile-based tool activation with frequency promotion), tool-toggle (enable or disable individual tools), and mcp-client-config (writes the MCP client config such as claude_desktop_config.json).
+
+### Feature Structure (convention for new features)
 
 ```
-src/features/
-├── core/                # Plugin initialization and settings
-├── mcp-tools/           # MCP tool handlers (vault, fetch, commands)
-├── mcp-transport/       # In-process HTTP MCP server
-├── prompts/             # MCP prompts (vault-driven, tag-gated)
-├── mcp-client-config/   # claude_desktop_config.json writer
-├── semantic-search/     # Native semantic search via Transformers.js
-└── migration/           # Settings migration helpers
-
-Each feature contains:
-feature/
-├── components/    # UI components
-├── services/     # Business logic
-├── types.ts      # Feature-specific types
-├── utils.ts      # Feature-specific utilities
-├── constants.ts  # Feature-specific constants
-└── index.ts      # Public API with setup function
+src/features/<feature>/
+├── components/   # UI components
+├── services/     # business logic
+├── types.ts      # feature-specific types
+├── utils.ts      # feature-specific utilities
+├── constants.ts  # feature-specific constants
+└── index.ts      # public API with a setup function
 ```
 
 ### Feature Management
 
-Each feature exports a setup function for initialization:
+Each feature exports a setup function for initialization. Features initialize independently, handle their own dependencies, continue running if other features fail, and log failures for debugging.
 
 ```typescript
 export async function setup(plugin: Plugin): Promise<SetupResult> {
@@ -69,16 +63,9 @@ export async function setup(plugin: Plugin): Promise<SetupResult> {
 }
 ```
 
-Features:
+### Settings Management
 
-- Initialize independently
-- Handle their own dependencies
-- Continue running if other features fail
-- Log failures for debugging
-
-### McpToolsPlugin Settings Management
-
-Use TypeScript module augmentation to extend the McpToolsPluginSettings interface:
+Use TypeScript module augmentation to extend the `McpToolsPluginSettings` interface:
 
 ```typescript
 // packages/obsidian-plugin/src/types.ts
@@ -104,31 +91,16 @@ declare module "obsidian" {
 }
 ```
 
-Extending the settings interface allows for type-safe access to feature settings
-via `McpToolsPlugin.loadData()` and `McpToolsPlugin.saveData()`.
+Extending the settings interface gives type-safe access to feature settings via `Plugin.loadData()` and `Plugin.saveData()`.
 
 ### Version Management
 
-Unified version approach:
-
-- Plugin and server share version number
-- Version stored in plugin manifest
-- Server binaries include version in filename
-- Version checked during initialization
+The plugin ships a single version, with no separate server binary. The version lives in the root `manifest.json` and `package.json`, `versions.json` maps each plugin version to its minimum Obsidian version, and `scripts/version.ts` bumps all three in one step.
 
 ### UI Integration
 
-The core feature provides a PluginSettingTab that:
-
-- Loads UI components from each feature
-- Maintains consistent UI organization
-- Handles conditional rendering based on feature state
+The core feature provides a `PluginSettingTab` that loads UI from each feature, keeps the settings layout consistent, and renders conditionally based on feature state.
 
 ### Error Handling
 
-Features implement consistent error handling:
-
-- Return descriptive error messages
-- Log detailed information for debugging
-- Provide user feedback via Obsidian Notice API
-- Clean up resources on failure
+Features implement consistent error handling: they return descriptive error messages, log detailed information for debugging, give the user feedback through the Obsidian Notice API, and clean up resources on failure.


### PR DESCRIPTION
Brings `docs/project-architecture.md` in line with the current codebase. The doc still described the 0.4.x layout and the retired server-binary model.

Corrections:
- Header points to README.md / CHANGELOG.md for authoritative version detail (the old pointer named CLAUDE.md / .clinerules, which are local-only and gitignored, not in the repo).
- `manifest.json` / `versions.json` / `package.json` shown at the repo root, where they actually live (the diagram had `manifest.json` under `packages/obsidian-plugin/`).
- Feature list updated to the 9 real feature modules (core, mcp-transport, mcp-tools, prompts, semantic-search, command-permissions, adaptive-tool-loading, tool-toggle, mcp-client-config). The stale `migration` entry is gone; new features since 0.4.x are in.
- `packages/shared/src` layout corrected (`types/`, `logger.ts`, `index.ts`).
- Version Management rewritten: single plugin version across root `manifest.json` / `package.json` / `versions.json` bumped by `scripts/version.ts`; the dead "server binaries include version in filename" line removed.

Kept the useful contributor guidance (setup function, settings module augmentation, error handling). Prose passed through humanize-en; Prettier clean.