### PR TITLE
docs: add POST-only bridge workaround for Windows mcp-remote hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,12 @@ You can export the current buffer as CSV via the **Export CSV** button at the to
 - **Fix**: fully quit Claude Desktop (Cmd+Q on macOS) and reopen it. Claude Desktop only re-reads `claude_desktop_config.json` at launch, so closing the window or an in-app restart is not enough. With auto-write on (the default) the plugin keeps the config in sync afterward.
 - Still failing? Confirm the port in `claude_desktop_config.json` (`http://127.0.0.1:<port>/mcp`) matches the port the plugin logs on start (Settings, **Open Logs**), and make sure only one Obsidian vault has the plugin enabled (two instances contend for the port). Then fully restart Claude Desktop again.
 
+### Claude Desktop hangs ~60s on Windows, then "Could not attach to MCP server"
+
+- **Symptom**: on Windows, the connection starts, the logs show the `initialize` request sent, then 60 seconds of silence and a timeout. Reproducible across restarts and across different MCP servers on the same machine.
+- **Cause**: a bug in the `mcp-remote` bridge on Windows, not in the plugin. Claude Code over direct HTTP is unaffected.
+- **Fix**: replace `mcp-remote` with the POST-only bridge in [`scripts/obsidian_mcp_bridge.py`](scripts/obsidian_mcp_bridge.py). See [docs/windows-post-only-bridge.md](docs/windows-post-only-bridge.md) for the setup.
+
 ### `tool/call` returns HTTP 401
 
 - The bearer token in your client config does not match the plugin's current token. Open the plugin settings, **Bearer token**, click **Show** to reveal the current token and **Copy** to copy it. Update your client config and restart the client.

--- a/docs/windows-post-only-bridge.md
+++ b/docs/windows-post-only-bridge.md
@@ -1,0 +1,42 @@
+# Windows workaround: POST-only bridge
+
+On some Windows setups, Claude Desktop fails to connect to the plugin through `mcp-remote`. The connection starts, the `initialize` request is sent, and then nothing happens for 60 seconds until it times out with "Could not attach to MCP server". The plugin and its HTTP server are fine: Claude Code connects over direct HTTP without trouble, and the same `mcp-remote` hang reproduces against unrelated MCP servers on the same machine. The fault is in the `mcp-remote` bridge on Windows, not in the plugin.
+
+`scripts/obsidian_mcp_bridge.py` replaces `mcp-remote` with a small bridge that speaks to the plugin over POST only. It never opens the GET stream that triggers the hang. It uses the Python standard library, so there is nothing to install beyond Python itself.
+
+## Requirements
+
+- Python 3.8 or newer on PATH (`python --version`).
+- The plugin running in Obsidian, with its bearer token and port from the plugin settings.
+
+## Setup
+
+1. Save `obsidian_mcp_bridge.py` somewhere stable, for example `C:\Users\you\obsidian_mcp_bridge.py`.
+2. Open the plugin settings and copy the bearer token and the port (the URL is `http://127.0.0.1:<port>/mcp`).
+3. Edit `claude_desktop_config.json` to launch the bridge instead of `mcp-remote`:
+
+```json
+{
+  "mcpServers": {
+    "obsidian": {
+      "command": "python",
+      "args": ["C:\\Users\\you\\obsidian_mcp_bridge.py", "http://127.0.0.1:27200/mcp"],
+      "env": { "OBSIDIAN_BEARER_TOKEN": "paste-your-token-here" }
+    }
+  }
+}
+```
+
+4. Fully quit Claude Desktop and reopen it. It only reads the config at launch.
+
+## Checking it works
+
+Ask Claude to list your vault files. If the tools respond, the bridge is working. The bridge writes a short line to Claude Desktop's MCP log on start (`[obsidian-bridge] started`), and reports the negotiated protocol after the first `initialize`.
+
+## Limits
+
+The bridge carries requests and responses, which covers every tool call and prompt. It does not carry server-initiated notifications, because the plugin's stateless server never sends any. This is the same trade-off the plugin already makes for `mcp-remote` (the `tools/list_changed` notification is best-effort).
+
+## When you can drop it
+
+Once `mcp-remote` ships a fix for the Windows hang, the standard setup in the README works again and you can switch `claude_desktop_config.json` back to `mcp-remote`.

