### PR TITLE
fix(nodeDetect): return npx.cmd on Windows when node found via PATH

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import os from "os";
 import {
   clearNodeDetectCache,
   detectBrew,
   detectNode,
+  getDetectedNpxPath,
   installNodeViaBrew,
   type ExecRunner,
 } from "./nodeDetect";
@@ -237,6 +239,54 @@ describe("detectNode — canonical-path fallback (launchctl PATH gotcha)", () =>
     expect(r).toEqual({ found: true, version: "20.0.0", raw: "v20.0.0\n" });
     // The full evil string is the literal argv[0] — never split by a shell.
     expect(received).toEqual({ file: evil, args: ["--version"] });
+  });
+});
+
+describe("getDetectedNpxPath", () => {
+  test("null when node was never detected", () => {
+    expect(getDetectedNpxPath()).toBeNull();
+  });
+
+  test("absolute /opt/homebrew/bin/node → /opt/homebrew/bin/npx", async () => {
+    const runner: ExecRunner = async (file) => {
+      if (file === "node") throw new Error("spawn node ENOENT");
+      if (file === "/opt/homebrew/bin/node")
+        return { stdout: "v22.3.0\n", stderr: "" };
+      throw new Error("unexpected: " + file);
+    };
+    await detectNode({
+      runner,
+      forceRefresh: true,
+      candidatePaths: ["/opt/homebrew/bin/node"],
+      pathExists: () => true,
+    });
+    expect(getDetectedNpxPath()).toBe("/opt/homebrew/bin/npx");
+  });
+
+  test("absolute Windows node.exe → npx.cmd (issue #302)", async () => {
+    const runner: ExecRunner = async (file) => {
+      if (file === "node") throw new Error("spawn node ENOENT");
+      if (file === "C:\\Program Files\\nodejs\\node.exe")
+        return { stdout: "v22.3.0\n", stderr: "" };
+      throw new Error("unexpected: " + file);
+    };
+    await detectNode({
+      runner,
+      forceRefresh: true,
+      candidatePaths: ["C:\\Program Files\\nodejs\\node.exe"],
+      pathExists: () => true,
+    });
+    expect(getDetectedNpxPath()).toBe("C:\\Program Files\\nodejs\\npx.cmd");
+  });
+
+  test("PATH-based lookup → platform-appropriate npx name", async () => {
+    const runner: ExecRunner = async () => ({
+      stdout: "v22.3.0\n",
+      stderr: "",
+    });
+    await detectNode({ runner, forceRefresh: true });
+    const expected = os.platform() === "win32" ? "npx.cmd" : "npx";
+    expect(getDetectedNpxPath()).toBe(expected);
   });
 });
 

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/nodeDetect.ts
@@ -198,7 +198,8 @@ export function getDetectedNodeBinDir(): string | null {
  */
 export function getDetectedNpxPath(): string | null {
   if (cachedNodePath === null) return null;
-  if (cachedNodePath === "node") return "npx";
+  if (cachedNodePath === "node")
+    return os.platform() === "win32" ? "npx.cmd" : "npx";
   // Replace the trailing `node` (or `node.exe`) with the npx
   // counterpart. Use a regex so we don't accidentally chop a
   // path that happens to contain "node" elsewhere.


### PR DESCRIPTION
Fixes #302.

When `node` is found via the PATH-based lookup, `cachedNodePath` is set to the bare string `"node"`. `getDetectedNpxPath()` then returned `"npx"` unconditionally, which does not resolve on Windows. The correct name is `npx.cmd`. The absolute-path branch already handled `.exe -> .cmd` correctly; this extends the same logic to the PATH case.

Adds four unit tests for `getDetectedNpxPath`: null before detection, absolute non-Windows path, absolute Windows `.exe` path, and PATH-based lookup (platform-aware expected value).