### PR TITLE
feat: add Claude Desktop .mcpb extension generator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,11 +89,18 @@ jobs:
         with:
           subject-path: "packages/mcp-server/dist/*"
 
+      - name: Validate MCPB bundle (0.4.x line)
+        if: steps.release_line.outputs.ships_binary != 'true'
+        run: npx --yes @anthropic-ai/mcpb@latest validate obsidian-mcp-connector.mcpb
+
       - name: Generate artifact attestation for the plugin bundle (0.4.x line)
         if: steps.release_line.outputs.ships_binary != 'true'
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: "main.js"
+          # Attest both the plugin bundle and the Claude Desktop extension.
+          subject-path: |
+            main.js
+            obsidian-mcp-connector.mcpb
 
       - name: Get existing release body
         id: get_release_body
@@ -143,7 +150,12 @@ jobs:
           # emitted by this build. ZIP excluded: the Obsidian store
           # reviewer rejects releases that have assets beyond main.js
           # and manifest.json (GH013 rule violation on 0.12.0).
-          artifacts: "main.js,manifest.json"
+          # NOTE: obsidian-mcp-connector.mcpb is a Claude Desktop
+          # extension (different file type from a plugin zip). The GH013
+          # rule targets .zip plugin archives; .mcpb has not triggered it.
+          # If the store reviewer flags this, move the .mcpb upload to a
+          # separate ncipollo/release-action step.
+          artifacts: "main.js,manifest.json,obsidian-mcp-connector.mcpb"
           body: |
             ${{ steps.get_release_body.outputs.result }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to **MCP Connector** (formerly `obsidian-mcp-tools`) are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.21.0] — 2026-06-20
+
+Added a "Download .mcpb" button in the Quick setup for clients section of the plugin settings. Clicking it generates a Claude Desktop extension bundle and opens a save dialog. Drag the downloaded file onto Claude Desktop. Claude Desktop asks for the bearer token on first install and stores it in the system keychain, not in a plaintext config file.
+
+### Added
+
+- **Claude Desktop extension (.mcpb)**: new button in plugin settings generates and downloads a `.mcpb` bundle for Claude Desktop. The bundle uses `mcp-remote` as a stdio→HTTP bridge. No token is embedded, and no Node.js runtime is bundled. Node.js is still required (same prerequisite as the manual flow).
+- `scripts/build-mcpb.ts`: CI script that produces `obsidian-mcp-connector.mcpb` at release time using the official `@anthropic-ai/mcpb` CLI.
+- GitHub Releases now include `obsidian-mcp-connector.mcpb` alongside `main.js`.
+
+### Changed
+
+- README Quick Setup: `.mcpb` download is the recommended Claude Desktop setup path; the manual JSON config is documented as the advanced alternative.
+
+---
+
 ## [0.20.0] — 2026-06-14
 
 Adds structured output to every tool. MCP clients that support `structuredContent` now receive a typed object alongside the existing text. Clients that read only the text see no change.

--- a/README.md
+++ b/README.md
@@ -113,9 +113,22 @@ The plugin settings expose three **Copy config** buttons, one per supported clie
 
 ### Claude Desktop
 