--- a/scripts/obsidian_mcp_bridge.py
+++ b/scripts/obsidian_mcp_bridge.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""POST-only stdio bridge for the Obsidian MCP Connector plugin.
+
+A drop-in replacement for mcp-remote on setups where mcp-remote hangs on
+`initialize` (observed on Windows: the client times out after 60s because the
+GET SSE stream mcp-remote opens never settles). This bridge talks to the
+plugin's local HTTP server using POST requests only, so it never opens that
+stream.
+
+The plugin's server is stateless and answers each POST with a single JSON
+response (it sends no server-initiated messages), so a plain request/response
+loop is all that is needed. Standard library only, no pip install.
+
+Usage (claude_desktop_config.json):
+
+    {
+      "mcpServers": {
+        "obsidian": {
+          "command": "python",
+          "args": ["C:\\\\path\\\\to\\\\obsidian_mcp_bridge.py", "http://127.0.0.1:27200/mcp"],
+          "env": { "OBSIDIAN_BEARER_TOKEN": "your-token-here" }
+        }
+      }
+    }
+
+The token can also be passed as a second argument instead of the env var, but
+the env var keeps it out of the process list.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+PROTOCOL_VERSION_FALLBACK = "2025-06-18"
+
+
+def log(msg):
+    # stderr only: stdout is the JSON-RPC channel the MCP client reads.
+    print(f"[obsidian-bridge] {msg}", file=sys.stderr, flush=True)
+
+
+def emit_error(req_id, code, msg):
+    error = {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": msg}}
+    sys.stdout.write(json.dumps(error) + "\n")
+    sys.stdout.flush()
+
+
+def main():
+    if len(sys.argv) < 2:
+        log("missing server URL argument")
+        sys.exit(1)
+    url = sys.argv[1]
+    token = sys.argv[2] if len(sys.argv) > 2 else os.environ.get("OBSIDIAN_BEARER_TOKEN", "")
+    if not token:
+        log("no bearer token (pass as 2nd arg or set OBSIDIAN_BEARER_TOKEN)")
+        sys.exit(1)
+
+    negotiated_version = {"value": None}
+
+    def post(message):
+        body = json.dumps(message).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "Authorization": f"Bearer {token}",
+        }
+        # After initialize, the spec asks clients to echo the negotiated version.
+        if negotiated_version["value"]:
+            headers["MCP-Protocol-Version"] = negotiated_version["value"]
+        req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read()
+
+    log(f"started, target={url}")
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            log(f"skipping non-JSON line: {line[:80]}")
+            continue
+
+        is_request = "id" in message and message["id"] is not None
+        try:
+            status, raw = post(message)
+        except urllib.error.URLError as err:
+            log(f"POST failed: {err}")
+            if is_request:
+                emit_error(message["id"], -32000, f"bridge POST failed: {err}")
+            continue
+
+        if not is_request:
+            # Notification: the stateless server replies 202 with no body.
+            continue
+
+        if not raw:
+            emit_error(message["id"], -32000, f"empty response (HTTP {status})")
+            continue
+        try:
+            response = json.loads(raw.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            emit_error(message["id"], -32000, f"non-JSON response (HTTP {status})")
+            continue
+
+        if message.get("method") == "initialize":
+            result = response.get("result") or {}
+            negotiated_version["value"] = result.get("protocolVersion") or PROTOCOL_VERSION_FALLBACK
+            log(f"initialized, protocol={negotiated_version['value']}")
+
+        sys.stdout.write(json.dumps(response) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a Python POST-only bridge (`scripts/obsidian_mcp_bridge.py`) that replaces mcp-remote for Windows users hitting the 60-second initialize hang (#300), plus a setup guide (`docs/windows-post-only-bridge.md`) and a README troubleshooting pointer.

## Why

The 0.21.5 405/GET fix does not resolve the Windows hang. The reporter confirmed 0.21.5 is the loaded build and it still hangs, with the Obsidian console silent throughout. A local repro shows mcp-remote 0.1.37 completing the initialize handshake against an identical stateless server in milliseconds on macOS, so the defect is in mcp-remote on Windows, not the plugin. The bridge talks POST only, so it never opens the GET stream that triggers the hang.

## Testing

- Repro server mirroring the 0.21.5 config (stateless StreamableHTTPServerTransport, enableJsonResponse, POST-only with 405 on GET) against mcp-remote 0.1.37: handshake completes on macOS in about 3 ms.
- Bridge driven with initialize, notifications/initialized, tools/list, tools/call: every request answered with a result, the notification correctly produces no stdout.
- `python3 -m py_compile` passes.

Refs #300