### PR TITLE
chore(.github): add FUNDING.yml with GitHub and Ko-fi sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: istefox
+ko_fi: stefox


### PR DESCRIPTION
Adds `.github/FUNDING.yml` to enable the GitHub Sponsors button on the repo page.

Configured platforms:
- GitHub: `istefox`
- Ko-fi: `stefox`