### PR TITLE
fix(semantic-search): only index .md files in the live path (#323)

### DIFF
--- a/packages/obsidian-plugin/src/features/semantic-search/services/productionWiring.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/productionWiring.test.ts
@@ -146,28 +146,30 @@ describe("probeAndWipeStaleStores", () => {
 });
 
 describe("isIndexableFile", () => {
-  // Construye un objeto que pasa `instanceof TFile` (el mock de obsidian
-  // enlaza el prototipo) con una `extension` explícita, sin depender de
-  // MockTFile.
+  // Builds an object that passes `instanceof TFile` (the obsidian mock
+  // wires up the prototype) with an explicit `extension`, without
+  // depending on MockTFile.
   function fakeTFile(path: string, extension: string): TFile {
     const f = Object.create(TFile.prototype) as TFile;
     Object.assign(f, { path, extension });
     return f;
   }
 
-  test("acepta un TFile .md", () => {
-    expect(isIndexableFile(fakeTFile("Notas/a.md", "md"))).toBe(true);
+  test("accepts a .md TFile", () => {
+    expect(isIndexableFile(fakeTFile("Notes/a.md", "md"))).toBe(true);
   });
 
-  test("rechaza un TFile .pdf", () => {
-    expect(isIndexableFile(fakeTFile("Adjuntos/doc.pdf", "pdf"))).toBe(false);
+  test("rejects a .pdf TFile", () => {
+    expect(isIndexableFile(fakeTFile("Attachments/doc.pdf", "pdf"))).toBe(
+      false,
+    );
   });
 
-  test("rechaza un TFile .canvas", () => {
-    expect(isIndexableFile(fakeTFile("mapa.canvas", "canvas"))).toBe(false);
+  test("rejects a .canvas TFile", () => {
+    expect(isIndexableFile(fakeTFile("map.canvas", "canvas"))).toBe(false);
   });
 
-  test("rechaza algo que no es TFile", () => {
+  test("rejects something that is not a TFile", () => {
     expect(isIndexableFile({ path: "x.md", extension: "md" })).toBe(false);
     expect(isIndexableFile(null)).toBe(false);
   });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/productionWiring.test.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/productionWiring.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { probeAndWipeStaleStores } from "./productionWiring";
+import { isIndexableFile, probeAndWipeStaleStores } from "./productionWiring";
 import { createEmbeddingStoreRegistry } from "./storeRegistry";
 import { FORMAT_VERSION, type VaultAdapter } from "./store";
+import { TFile } from "obsidian";
 
 /** In-memory adapter tracking text + binary files and remove() calls. */
 function memAdapter() {
@@ -141,5 +142,33 @@ describe("probeAndWipeStaleStores", () => {
     expect(
       await mem.adapter.exists(`${BASE}/embedding-gemma-300m/embeddings.bin`),
     ).toBe(false);
+  });
+});
+
+describe("isIndexableFile", () => {
+  // Construye un objeto que pasa `instanceof TFile` (el mock de obsidian
+  // enlaza el prototipo) con una `extension` explícita, sin depender de
+  // MockTFile.
+  function fakeTFile(path: string, extension: string): TFile {
+    const f = Object.create(TFile.prototype) as TFile;
+    Object.assign(f, { path, extension });
+    return f;
+  }
+
+  test("acepta un TFile .md", () => {
+    expect(isIndexableFile(fakeTFile("Notas/a.md", "md"))).toBe(true);
+  });
+
+  test("rechaza un TFile .pdf", () => {
+    expect(isIndexableFile(fakeTFile("Adjuntos/doc.pdf", "pdf"))).toBe(false);
+  });
+
+  test("rechaza un TFile .canvas", () => {
+    expect(isIndexableFile(fakeTFile("mapa.canvas", "canvas"))).toBe(false);
+  });
+
+  test("rechaza algo que no es TFile", () => {
+    expect(isIndexableFile({ path: "x.md", extension: "md" })).toBe(false);
+    expect(isIndexableFile(null)).toBe(false);
   });
 });

--- a/packages/obsidian-plugin/src/features/semantic-search/services/productionWiring.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/productionWiring.ts
@@ -42,10 +42,11 @@ import { makeChunkerForProvider } from "./chunker";
 import type { ExcerptResolver } from "./nativeProvider";
 
 /**
- * El camino Live de indexación debe ver el MISMO conjunto de archivos que
- * el rebuild (`vault.getMarkdownFiles()`): solo `.md`. Sin esta guarda, un
- * `create`/`modify` de un PDF u otro adjunto se reenvía al indexer, que lo
- * lee como UTF-8 y lo vectoriza como basura (pico de CPU + índice sucio).
+ * The live indexing path must see the SAME set of files as the rebuild
+ * (`vault.getMarkdownFiles()`): only `.md`. Without this guard, a
+ * `create`/`modify` for a PDF or other attachment is forwarded to the
+ * indexer, which reads it as UTF-8 and embeds it as garbage (CPU spike +
+ * polluted index).
  */
 export function isIndexableFile(f: unknown): f is TFile {
   return f instanceof TFile && f.extension === "md";

--- a/packages/obsidian-plugin/src/features/semantic-search/services/productionWiring.ts
+++ b/packages/obsidian-plugin/src/features/semantic-search/services/productionWiring.ts
@@ -41,6 +41,16 @@ import {
 import { makeChunkerForProvider } from "./chunker";
 import type { ExcerptResolver } from "./nativeProvider";
 
+/**
+ * El camino Live de indexación debe ver el MISMO conjunto de archivos que
+ * el rebuild (`vault.getMarkdownFiles()`): solo `.md`. Sin esta guarda, un
+ * `create`/`modify` de un PDF u otro adjunto se reenvía al indexer, que lo
+ * lee como UTF-8 y lo vectoriza como basura (pico de CPU + índice sucio).
+ */
+export function isIndexableFile(f: unknown): f is TFile {
+  return f instanceof TFile && f.extension === "md";
+}
+
 export async function wireSemanticSearch(
   plugin: McpToolsPlugin,
 ): Promise<SemanticSearchState | undefined> {
@@ -80,7 +90,7 @@ export async function wireSemanticSearch(
           on: (event: string, handler: (f: unknown) => void) => EventRef;
         }
       ).on(event, (f: unknown) => {
-        if (f instanceof TFile) handler(f.path);
+        if (isIndexableFile(f)) handler(f.path);
       });
       return () => plugin.app.vault.offref(ref);
     },


### PR DESCRIPTION
## Pull Request Description
Fixes #323.

The semantic search **live indexer** forwarded every `TFile` from the vault `create`/`modify`/`delete` events, while the rebuild and low‑power paths only iterate `vault.getMarkdownFiles()` (markdown only). Because of that asymmetry, adding a PDF (or any attachment) fired a `create` event, got read as UTF‑8 via `vault.read()`, chunked, and embedded by the configured provider — a large CPU spike in the renderer (heavy with native providers like EmbeddingGemma 300M) and junk binary chunks polluting the index queried by `search_vault_smart`.

This change gates the live event wrapper so it mirrors `getMarkdownFiles()`: only `.md` files reach the indexer. The guard is extracted into a small exported, type‑narrowing predicate `isIndexableFile(f): f is TFile` so it can be unit‑tested in isolation (the wrapper itself is a closure inside the wiring setup).

Out of scope (noted in #323 as possible follow‑ups): purging non‑`.md` chunks already on disk, and real PDF support via text extraction.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing
**How has this been tested?**
- [x] Local unit tests (`packages/obsidian-plugin`): added 4 tests for `isIndexableFile` in `productionWiring.test.ts` (accepts `.md`; rejects `.pdf`, `.canvas`, and non‑`TFile`); file suite 8/8 passing.
- Full package suite (`bun test`) passes apart from one pre‑existing, environment‑related failure unrelated to this change.
- The fix is a pure predicate wired into the existing event guard; no behavior outside the live `.md` filter changes.

> Manual in‑vault reproduction and MCP/Claude Desktop integration were not re‑run for this PR — the change is isolated and covered by unit tests.

## Architecture Compliance
- [x] Follows feature-based architecture patterns (lives in the existing `semantic-search` feature)
- [x] Implements proper error handling (no error paths added; existing behavior preserved)
- [x] Follows coding standards in `.clinerules`

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Security Considerations
- [x] No hardcoded secrets or API keys
- [x] No new security vulnerabilities introduced
- [x] Follows minimum permission principles

## Additional Context
Related issue: #323. Consistency precedent with #238 (live path matching the markdown set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