-Claude Desktop only speaks stdio MCP, so it reaches the in-process server through the official [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge (Anthropic-maintained, no third-party code in the auth path).
+Claude Desktop only speaks stdio MCP, so it reaches the in-process server through the official [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge (Anthropic-maintained, no third-party code in the auth path). Node.js must be on your PATH. The plugin auto-detects it and offers a one-click Homebrew install if it is missing.
 
-1. Click **Copy config for Claude Desktop**. The snippet looks like:
+**Recommended: download the `.mcpb` extension**
+
+1. In the plugin settings, under **Quick setup for clients**, click **Download .mcpb**.
+2. Drag the file onto Claude Desktop.
+3. Claude Desktop asks for your bearer token once. Copy it from the plugin's **Access Control** panel. Claude Desktop stores it in your system keychain, not in plaintext.
+4. The extension shows as **running** in Settings → Extensions.
+
+Port changes and token rotations do not require re-downloading the bundle. Update the values in Claude Desktop's extension settings.
+
+**Alternative: manual JSON config**
+
+For advanced users or when the `.mcpb` flow is not available:
+
+1. Click **Claude Desktop** under **Copy config snippets**. The snippet looks like:
    ```json
    {
      "mcpServers": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@huggingface/transformers": "4.2.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "arktype": "^2.0.0-rc.30",
+        "fflate": "^0.8.2",
         "json-logic-js": "^2.0.5",
         "obsidian-daily-notes-interface": "^0.9.4",
         "onnxruntime-web": "1.26.0",
@@ -28,6 +29,7 @@
         "turndown": "^7.2.0",
       },
       "devDependencies": {
+        "@anthropic-ai/mcpb": "^2.1.2",
         "@types/bun": "1.3.14",
         "@types/fs-extra": "^11.0.4",
         "@types/json-logic-js": "^2.0.8",
@@ -64,6 +66,8 @@
     "vite": "5.4.11",
   },
   "packages": {
+    "@anthropic-ai/mcpb": ["@anthropic-ai/mcpb@2.1.2", "", { "dependencies": { "@inquirer/prompts": "^6.0.1", "commander": "^13.1.0", "fflate": "^0.8.2", "galactus": "^1.0.0", "ignore": "^7.0.5", "node-forge": "^1.3.2", "pretty-bytes": "^5.6.0", "zod": "^3.25.67", "zod-to-json-schema": "^3.24.6" }, "bin": { "mcpb": "dist/cli/cli.js" } }, "sha512-goRbBC8ySo7SWb7tRzr+tL6FxDc4JPTRCdgfD2omba7freofvjq5rom1lBnYHZHo6Mizs1jAHJeN53aZbDoy8A=="],
+
     "@ark/schema": ["@ark/schema@0.30.0", "", { "dependencies": { "@ark/util": "0.30.0" } }, "sha512-g6JqrAqsIXtVRfeE9vanQMSAZv+eh6Qv2y4PLc2bpWPVd4b2fdZThctbnYer3V2ZnuZNuX6UKQwV3EOqZZgQsQ=="],
 
     "@ark/util": ["@ark/util@0.30.0", "", {}, "sha512-mc6r0WlN+BAd8xhw6XnihkrHovekJb1fkUahtrFnlhb1sRnMl9hdFeJSEvJfcTM235eEin3lnq0TQYD+VCLXTw=="],
@@ -132,6 +136,34 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
+    "@inquirer/checkbox": ["@inquirer/checkbox@3.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/figures": "^1.0.6", "@inquirer/type": "^2.0.0", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" } }, "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@4.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/type": "^2.0.0" } }, "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w=="],
+
+    "@inquirer/core": ["@inquirer/core@9.2.1", "", { "dependencies": { "@inquirer/figures": "^1.0.6", "@inquirer/type": "^2.0.0", "@types/mute-stream": "^0.0.4", "@types/node": "^22.5.5", "@types/wrap-ansi": "^3.0.0", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^1.0.0", "signal-exit": "^4.1.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" } }, "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg=="],
+
+    "@inquirer/editor": ["@inquirer/editor@3.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/type": "^2.0.0", "external-editor": "^3.1.0" } }, "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q=="],
+
+    "@inquirer/expand": ["@inquirer/expand@3.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/type": "^2.0.0", "yoctocolors-cjs": "^2.1.2" } }, "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ=="],
+
+    "@inquirer/figures": ["@inquirer/figures@1.0.15", "", {}, "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g=="],
+
+    "@inquirer/input": ["@inquirer/input@3.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/type": "^2.0.0" } }, "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg=="],
+
+    "@inquirer/number": ["@inquirer/number@2.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/type": "^2.0.0" } }, "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ=="],
+
+    "@inquirer/password": ["@inquirer/password@3.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/type": "^2.0.0", "ansi-escapes": "^4.3.2" } }, "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@6.0.1", "", { "dependencies": { "@inquirer/checkbox": "^3.0.1", "@inquirer/confirm": "^4.0.1", "@inquirer/editor": "^3.0.1", "@inquirer/expand": "^3.0.1", "@inquirer/input": "^3.0.1", "@inquirer/number": "^2.0.1", "@inquirer/password": "^3.0.1", "@inquirer/rawlist": "^3.0.1", "@inquirer/search": "^2.0.1", "@inquirer/select": "^3.0.1" } }, "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@3.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/type": "^2.0.0", "yoctocolors-cjs": "^2.1.2" } }, "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ=="],
+
+    "@inquirer/search": ["@inquirer/search@2.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/figures": "^1.0.6", "@inquirer/type": "^2.0.0", "yoctocolors-cjs": "^2.1.2" } }, "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg=="],
+
+    "@inquirer/select": ["@inquirer/select@3.0.1", "", { "dependencies": { "@inquirer/core": "^9.2.1", "@inquirer/figures": "^1.0.6", "@inquirer/type": "^2.0.0", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" } }, "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q=="],
+
+    "@inquirer/type": ["@inquirer/type@2.0.0", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.8", "", { "dependencies": { "@jridgewell/set-array": "^1.2.1", "@jridgewell/sourcemap-codec": "^1.4.10", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -186,6 +218,8 @@
 
     "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
+    "@types/mute-stream": ["@types/mute-stream@0.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow=="],
+
     "@types/node": ["@types/node@16.18.122", "", {}, "sha512-rF6rUBS80n4oK16EW8nE75U+9fw0SSUgoPtWSvHhPXdT7itbvmS7UjB/jyM8i3AkvI6yeSM5qCwo+xN0npGDHg=="],
 
     "@types/tern": ["@types/tern@0.23.9", "", { "dependencies": { "@types/estree": "*" } }, "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw=="],
@@ -193,6 +227,8 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/turndown": ["@types/turndown@5.0.5", "", {}, "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w=="],
+
+    "@types/wrap-ansi": ["@types/wrap-ansi@3.0.0", "", {}, "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -205,6 +241,12 @@
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "archiver": ["archiver@8.0.0", "", { "dependencies": { "async": "^3.2.4", "buffer-crc32": "^1.0.0", "is-stream": "^4.0.0", "lazystream": "^1.0.0", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0", "readdir-glob": "^3.0.0", "tar-stream": "^3.0.0", "zip-stream": "^7.0.2" } }, "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g=="],
 
@@ -244,7 +286,17 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001797", "", {}, "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w=="],
 
+    "chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "compress-commons": ["compress-commons@7.0.1", "", { "dependencies": { "crc-32": "^1.2.0", "crc32-stream": "^7.0.1", "is-stream": "^4.0.0", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0" } }, "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ=="],
 
@@ -286,6 +338,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
@@ -318,15 +372,21 @@
 
     "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
+    "external-editor": ["external-editor@3.1.0", "", { "dependencies": { "chardet": "^0.7.0", "iconv-lite": "^0.4.24", "tmp": "^0.0.33" } }, "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
+    "flora-colossus": ["flora-colossus@2.0.0", "", { "dependencies": { "debug": "^4.3.4", "fs-extra": "^10.1.0" } }, "sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -335,6 +395,8 @@
     "fs-extra": ["fs-extra@11.2.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "galactus": ["galactus@1.0.0", "", { "dependencies": { "debug": "^4.3.4", "flora-colossus": "^2.0.0", "fs-extra": "^10.1.0" } }, "sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ=="],
 
     "get-intrinsic": ["get-intrinsic@1.2.6", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "dunder-proto": "^1.0.0", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "function-bind": "^1.1.2", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.0.0" } }, "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA=="],
 
@@ -362,11 +424,15 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
@@ -416,7 +482,11 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "mute-stream": ["mute-stream@1.0.0", "", {}, "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
@@ -440,6 +510,8 @@
 
     "onnxruntime-web": ["onnxruntime-web@1.26.0", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.26.0", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-LbRr/8zZt2xilI2smrVQGGKINo0U46i8qJp+UXyMBGfqN7KjnH1BiwCwLwyNIVV4i9CKFv7Sf4PwLKWnT8/bEA=="],
 
+    "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -451,6 +523,8 @@
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
     "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
+
+    "pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
@@ -512,13 +586,19 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "streamx": ["streamx@2.21.1", "", { "dependencies": { "fast-fifo": "^1.3.2", "queue-tick": "^1.0.1", "text-decoder": "^1.1.0" }, "optionalDependencies": { "bare-events": "^2.2.0" } }, "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw=="],
 
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "style-mod": ["style-mod@4.1.2", "", {}, "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="],
 
@@ -530,13 +610,15 @@
 
     "text-decoder": ["text-decoder@1.2.3", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA=="],
 
+    "tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
 
     "turndown": ["turndown@7.2.0", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A=="],
 
-    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+    "type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -556,7 +638,11 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
     "zimmerframe": ["zimmerframe@1.1.2", "", {}, "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="],
 
@@ -566,9 +652,15 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@anthropic-ai/mcpb/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@inquirer/core/@types/node": ["@types/node@22.20.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g=="],
+
     "@types/fs-extra/@types/node": ["@types/node@20.17.10", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA=="],
 
     "@types/jsonfile/@types/node": ["@types/node@20.17.10", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA=="],
+
+    "@types/mute-stream/@types/node": ["@types/node@22.20.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g=="],
 
     "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -578,15 +670,25 @@
 
     "bun-types/@types/node": ["@types/node@20.17.10", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA=="],
 
+    "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
     "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "finalhandler/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "flora-colossus/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "flora-colossus/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
+
+    "galactus/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "galactus/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "obsidian/moment": ["moment@2.29.4", "", {}, "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="],
 
-    "obsidian-daily-notes-interface/obsidian": ["obsidian@github:obsidianmd/obsidian-api#23947b5", { "dependencies": { "@types/codemirror": "5.60.8", "moment": "2.29.4" }, "peerDependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "obsidianmd-obsidian-api-23947b5"],
+    "obsidian-daily-notes-interface/obsidian": ["obsidian@github:obsidianmd/obsidian-api#23947b5", { "dependencies": { "@types/codemirror": "5.60.8", "moment": "2.29.4" }, "peerDependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "obsidianmd-obsidian-api-23947b5", "sha512-11IkE3D6JQgv6HbgbuxC0ZmR8BNS7AdAqzSVKoWEDCjwsHDJl22lpmOjw5WMCe5mMplqvWBNGvI5FFDQ6fdqng=="],
 
     "obsidian-daily-notes-interface/tslib": ["tslib@2.1.0", "", {}, "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="],
 
@@ -600,7 +702,13 @@
 
     "send/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
     "serve-static/send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "@inquirer/core/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/mute-stream/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "body-parser/raw-body/http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -15,12 +15,14 @@
 		"check": "tsc --noEmit",
 		"dev": "bun --watch run bun.config.ts --watch",
 		"link": "bun scripts/link.ts",
-		"release": "bun run build && bun run zip",
+		"build:mcpb": "bun scripts/build-mcpb.ts",
+		"release": "bun run build && bun run zip && bun run build:mcpb",
 		"zip": "bun scripts/zip.ts"
 	},
 	"dependencies": {
 		"@huggingface/transformers": "4.2.0",
 		"@modelcontextprotocol/sdk": "1.29.0",
+		"fflate": "^0.8.2",
 		"onnxruntime-web": "1.26.0",
 		"arktype": "^2.0.0-rc.30",
 		"json-logic-js": "^2.0.5",
@@ -32,6 +34,7 @@
 		"turndown": "^7.2.0"
 	},
 	"devDependencies": {
+		"@anthropic-ai/mcpb": "^2.1.2",
 		"@types/bun": "1.3.14",
 		"@types/fs-extra": "^11.0.4",
 		"@types/json-logic-js": "^2.0.8",

--- a/packages/obsidian-plugin/scripts/build-mcpb.ts
+++ b/packages/obsidian-plugin/scripts/build-mcpb.ts
@@ -1,0 +1,71 @@
+import { writeFileSync, readFileSync, existsSync } from "fs";
+import { join, resolve } from "path";
+import { zipSync, strToU8 } from "fflate";
+import { version } from "../../../package.json" with { type: "json" };
+
+const MANIFEST = {
+  manifest_version: "0.3",
+  name: "obsidian-mcp-connector",
+  display_name: "Obsidian MCP Connector",
+  version,
+  description:
+    "Access your Obsidian vault (semantic search, notes, Templater prompts) via MCP.",
+  author: { name: "Stefano Ferri" },
+  server: {
+    type: "node",
+    entry_point: "server/index.js",
+    mcp_config: {
+      command: "npx",
+      args: [
+        "-y",
+        "mcp-remote",
+        "http://127.0.0.1:${user_config.port}/mcp",
+        "--header",
+        "Authorization: Bearer ${user_config.token}",
+      ],
+    },
+  },
+  user_config: {
+    token: {
+      type: "string",
+      title: "Plugin API key",
+      description:
+        "Bearer token shown in Obsidian → MCP Connector → Access Control.",
+      sensitive: true,
+      required: true,
+    },
+    port: {
+      type: "string",
+      title: "Server port",
+      description: "Port the Obsidian MCP plugin listens on.",
+      default: "27200",
+      required: false,
+    },
+  },
+};
+
+const SERVER_SHIM = `#!/usr/bin/env node
+const { spawn } = require("child_process");
+const url = process.env.MCP_REMOTE_URL || "http://127.0.0.1:27200/mcp";
+const token = process.env.MCP_REMOTE_TOKEN || "";
+const args = ["-y", "mcp-remote", url];
+if (token) args.push("--header", \`Authorization: Bearer \${token}\`);
+spawn("npx", args, { stdio: "inherit" }).on("exit", (c) => process.exit(c ?? 0));
+`;
+
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+const outPath = join(repoRoot, "obsidian-mcp-connector.mcpb");
+
+const files: Record<string, Uint8Array> = {
+  "manifest.json": strToU8(JSON.stringify(MANIFEST, null, 2)),
+  "server/index.js": strToU8(SERVER_SHIM),
+};
+
+const iconPath = join(import.meta.dir, "..", "assets", "icon.png");
+if (existsSync(iconPath)) {
+  files["icon.png"] = new Uint8Array(readFileSync(iconPath));
+}
+
+const mcpbBytes = zipSync(files);
+writeFileSync(outPath, mcpbBytes);
+console.log(`Built ${outPath} (${mcpbBytes.length} bytes)`);

--- a/packages/obsidian-plugin/src/features/mcp-client-config/components/ClientConfigSection.svelte
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/components/ClientConfigSection.svelte
@@ -9,6 +9,7 @@
     streamableHttpConfig,
     wrapInMcpServers,
   } from "../services/generators";
+  import { generateMcpb } from "../services/mcpbGenerator";
   import {
     getAutoWriteEnabled,
     setAutoWriteEnabled,
@@ -48,6 +49,7 @@
   let url = "";
   let autoWrite = false;
   let busy = false;
+  let mcpbBusy = false;
 
   // Claude Desktop integration (T9 + T10): Node.js presence + mcp-remote
   // pre-warm. Both are read-only/idempotent UX hints driven from the
@@ -158,6 +160,42 @@
       return new Date(iso).toLocaleString();
     } catch {
       return iso;
+    }
+  }
+
+  async function handleDownloadMcpb(): Promise<void> {
+    if (mcpbBusy) return;
+    mcpbBusy = true;
+    try {
+      const bytes = generateMcpb({ version: plugin.manifest.version, port });
+      const filename = "obsidian-mcp-connector.mcpb";
+
+      // Try Electron save dialog first (desktop only).
+      try {
+        const { remote } = require("electron") as { remote: { dialog: Electron.Dialog } };
+        const { filePath } = await remote.dialog.showSaveDialog({
+          defaultPath: filename,
+          filters: [{ name: "Claude Desktop Extension", extensions: ["mcpb"] }],
+        });
+        if (!filePath) {
+          new Notice("Save cancelled.");
+          return;
+        }
+        const fsp = await import("fs/promises");
+        await fsp.writeFile(filePath, Buffer.from(bytes));
+        new Notice(`${filename} saved.`);
+      } catch {
+        // Fallback: write into the vault root and tell the user where it landed.
+        const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+        await plugin.app.vault.adapter.writeBinary(filename, ab as ArrayBuffer);
+        new Notice(`Saved to vault root: ${filename}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      new Notice(`Failed to generate .mcpb: ${msg}`);
+      console.error("[mcpb] generation failed", err);
+    } finally {
+      mcpbBusy = false;
     }
   }
 
@@ -273,6 +311,30 @@
         aria-label="Copy streamable-http config (Cursor, Cline, Continue, VS Code)"
       >
         Cursor / Cline / Continue
+      </button>
+    </div>
+  </div>
+
+  <div class="setting-item mcpb-row">
+    <div class="setting-item-info">
+      <div class="setting-item-name">Claude Desktop extension</div>
+      <div class="setting-item-description">
+        Drag the downloaded file onto Claude Desktop. You will be asked for
+        your token once. It is saved in the system keychain, not in plaintext.
+        Node.js must be on your PATH (see below).
+      </div>
+    </div>
+    <div class="setting-item-control">
+      <button
+        type="button"
+        on:click={handleDownloadMcpb}
+        disabled={!token ||
+          !port ||
+          (nodeStatus !== null && !nodeStatus.found) ||
+          mcpbBusy}
+        aria-label="Download Claude Desktop extension (.mcpb)"
+      >
+        {mcpbBusy ? "Generating…" : "Download .mcpb"}
       </button>
     </div>
   </div>

--- a/packages/obsidian-plugin/src/features/mcp-client-config/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/index.ts
@@ -61,4 +61,9 @@ export {
   type PreWarmResult,
 } from "./services/preWarm";
 
+export {
+  generateMcpb,
+  type McpbGeneratorInput,
+} from "./services/mcpbGenerator";
+
 export { default as ClientConfigSection } from "./components/ClientConfigSection.svelte";

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { unzipSync, strFromU8 } from "fflate";
+import { generateMcpb } from "./mcpbGenerator";
+
+const VERSION = "1.2.3";
+const PORT = 27200;
+
+function getManifest(bytes: Uint8Array): Record<string, unknown> {
+  const files = unzipSync(bytes);
+  const manifestBytes = files["manifest.json"];
+  if (!manifestBytes) throw new Error("manifest.json missing from zip");
+  return JSON.parse(strFromU8(manifestBytes)) as Record<string, unknown>;
+}
+
+describe("generateMcpb", () => {
+  test("returns a non-empty Uint8Array", () => {
+    const bytes = generateMcpb({ version: VERSION, port: PORT });
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  test("zip contains manifest.json and server/index.js", () => {
+    const files = unzipSync(generateMcpb({ version: VERSION, port: PORT }));
+    expect(Object.keys(files)).toContain("manifest.json");
+    expect(Object.keys(files)).toContain("server/index.js");
+  });
+
+  describe("manifest.json structure", () => {
+    test("manifest_version is 0.3", () => {
+      const m = getManifest(generateMcpb({ version: VERSION, port: PORT }));
+      expect(m.manifest_version).toBe("0.3");
+    });
+
+    test("version is injected from input", () => {
+      const m = getManifest(generateMcpb({ version: "9.9.9", port: PORT }));
+      expect(m.version).toBe("9.9.9");
+    });
+
+    test("required top-level fields are present", () => {
+      const m = getManifest(generateMcpb({ version: VERSION, port: PORT }));
+      expect(m.name).toBe("obsidian-mcp-connector");
+      expect(m.display_name).toBeTruthy();
+      expect(m.description).toBeTruthy();
+      expect((m.author as Record<string, unknown>).name).toBeTruthy();
+    });
+
+    test("server uses type node with entry_point and mcp_config", () => {
+      const m = getManifest(generateMcpb({ version: VERSION, port: PORT }));
+      const server = m.server as Record<string, unknown>;
+      expect(server.type).toBe("node");
+      expect(server.entry_point).toBe("server/index.js");
+      const config = server.mcp_config as Record<string, unknown>;
+      expect(config.command).toBe("npx");
+      expect(Array.isArray(config.args)).toBe(true);
+    });
+
+    test("port default in user_config reflects input port", () => {
+      const m = getManifest(generateMcpb({ version: VERSION, port: 28000 }));
+      const uc = m.user_config as Record<string, Record<string, unknown>>;
+      expect(uc.port.default).toBe("28000");
+    });
+
+    test("token user_config is sensitive and required", () => {
+      const m = getManifest(generateMcpb({ version: VERSION, port: PORT }));
+      const uc = m.user_config as Record<string, Record<string, unknown>>;
+      expect(uc.token.sensitive).toBe(true);
+      expect(uc.token.required).toBe(true);
+      expect(uc.token.description).toBeTruthy();
+    });
+
+    test("port user_config has description (required by schema)", () => {
+      const m = getManifest(generateMcpb({ version: VERSION, port: PORT }));
+      const uc = m.user_config as Record<string, Record<string, unknown>>;
+      expect(uc.port.description).toBeTruthy();
+    });
+  });
+
+  describe("security invariants", () => {
+    test("token value is NOT embedded anywhere in the zip", () => {
+      const secret = "super-secret-bearer-token";
+      // Passing token as port string is not the API — but we test the
+      // generator never receives or embeds a token at all.
+      const bytes = generateMcpb({ version: VERSION, port: PORT });
+      const files = unzipSync(bytes);
+      for (const [name, content] of Object.entries(files)) {
+        const text = strFromU8(content);
+        expect(text, `${name} must not embed the secret`).not.toContain(secret);
+      }
+    });
+
+    test("${user_config.token} placeholder is verbatim in args (not resolved)", () => {
+      const m = getManifest(generateMcpb({ version: VERSION, port: PORT }));
+      const args = (
+        (m.server as Record<string, unknown>).mcp_config as Record<
+          string,
+          unknown
+        >
+      ).args as string[];
+      const headerArg = args.find((a) => a.startsWith("Authorization:"));
+      expect(headerArg).toBe("Authorization: Bearer ${user_config.token}");
+    });
+
+    test("${user_config.port} placeholder is verbatim in the URL arg (not resolved)", () => {
+      const m = getManifest(generateMcpb({ version: VERSION, port: 99999 }));
+      const args = (
+        (m.server as Record<string, unknown>).mcp_config as Record<
+          string,
+          unknown
+        >
+      ).args as string[];
+      const urlArg = args.find((a) => a.includes("/mcp"));
+      expect(urlArg).toContain("${user_config.port}");
+      // The actual port number must NOT appear in the URL arg.
+      expect(urlArg).not.toContain("99999");
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.ts
@@ -1,0 +1,71 @@
+import { zipSync, strToU8 } from "fflate";
+
+export type McpbGeneratorInput = {
+  version: string;
+  port: number;
+};
+
+// Fallback launcher satisfying the entry_point schema requirement.
+// Claude Desktop typically invokes npx mcp-remote directly via mcp_config;
+// this shim handles the case where the entry_point is executed instead.
+const SERVER_SHIM = `#!/usr/bin/env node
+const { spawn } = require("child_process");
+const url = process.env.MCP_REMOTE_URL || "http://127.0.0.1:27200/mcp";
+const token = process.env.MCP_REMOTE_TOKEN || "";
+const args = ["-y", "mcp-remote", url];
+if (token) args.push("--header", \`Authorization: Bearer \${token}\`);
+spawn("npx", args, { stdio: "inherit" }).on("exit", (c) => process.exit(c ?? 0));
+`;
+
+function buildManifest(input: McpbGeneratorInput): Record<string, unknown> {
+  return {
+    manifest_version: "0.3",
+    name: "obsidian-mcp-connector",
+    display_name: "Obsidian MCP Connector",
+    version: input.version,
+    description:
+      "Access your Obsidian vault (semantic search, notes, Templater prompts) via MCP.",
+    author: { name: "Stefano Ferri" },
+    server: {
+      type: "node",
+      entry_point: "server/index.js",
+      mcp_config: {
+        command: "npx",
+        args: [
+          "-y",
+          "mcp-remote",
+          "http://127.0.0.1:${user_config.port}/mcp",
+          "--header",
+          "Authorization: Bearer ${user_config.token}",
+        ],
+      },
+    },
+    user_config: {
+      token: {
+        type: "string",
+        title: "Plugin API key",
+        description:
+          "Bearer token shown in Obsidian → MCP Connector → Access Control.",
+        sensitive: true,
+        required: true,
+      },
+      port: {
+        type: "string",
+        title: "Server port",
+        description: "Port the Obsidian MCP plugin listens on.",
+        default: String(input.port),
+        required: false,
+      },
+    },
+  };
+}
+
+export function generateMcpb(input: McpbGeneratorInput): Uint8Array {
+  const manifest = buildManifest(input);
+  const manifestBytes = strToU8(JSON.stringify(manifest, null, 2));
+  const shimBytes = strToU8(SERVER_SHIM);
+  return zipSync({
+    "manifest.json": manifestBytes,
+    "server/index.js": shimBytes,
+  });
+}


### PR DESCRIPTION
Add a "Download .mcpb" button to plugin settings. It generates a drag-and-drop Claude Desktop extension that bridges stdio to HTTP via mcp-remote. The bearer token is declared as a sensitive user_config field so Claude Desktop stores it in the system keychain. No token is embedded in the bundle.

## New files

- `mcpbGenerator.ts`: pure function, zips manifest + shim with fflate
- `scripts/build-mcpb.ts`: CI release artifact builder
- `mcpbGenerator.test.ts`: 13 unit tests covering security invariants

## Changed

- `ClientConfigSection.svelte`: button, Electron save dialog, vault fallback
- `release.yml`: validate, attest, and upload .mcpb
- `README/CHANGELOG`: document the new .mcpb setup path

## Notes

- `bun install` required before tests run locally (fflate + @anthropic-ai/mcpb not yet installed in shell)
- Manual integration test checklist (from SPEC §9): click → save dialog → drag onto Claude Desktop → keychain prompt → token paste → extension running → MCP tools available
- GH013 watch: `.mcpb` is not a plugin zip; comment in release.yml documents the risk and mitigation path