### PR TITLE
feat(mcp): reliable activate_tool (list_changed delivery, batch activation, settings promote picker)

### DIFF
--- a/packages/obsidian-plugin/src/composeToolRegistry.ts
+++ b/packages/obsidian-plugin/src/composeToolRegistry.ts
@@ -60,17 +60,21 @@ export async function composeToolRegistry(
   toolRegistry.register(toolCatalogSchema, () =>
     toolCatalogHandler({ registry: toolRegistry, plugin: config.plugin }),
   );
-  toolRegistry.register(activateToolSchema, async (request, { server }) =>
-    activateToolHandler({
-      arguments: (request as { arguments: { name: string; persist?: boolean } })
-        .arguments,
-      registry: toolRegistry,
-      plugin: config.plugin,
-      server,
-      onActivated: (name) =>
-        new Notice(`MCP Connector: "${name}" promoted to active`),
-      enableInRegistry: (name) => toolRegistry.enableByName(name),
-    }),
+  toolRegistry.register(
+    activateToolSchema,
+    async (request, { server, sendNotification }) =>
+      activateToolHandler({
+        arguments: (
+          request as { arguments: { name: string; persist?: boolean } }
+        ).arguments,
+        registry: toolRegistry,
+        plugin: config.plugin,
+        server,
+        onActivated: (name) =>
+          new Notice(`MCP Connector: "${name}" promoted to active`),
+        enableInRegistry: (name) => toolRegistry.enableByName(name),
+        sendNotification,
+      }),
   );
 
   // Adaptive profile filter (All/Core/Adaptive) runs before toolToggle

--- a/packages/obsidian-plugin/src/composeToolRegistry.ts
+++ b/packages/obsidian-plugin/src/composeToolRegistry.ts
@@ -29,6 +29,10 @@ import {
   activateToolSchema,
   activateToolHandler,
 } from "$/features/mcp-tools/tools/activateTool";
+import {
+  activateToolsSchema,
+  activateToolsHandler,
+} from "$/features/mcp-tools/tools/activateTools";
 
 export type ToolRegistryConfig = {
   app: App;
@@ -66,6 +70,22 @@ export async function composeToolRegistry(
       activateToolHandler({
         arguments: (
           request as { arguments: { name: string; persist?: boolean } }
+        ).arguments,
+        registry: toolRegistry,
+        plugin: config.plugin,
+        server,
+        onActivated: (name) =>
+          new Notice(`MCP Connector: "${name}" promoted to active`),
+        enableInRegistry: (name) => toolRegistry.enableByName(name),
+        sendNotification,
+      }),
+  );
+  toolRegistry.register(
+    activateToolsSchema,
+    async (request, { server, sendNotification }) =>
+      activateToolsHandler({
+        arguments: (
+          request as { arguments: { names: string[]; persist?: boolean } }
         ).arguments,
         registry: toolRegistry,
         plugin: config.plugin,

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/applyAdaptiveFilter.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { applyAdaptiveFilter } from "./applyAdaptiveFilter";
-import {
-  ADAPTIVE_META_TOOLS,
-  ALWAYS_ACTIVE_TOOLS,
-  META_TOOLS,
-} from "./constants";
+import { ALWAYS_ACTIVE_TOOLS, META_TOOLS } from "./constants";
 
 type FakeEntry = { name: string; description: string; enabled: boolean };
 
@@ -57,18 +53,15 @@ describe("applyAdaptiveFilter", () => {
     expect(registry._disabled()).toHaveLength(0);
   });
 
-  test("core profile: tool_catalog stays enabled, activate_tool is disabled", async () => {
+  test("core profile: meta-tools stay enabled, non-core domain tools disabled", async () => {
     const registry = makeRegistry(ALL_TOOLS);
     const plugin = makePlugin({ profile: "core", counters: {}, promoted: [] });
     await applyAdaptiveFilter(registry, plugin);
 
-    // tool_catalog always active
+    // Meta-tools (tool_catalog AND activate_tool) are never disabled, even
+    // in core — demoting activate_tool would make promotion impossible.
     for (const m of ALWAYS_ACTIVE_TOOLS) {
       expect(registry._disabled()).not.toContain(m);
-    }
-    // activate_tool must be disabled in core
-    for (const m of ADAPTIVE_META_TOOLS) {
-      expect(registry._disabled()).toContain(m);
     }
     // Non-core domain tools must be disabled
     expect(registry._disabled()).toContain("search_and_replace");

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/components/AdaptiveToolLoadingSettings.svelte
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/components/AdaptiveToolLoadingSettings.svelte
@@ -5,6 +5,7 @@
   import { globalSettingsMutex } from "$/features/command-permissions";
   import { ToolLoadingManager } from "../toolLoadingManager";
   import type { ToolLoadingState } from "../toolLoadingManager";
+  import { CORE_SET, META_TOOLS } from "../constants";
 
   export let plugin: McpToolsPlugin;
 
@@ -13,14 +14,41 @@
   let busy = false;
   let mounted = false;
 
+  // All registered tool names, read from the live registry when the MCP
+  // server is up. Empty when the server has not started yet (settings
+  // opened before connect): the manual picker then shows a hint.
+  let allToolNames: string[] = [];
+  let selected = "";
+
   const mgr = new ToolLoadingManager();
+
+  // Tools the user can usefully promote: everything except meta-tools and
+  // core-set tools (always active anyway) and those already promoted.
+  $: alwaysActive = new Set<string>([...META_TOOLS, ...CORE_SET]);
+  $: promotable = allToolNames
+    .filter((n) => !alwaysActive.has(n) && !promoted.includes(n))
+    .sort((a, b) => a.localeCompare(b));
 
   onMount(async () => {
     const state = await mgr.loadState(plugin);
     profile = state.profile;
     promoted = state.promoted;
+    const registry = plugin.mcpTransportState?.mcp.registry;
+    allToolNames = registry ? registry.listAll().map((t) => t.name) : [];
     mounted = true;
   });
+
+  async function addPromoted(name: string): Promise<void> {
+    if (!name) return;
+    busy = true;
+    try {
+      await mgr.activateTool(name, allToolNames, plugin);
+      promoted = [...promoted, name];
+      selected = "";
+    } finally {
+      busy = false;
+    }
+  }
 
   async function persist(patch: Partial<ToolLoadingState>): Promise<void> {
     busy = true;
@@ -108,10 +136,35 @@
         <p class="section-label">
           Promoted tools
           <span class="muted"
-            >— auto-promoted after {3} calls, or activated via
-            <code>activate_tool</code></span
+            >— auto-promoted after {3} calls, activated via
+            <code>activate_tool</code>, or added here</span
           >
         </p>
+
+        {#if allToolNames.length === 0}
+          <p class="muted empty-hint">
+            Connect an MCP client once so the tool list is available, then
+            reopen settings to add tools here.
+          </p>
+        {:else if promotable.length > 0}
+          <div class="add-row">
+            <select bind:value={selected} disabled={busy} aria-label="Tool to promote">
+              <option value="" disabled selected>Add a tool…</option>
+              {#each promotable as name (name)}
+                <option value={name}>{name}</option>
+              {/each}
+            </select>
+            <button
+              type="button"
+              on:click={() => void addPromoted(selected)}
+              disabled={busy || !selected}
+              aria-label="Add selected tool to promoted"
+            >
+              Add
+            </button>
+          </div>
+        {/if}
+
         {#if promoted.length === 0}
           <p class="muted empty-hint">
             No promoted tools yet. Use a non-core tool 3 times in Adaptive mode
@@ -193,6 +246,18 @@
     background: var(--background-secondary);
     border-radius: 4px;
     margin-bottom: 0.8em;
+  }
+
+  .add-row {
+    display: flex;
+    gap: 0.5em;
+    align-items: center;
+    margin-bottom: 0.6em;
+  }
+
+  .add-row select {
+    flex: 1;
+    min-width: 0;
   }
 
   .promoted-list {

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/components/AdaptiveToolLoadingSettings.svelte
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/components/AdaptiveToolLoadingSettings.svelte
@@ -89,9 +89,9 @@
   <h3>Tool Loading</h3>
   <p class="description">
     Control which MCP tools are loaded at connect time. "All tools" (default)
-    preserves current behavior. "Core set" loads ~13 frequently-used tools.
-    "Adaptive" starts from the core set and adds tools you use often or
-    activate explicitly via <code>activate_tool</code>.
+    loads every tool. "Core set" loads ~13 essential tools plus any you
+    promote below. "Adaptive" is the core set plus your promotions, and also
+    auto-promotes tools you use often.
   </p>
 
   {#if mounted}
@@ -131,13 +131,14 @@
       </label>
     </div>
 
-    {#if profile === "adaptive"}
+    {#if profile !== "all"}
       <div class="promoted-section">
         <p class="section-label">
           Promoted tools
           <span class="muted"
-            >— auto-promoted after {3} calls, activated via
-            <code>activate_tool</code>, or added here</span
+            >— added here, via <code>activate_tool</code>, or auto-promoted
+            after {3} calls (Adaptive only). Active at connect time in both
+            Core and Adaptive.</span
           >
         </p>
 

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/constants.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/constants.ts
@@ -14,6 +14,7 @@ export const PROMOTION_THRESHOLD = 3;
 export const ALWAYS_ACTIVE_TOOLS: readonly string[] = [
   "tool_catalog",
   "activate_tool",
+  "activate_tools",
 ];
 
 /** Combined set used for promotion-exclusion checks in recordCall. */

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/constants.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/constants.ts
@@ -1,16 +1,23 @@
 export const PROMOTION_THRESHOLD = 3;
 
-/** Always active regardless of profile — informational, no side effects. */
-export const ALWAYS_ACTIVE_TOOLS: readonly string[] = ["tool_catalog"];
-
-/** Active only in adaptive and all profiles — can expand the tool surface. */
-export const ADAPTIVE_META_TOOLS: readonly string[] = ["activate_tool"];
+/**
+ * Meta-tools that are always active regardless of profile and can never be
+ * demoted.
+ *
+ * `activate_tool` MUST be here: it is the only in-band promotion mechanism,
+ * so demoting it (as the `core` profile used to) makes promotion impossible
+ * — an inactive tool cannot activate other tools, a circular dead end where
+ * `tool_catalog` advertises a tool as promotable but the promotion call
+ * returns "Unknown tool: activate_tool". `tool_catalog` is here so the
+ * catalog itself is always discoverable.
+ */
+export const ALWAYS_ACTIVE_TOOLS: readonly string[] = [
+  "tool_catalog",
+  "activate_tool",
+];
 
 /** Combined set used for promotion-exclusion checks in recordCall. */
-export const META_TOOLS: readonly string[] = [
-  ...ALWAYS_ACTIVE_TOOLS,
-  ...ADAPTIVE_META_TOOLS,
-];
+export const META_TOOLS: readonly string[] = [...ALWAYS_ACTIVE_TOOLS];
 
 export const CORE_SET: readonly string[] = [
   "get_server_info",

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
@@ -273,6 +273,50 @@ describe("loadState", () => {
   });
 });
 
+describe("activateTools (batch)", () => {
+  const ALL = ["a", "b", "c", "d"];
+
+  test("promotes several unknown-free names in one write", async () => {
+    const plugin = makePlugin();
+    const out = await mgr.activateTools(["b", "c"], ALL, plugin);
+    expect(out).toEqual({ b: "activated", c: "activated" });
+    const state = plugin._store().toolLoading as { promoted: string[] };
+    expect(state.promoted).toEqual(["b", "c"]);
+  });
+
+  test("reports already_active and not_found, persists only new ones", async () => {
+    const plugin = makePlugin({
+      toolLoading: { profile: "adaptive", counters: {}, promoted: ["b"] },
+    });
+    const out = await mgr.activateTools(["b", "c", "zzz"], ALL, plugin);
+    expect(out).toEqual({
+      b: "already_active",
+      c: "activated",
+      zzz: "not_found",
+    });
+    const state = plugin._store().toolLoading as { promoted: string[] };
+    expect(state.promoted).toEqual(["b", "c"]);
+  });
+
+  test("no-op batch (all already promoted or unknown) does not write", async () => {
+    const plugin = makePlugin({
+      toolLoading: { profile: "adaptive", counters: {}, promoted: ["b"] },
+    });
+    const before = JSON.stringify(plugin._store());
+    const out = await mgr.activateTools(["b", "zzz"], ALL, plugin);
+    expect(out).toEqual({ b: "already_active", zzz: "not_found" });
+    expect(JSON.stringify(plugin._store())).toBe(before);
+  });
+
+  test("dedupes repeated names", async () => {
+    const plugin = makePlugin();
+    const out = await mgr.activateTools(["b", "b"], ALL, plugin);
+    expect(out).toEqual({ b: "activated" });
+    const state = plugin._store().toolLoading as { promoted: string[] };
+    expect(state.promoted).toEqual(["b"]);
+  });
+});
+
 // Smoke-test: CORE_SET contains only real tool names
 describe("CORE_SET", () => {
   test("all core tools are known names (sanity check)", () => {

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { ToolLoadingManager } from "./toolLoadingManager";
 import {
-  ADAPTIVE_META_TOOLS,
   ALWAYS_ACTIVE_TOOLS,
   CORE_SET,
   META_TOOLS,
@@ -42,16 +41,14 @@ describe("getActiveToolNames", () => {
     }
   });
 
-  test("core profile: returns CORE_SET plus tool_catalog only", () => {
+  test("core profile: returns CORE_SET plus the always-active meta-tools", () => {
     const state = { profile: "core" as const, counters: {}, promoted: [] };
     const active = mgr.getActiveToolNames(ALL_NAMES, state);
-    // tool_catalog always active
+    // Meta-tools (tool_catalog AND activate_tool) are always active, even in
+    // core — otherwise promotion is impossible (an inactive activate_tool
+    // cannot promote anything).
     for (const m of ALWAYS_ACTIVE_TOOLS) {
       expect(active.has(m)).toBe(true);
-    }
-    // activate_tool must NOT be active in core
-    for (const m of ADAPTIVE_META_TOOLS) {
-      expect(active.has(m)).toBe(false);
     }
     // Non-core, non-meta tools must be inactive
     expect(active.has("search_and_replace")).toBe(false);
@@ -74,7 +71,7 @@ describe("getActiveToolNames", () => {
     }
   });
 
-  test("tool_catalog always active regardless of profile", () => {
+  test("meta-tools always active regardless of profile", () => {
     for (const profile of ["all", "core", "adaptive"] as const) {
       const state = { profile, counters: {}, promoted: [] };
       const active = mgr.getActiveToolNames(ALL_NAMES, state);
@@ -84,19 +81,11 @@ describe("getActiveToolNames", () => {
     }
   });
 
-  test("activate_tool active for all and adaptive profiles, not core", () => {
-    for (const profile of ["all", "adaptive"] as const) {
-      const state = { profile, counters: {}, promoted: [] };
-      const active = mgr.getActiveToolNames(ALL_NAMES, state);
-      for (const m of ADAPTIVE_META_TOOLS) {
-        expect(active.has(m)).toBe(true);
-      }
-    }
+  test("activate_tool is active even in core (promotion is not self-blocking)", () => {
     const coreState = { profile: "core" as const, counters: {}, promoted: [] };
     const coreActive = mgr.getActiveToolNames(ALL_NAMES, coreState);
-    for (const m of ADAPTIVE_META_TOOLS) {
-      expect(coreActive.has(m)).toBe(false);
-    }
+    expect(coreActive.has("activate_tool")).toBe(true);
+    expect(coreActive.has("tool_catalog")).toBe(true);
   });
 });
 

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.test.ts
@@ -81,6 +81,18 @@ describe("getActiveToolNames", () => {
     }
   });
 
+  test("core profile honors explicit promotions (survive reconnect)", () => {
+    const state = {
+      profile: "core" as const,
+      counters: {},
+      promoted: ["search_and_replace"],
+    };
+    const active = mgr.getActiveToolNames(ALL_NAMES, state);
+    expect(active.has("search_and_replace")).toBe(true);
+    // Still no auto-promotion in core: an un-promoted non-core tool stays off.
+    expect(active.has("find_broken_links")).toBe(false);
+  });
+
   test("activate_tool is active even in core (promotion is not self-blocking)", () => {
     const coreState = { profile: "core" as const, counters: {}, promoted: [] };
     const coreActive = mgr.getActiveToolNames(ALL_NAMES, coreState);

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
@@ -46,9 +46,12 @@ export class ToolLoadingManager {
     }
     const base = new Set<string>(ALWAYS_ACTIVE_TOOLS);
     for (const n of CORE_SET) base.add(n);
-    if (state.profile === "adaptive") {
-      for (const n of state.promoted) base.add(n);
-    }
+    // Explicit promotions are honored in BOTH core and adaptive: a tool the
+    // user (or `activate_tool`/`activate_tools`) promoted with persist must
+    // survive a reconnect regardless of profile. The only core/adaptive
+    // difference is auto-promotion by frequency, which lives in recordCall
+    // and stays adaptive-only.
+    for (const n of state.promoted) base.add(n);
     return base;
   }
 

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
@@ -93,6 +93,48 @@ export class ToolLoadingManager {
     return outcome;
   }
 
+  /**
+   * Batch variant of {@link activateTool}: promote several tools in ONE
+   * settings write instead of N. Unknown names (not in `allNames`) are
+   * reported back and not persisted. Returns the per-name outcome so the
+   * caller can build a summary.
+   */
+  async activateTools(
+    names: string[],
+    allNames: string[],
+    plugin: PluginDataLike,
+  ): Promise<Record<string, "activated" | "already_active" | "not_found">> {
+    const known = new Set(allNames);
+    const outcomes: Record<
+      string,
+      "activated" | "already_active" | "not_found"
+    > = {};
+    // Dedupe input while preserving first-seen order.
+    const requested = [...new Set(names)];
+
+    await new SettingsStore(plugin).updateSlice(SLICE, (current) => {
+      const state = mergeState(current);
+      const promotedSet = new Set(state.promoted);
+      const toAdd: string[] = [];
+      for (const name of requested) {
+        if (!known.has(name)) {
+          outcomes[name] = "not_found";
+        } else if (promotedSet.has(name)) {
+          outcomes[name] = "already_active";
+        } else {
+          outcomes[name] = "activated";
+          promotedSet.add(name);
+          toAdd.push(name);
+        }
+      }
+      if (toAdd.length === 0) return current; // NO_CHANGE: no write
+      state.promoted = [...state.promoted, ...toAdd];
+      return state;
+    });
+
+    return outcomes;
+  }
+
   async deactivateTool(name: string, plugin: PluginDataLike): Promise<void> {
     await new SettingsStore(plugin).updateSlice(SLICE, (current) => {
       const state = mergeState(current);

--- a/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
+++ b/packages/obsidian-plugin/src/features/adaptive-tool-loading/toolLoadingManager.ts
@@ -1,7 +1,6 @@
 import { SettingsStore } from "$/shared/settingsStore";
 import type { PluginDataLike } from "$/shared/types";
 import {
-  ADAPTIVE_META_TOOLS,
   ALWAYS_ACTIVE_TOOLS,
   CORE_SET,
   META_TOOLS,
@@ -48,7 +47,6 @@ export class ToolLoadingManager {
     const base = new Set<string>(ALWAYS_ACTIVE_TOOLS);
     for (const n of CORE_SET) base.add(n);
     if (state.profile === "adaptive") {
-      for (const n of ADAPTIVE_META_TOOLS) base.add(n);
       for (const n of state.promoted) base.add(n);
     }
     return base;

--- a/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
@@ -115,4 +115,10 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
     idempotentHint: true,
     openWorldHint: false,
   },
+  activate_tools: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
 };

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.test.ts
@@ -131,6 +131,27 @@ describe("activateToolHandler", () => {
     expect(activated).toEqual(["find_broken_links"]);
   });
 
+  test("uses request-scoped sendNotification when provided, not the raw fallback", async () => {
+    const plugin = makePlugin();
+    const { server, notifications } = makeServer();
+    const scoped: string[] = [];
+    const result = await activateToolHandler({
+      arguments: { name: "find_broken_links" },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: () => true,
+      sendNotification: async (n) => {
+        scoped.push(n.method);
+      },
+    });
+    expect(result.isError).toBeUndefined();
+    // The scoped sender (relatedRequestId-tagged) is used...
+    expect(scoped).toEqual(["notifications/tools/list_changed"]);
+    // ...and the raw server.notification fallback is NOT.
+    expect(notifications).toHaveLength(0);
+  });
+
   test("notification failure is swallowed and activation still succeeds", async () => {
     const plugin = makePlugin();
     const server = {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTool.ts
@@ -24,6 +24,7 @@ export async function activateToolHandler({
   server,
   onActivated,
   enableInRegistry,
+  sendNotification,
 }: {
   arguments: { name: string; persist?: boolean };
   registry: RegistryLike;
@@ -31,6 +32,16 @@ export async function activateToolHandler({
   server: McpServer;
   onActivated?: (toolName: string) => void;
   enableInRegistry?: (name: string) => boolean;
+  /**
+   * Request-scoped notification sender (from the SDK handler's `extra`).
+   * When present it tags the notification with the current request's
+   * `relatedRequestId`, so `tools/list_changed` rides back on this call's
+   * POST response stream and the client re-lists without a reconnect.
+   */
+  sendNotification?: (notification: {
+    method: string;
+    params?: Record<string, unknown>;
+  }) => Promise<void>;
 }): Promise<{
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
@@ -63,11 +74,21 @@ export async function activateToolHandler({
   }
 
   try {
-    await server.server.notification({
-      method: "notifications/tools/list_changed",
-    });
+    // Prefer the request-scoped sender: it tags relatedRequestId so the
+    // notification is delivered on THIS call's POST response stream (the
+    // transport switches that response to SSE for activate_tool). The raw
+    // server.notification fallback goes to the standalone GET stream, which
+    // is blocked here, so it is a no-op — kept only so callers that don't
+    // thread sendNotification keep the prior behavior.
+    if (sendNotification) {
+      await sendNotification({ method: "notifications/tools/list_changed" });
+    } else {
+      await server.server.notification({
+        method: "notifications/tools/list_changed",
+      });
+    }
   } catch {
-    // Stateless JSON transport may not support server-initiated notifications.
+    // Transport may not support server-initiated notifications on this path.
     // Clients pick up the change on their next tools/list request.
   }
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTools.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTools.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { activateToolsHandler } from "./activateTools";
+
+function makeRegistry(
+  entries: { name: string; enabled: boolean }[],
+): Parameters<typeof activateToolsHandler>[0]["registry"] {
+  return {
+    listAll: () =>
+      entries.map((e) => ({
+        name: e.name,
+        description: `${e.name} description`,
+        enabled: e.enabled,
+      })),
+  };
+}
+
+function makePlugin() {
+  let store: Record<string, unknown> = {};
+  return {
+    loadData: async () => ({ ...store }),
+    saveData: async (d: unknown) => {
+      store = { ...(d as Record<string, unknown>) };
+    },
+    _store: () => store,
+  };
+}
+
+function makeServer(): { server: McpServer; notifications: string[] } {
+  const notifications: string[] = [];
+  const server = {
+    server: {
+      notification: async (n: { method: string }) => {
+        notifications.push(n.method);
+      },
+    },
+  } as unknown as McpServer;
+  return { server, notifications };
+}
+
+const ENTRIES = [
+  { name: "search_vault", enabled: true },
+  { name: "find_broken_links", enabled: false },
+  { name: "rename_vault_file", enabled: false },
+];
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text) as {
+    requested: number;
+    activated: number;
+    outcomes: Record<string, string>;
+    persisted?: boolean;
+  };
+}
+
+describe("activateToolsHandler", () => {
+  test("activates several inactive tools with a SINGLE notification", async () => {
+    const plugin = makePlugin();
+    const enabled: string[] = [];
+    const { server, notifications } = makeServer();
+    const result = await activateToolsHandler({
+      arguments: { names: ["find_broken_links", "rename_vault_file"] },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: (n) => (enabled.push(n), true),
+    });
+    const out = parse(result);
+    expect(out.activated).toBe(2);
+    expect(out.outcomes).toEqual({
+      find_broken_links: "activated",
+      rename_vault_file: "activated",
+    });
+    expect(enabled).toEqual(["find_broken_links", "rename_vault_file"]);
+    // Exactly one list_changed for the whole batch.
+    expect(notifications).toEqual(["notifications/tools/list_changed"]);
+  });
+
+  test("reports already_active and not_found per name", async () => {
+    const plugin = makePlugin();
+    const { server } = makeServer();
+    const result = await activateToolsHandler({
+      arguments: {
+        names: ["search_vault", "find_broken_links", "does_not_exist"],
+      },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: () => true,
+    });
+    const out = parse(result);
+    expect(out.outcomes).toEqual({
+      search_vault: "already_active",
+      find_broken_links: "activated",
+      does_not_exist: "not_found",
+    });
+    expect(out.activated).toBe(1);
+  });
+
+  test("no-op batch fires no notification and writes nothing", async () => {
+    const plugin = makePlugin();
+    const { server, notifications } = makeServer();
+    const result = await activateToolsHandler({
+      arguments: { names: ["search_vault"], persist: true },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: () => true,
+    });
+    expect(parse(result).activated).toBe(0);
+    expect(notifications).toHaveLength(0);
+    expect(plugin._store().toolLoading).toBeUndefined();
+  });
+
+  test("persist=true writes all newly-activated names in one slice", async () => {
+    const plugin = makePlugin();
+    const { server } = makeServer();
+    await activateToolsHandler({
+      arguments: {
+        names: ["find_broken_links", "rename_vault_file"],
+        persist: true,
+      },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: () => true,
+    });
+    const state = plugin._store().toolLoading as { promoted: string[] };
+    expect(state.promoted).toEqual(["find_broken_links", "rename_vault_file"]);
+  });
+
+  test("uses request-scoped sendNotification once, not the raw fallback", async () => {
+    const plugin = makePlugin();
+    const { server, notifications } = makeServer();
+    const scoped: string[] = [];
+    await activateToolsHandler({
+      arguments: { names: ["find_broken_links", "rename_vault_file"] },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: () => true,
+      sendNotification: async (n) => {
+        scoped.push(n.method);
+      },
+    });
+    expect(scoped).toEqual(["notifications/tools/list_changed"]);
+    expect(notifications).toHaveLength(0);
+  });
+
+  test("dedupes repeated names in the input", async () => {
+    const plugin = makePlugin();
+    const enabled: string[] = [];
+    const { server } = makeServer();
+    const result = await activateToolsHandler({
+      arguments: {
+        names: ["find_broken_links", "find_broken_links"],
+      },
+      registry: makeRegistry(ENTRIES),
+      plugin,
+      server,
+      enableInRegistry: (n) => (enabled.push(n), true),
+    });
+    expect(parse(result).activated).toBe(1);
+    expect(enabled).toEqual(["find_broken_links"]);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTools.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/activateTools.ts
@@ -1,0 +1,106 @@
+import { type } from "arktype";
+import { successText } from "../services/responseBuilders";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolLoadingManager } from "$/features/adaptive-tool-loading/toolLoadingManager";
+import type { PluginDataLike } from "$/shared/types";
+import type { RegistryLike } from "$/features/adaptive-tool-loading/types";
+
+export const activateToolsSchema = type({
+  name: '"activate_tools"',
+  arguments: {
+    names: type("string[]").describe(
+      "Exact names of the tools to activate, in one batch.",
+    ),
+    "persist?": type("boolean").describe(
+      "If true, write the promotions to data.json so they survive plugin reloads. Defaults to false (in-memory until the plugin reloads, available immediately).",
+    ),
+  },
+}).describe(
+  "Promotes several inactive tools to active status in ONE call. Prefer this over multiple `activate_tool` calls when a task needs more than one inactive tool: it activates them all and refreshes the client's tool list only once, instead of once per tool. Run `tool_catalog` first to see available tool names. With persist=true the promotions survive plugin reloads.",
+);
+
+type Outcome = "activated" | "already_active" | "not_found";
+
+export async function activateToolsHandler({
+  arguments: args,
+  registry,
+  plugin,
+  server,
+  onActivated,
+  enableInRegistry,
+  sendNotification,
+}: {
+  arguments: { names: string[]; persist?: boolean };
+  registry: RegistryLike;
+  plugin: PluginDataLike;
+  server: McpServer;
+  onActivated?: (toolName: string) => void;
+  enableInRegistry?: (name: string) => boolean;
+  sendNotification?: (notification: {
+    method: string;
+    params?: Record<string, unknown>;
+  }) => Promise<void>;
+}): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const allEntries = registry.listAll();
+  const byName = new Map(allEntries.map((e) => [e.name, e]));
+  // Dedupe while preserving first-seen order.
+  const requested = [...new Set(args.names)];
+
+  const outcomes: Record<string, Outcome> = {};
+  const activated: string[] = [];
+
+  for (const name of requested) {
+    const entry = byName.get(name);
+    if (!entry) {
+      outcomes[name] = "not_found";
+    } else if (entry.enabled) {
+      outcomes[name] = "already_active";
+    } else {
+      outcomes[name] = "activated";
+      activated.push(name);
+      onActivated?.(name);
+      enableInRegistry?.(name);
+    }
+  }
+
+  // Persist only the newly-activated tools, in a single write.
+  if (args.persist === true && activated.length > 0) {
+    const allNames = allEntries.map((e) => e.name);
+    await new ToolLoadingManager().activateTools(activated, allNames, plugin);
+  }
+
+  // One notification for the whole batch — the whole point of this tool.
+  // Only fire when something actually changed, so a no-op batch does not
+  // trigger a needless client re-list. Prefer the request-scoped sender so
+  // the notification rides the POST response stream (see activateTool.ts).
+  if (activated.length > 0) {
+    try {
+      if (sendNotification) {
+        await sendNotification({ method: "notifications/tools/list_changed" });
+      } else {
+        await server.server.notification({
+          method: "notifications/tools/list_changed",
+        });
+      }
+    } catch {
+      // Transport may not support server-initiated notifications on this
+      // path. Clients pick up the change on their next tools/list request.
+    }
+  }
+
+  const summary = {
+    requested: requested.length,
+    activated: activated.length,
+    outcomes,
+    ...(args.persist === true ? { persisted: activated.length > 0 } : {}),
+    note:
+      activated.length > 0
+        ? "Activated tools are available immediately."
+        : "No changes: all requested tools were already active or unknown.",
+  };
+
+  return successText(JSON.stringify(summary));
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -107,6 +107,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         .sort();
       expect(names).toEqual([
         "activate_tool",
+        "activate_tools",
         "add_canvas_node",
         "append_to_active_file",
         "append_to_periodic_note",
@@ -155,7 +156,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "tool_catalog",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(48);
+      expect(names).toHaveLength(49);
 
       // Annotations completeness: every exposed tool must carry MCP
       // annotations with an explicit readOnlyHint and openWorldHint.

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -17,6 +17,8 @@ import {
   META_TOOLS,
 } from "$/features/adaptive-tool-loading";
 import { composeToolRegistry } from "$/composeToolRegistry";
+import { MAX_REQUEST_BODY_BYTES } from "../constants";
+import { bodyTargetsActivateTool, readBodyWithCap } from "./parseRequestBody";
 
 export type McpServiceConfig = {
   app: App;
@@ -88,16 +90,26 @@ export async function createMcpService(
     // Server so tools/list and tools/call go through our boolean
     // coercion + error formatting + disableByName support.
     server.server.setRequestHandler(ListToolsRequestSchema, registry.list);
-    server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const result = await registry.dispatch(request.params, { server });
-      // Record the call for frequency-based promotion (meta-tools are excluded).
-      if (!(META_TOOLS as string[]).includes(request.params.name)) {
-        toolLoadingManager
-          .recordCall(request.params.name, config.plugin)
-          .catch(() => {});
-      }
-      return result;
-    });
+    server.server.setRequestHandler(
+      CallToolRequestSchema,
+      async (request, extra) => {
+        // Pass the SDK's request-scoped sendNotification down to the
+        // handler. activate_tool uses it so its tools/list_changed carries
+        // this call's relatedRequestId and is flushed on the POST response
+        // stream (which is SSE for activate_tool — see below).
+        const result = await registry.dispatch(request.params, {
+          server,
+          sendNotification: extra.sendNotification,
+        });
+        // Record the call for frequency-based promotion (meta-tools are excluded).
+        if (!(META_TOOLS as string[]).includes(request.params.name)) {
+          toolLoadingManager
+            .recordCall(request.params.name, config.plugin)
+            .catch(() => {});
+        }
+        return result;
+      },
+    );
     server.server.setRequestHandler(
       ListPromptsRequestSchema,
       promptRegistry.list,
@@ -106,16 +118,40 @@ export async function createMcpService(
       promptRegistry.dispatch(req.params),
     );
 
-    // Stateless mode (no sessionIdGenerator) + JSON response. Per-
-    // request transport — see file header for the SDK constraint.
+    // Inspect the body before choosing the response mode. The GET SSE
+    // stream is blocked (POST-only transport), so a server-initiated
+    // notification has nowhere to go — EXCEPT the response stream of the
+    // request that triggers it. activate_tool must therefore answer with
+    // SSE so its tools/list_changed is flushed on this call's stream and
+    // the client re-lists without a reconnect. Every other request keeps
+    // the default JSON response (Windows/mcp-remote path unchanged).
+    const rawBody = await readBodyWithCap(req, MAX_REQUEST_BODY_BYTES);
+    let parsedBody: unknown;
+    let isActivateTool = false;
+    if (rawBody !== null) {
+      try {
+        parsedBody = JSON.parse(rawBody);
+        isActivateTool = bodyTargetsActivateTool(parsedBody);
+      } catch {
+        // Malformed JSON: leave parsedBody undefined and let the SDK emit
+        // the standard -32700 parse error over the JSON response path.
+        parsedBody = undefined;
+      }
+    }
+
+    // Stateless mode (no sessionIdGenerator). Per-request transport — see
+    // file header for the SDK constraint. JSON response by default; SSE
+    // only for activate_tool so its notification can be delivered.
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
-      enableJsonResponse: true,
+      enableJsonResponse: !isActivateTool,
     });
 
     try {
       await server.connect(transport);
-      await transport.handleRequest(req, res);
+      // Pass the pre-parsed body so the SDK does not re-read the drained
+      // stream (readBodyWithCap already consumed it).
+      await transport.handleRequest(req, res, parsedBody);
     } finally {
       // Best-effort cleanup. If close() throws (e.g. transport
       // already closed by the SDK), log and swallow so the next

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/parseRequestBody.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/parseRequestBody.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { bodyTargetsActivateTool } from "./parseRequestBody";
+
+const activateCall = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "tools/call",
+  params: { name: "activate_tool", arguments: { name: "get_backlinks" } },
+};
+
+const otherCall = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "tools/call",
+  params: { name: "list_vault_files", arguments: {} },
+};
+
+describe("bodyTargetsActivateTool", () => {
+  test("true for a single activate_tool call", () => {
+    expect(bodyTargetsActivateTool(activateCall)).toBe(true);
+  });
+
+  test("false for a different tools/call", () => {
+    expect(bodyTargetsActivateTool(otherCall)).toBe(false);
+  });
+
+  test("false for a non tools/call method", () => {
+    expect(
+      bodyTargetsActivateTool({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    ).toBe(false);
+  });
+
+  test("true when a batch contains an activate_tool call", () => {
+    expect(bodyTargetsActivateTool([otherCall, activateCall])).toBe(true);
+  });
+
+  test("false when a batch has no activate_tool call", () => {
+    expect(bodyTargetsActivateTool([otherCall, otherCall])).toBe(false);
+  });
+
+  test("false for a notification with no params", () => {
+    expect(
+      bodyTargetsActivateTool({ jsonrpc: "2.0", method: "tools/call" }),
+    ).toBe(false);
+  });
+
+  test("false for null / non-object bodies", () => {
+    expect(bodyTargetsActivateTool(null)).toBe(false);
+    expect(bodyTargetsActivateTool("nope")).toBe(false);
+    expect(bodyTargetsActivateTool(42)).toBe(false);
+  });
+
+  test("false for params without a name", () => {
+    expect(
+      bodyTargetsActivateTool({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { arguments: {} },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/parseRequestBody.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/parseRequestBody.test.ts
@@ -20,6 +20,17 @@ describe("bodyTargetsActivateTool", () => {
     expect(bodyTargetsActivateTool(activateCall)).toBe(true);
   });
 
+  test("true for a batch activate_tools call", () => {
+    expect(
+      bodyTargetsActivateTool({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "activate_tools", arguments: { names: ["a", "b"] } },
+      }),
+    ).toBe(true);
+  });
+
   test("false for a different tools/call", () => {
     expect(bodyTargetsActivateTool(otherCall)).toBe(false);
   });

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/parseRequestBody.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/parseRequestBody.ts
@@ -1,11 +1,19 @@
 import type { IncomingMessage } from "node:http";
 
 /**
- * Whether a parsed JSON-RPC request body targets the `activate_tool` tool.
+ * Tools whose handler emits `notifications/tools/list_changed`. A call to
+ * one of these must get an SSE response so the notification can ride back
+ * on its own POST stream (see mcpServer.ts / activateTool.ts).
+ */
+const ACTIVATION_TOOLS = new Set(["activate_tool", "activate_tools"]);
+
+/**
+ * Whether a parsed JSON-RPC request body targets a tool-activation call
+ * (`activate_tool` or `activate_tools`).
  *
  * Accepts either a single JSON-RPC request object or a batch array, and
- * returns true if ANY member is a `tools/call` whose `params.name` is
- * `activate_tool`. Everything else (notifications, responses, other tool
+ * returns true if ANY member is a `tools/call` whose `params.name` is an
+ * activation tool. Everything else (notifications, responses, other tool
  * calls, malformed shapes) returns false.
  *
  * Used by the transport to decide whether the response must be delivered
@@ -20,7 +28,8 @@ export function bodyTargetsActivateTool(parsed: unknown): boolean {
     if (msg.method !== "tools/call") return false;
     const params = msg.params;
     if (typeof params !== "object" || params === null) return false;
-    return (params as { name?: unknown }).name === "activate_tool";
+    const name = (params as { name?: unknown }).name;
+    return typeof name === "string" && ACTIVATION_TOOLS.has(name);
   });
 }
 

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/parseRequestBody.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/parseRequestBody.ts
@@ -1,0 +1,67 @@
+import type { IncomingMessage } from "node:http";
+
+/**
+ * Whether a parsed JSON-RPC request body targets the `activate_tool` tool.
+ *
+ * Accepts either a single JSON-RPC request object or a batch array, and
+ * returns true if ANY member is a `tools/call` whose `params.name` is
+ * `activate_tool`. Everything else (notifications, responses, other tool
+ * calls, malformed shapes) returns false.
+ *
+ * Used by the transport to decide whether the response must be delivered
+ * as SSE (so the `notifications/tools/list_changed` the handler emits can
+ * ride back on the same POST stream) instead of the default JSON mode.
+ */
+export function bodyTargetsActivateTool(parsed: unknown): boolean {
+  const messages = Array.isArray(parsed) ? parsed : [parsed];
+  return messages.some((m) => {
+    if (typeof m !== "object" || m === null) return false;
+    const msg = m as { method?: unknown; params?: unknown };
+    if (msg.method !== "tools/call") return false;
+    const params = msg.params;
+    if (typeof params !== "object" || params === null) return false;
+    return (params as { name?: unknown }).name === "activate_tool";
+  });
+}
+
+/**
+ * Read an IncomingMessage body into a UTF-8 string, aborting once more
+ * than `cap` bytes have arrived.
+ *
+ * `httpServer.ts` only rejects oversize bodies via the declared
+ * Content-Length; a chunked request with no length still reaches here, so
+ * we re-cap while buffering. Returns `null` when the cap is exceeded (the
+ * caller falls back to the SDK's own parser + JSON response) so a hostile
+ * payload never accumulates unbounded in the renderer.
+ *
+ * Precondition: the stream must not have been consumed yet. The caller
+ * passes the parsed result back to `transport.handleRequest(req, res,
+ * parsedBody)` so the SDK does not attempt to re-read the drained stream.
+ */
+export async function readBodyWithCap(
+  req: IncomingMessage,
+  cap: number,
+): Promise<string | null> {
+  return new Promise<string | null>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let aborted = false;
+
+    req.on("data", (chunk: Buffer) => {
+      if (aborted) return;
+      total += chunk.length;
+      if (total > cap) {
+        aborted = true;
+        resolve(null);
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (!aborted) resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    req.on("error", (err) => {
+      if (!aborted) reject(err);
+    });
+  });
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
@@ -11,6 +11,17 @@ import { logger } from "$/shared";
 
 interface HandlerContext {
   server: McpServer;
+  /**
+   * SDK-provided notification sender, bound to the current request so the
+   * message carries its `relatedRequestId` and is delivered on the POST
+   * response stream (see mcpServer.ts). Optional: absent for callers that
+   * don't thread it, in which case handlers fall back to a raw
+   * server-initiated notification.
+   */
+  sendNotification?: (notification: {
+    method: string;
+    params?: Record<string, unknown>;
+  }) => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## What

Two commits that make progressive tool disclosure usable through real MCP clients.

**dfff164: fix `activate_tool` and deliver `list_changed`**
- `activate_tool` was filtered out in the `core` profile, a circular dead end: an inactive tool cannot activate tools. It is now always active in every profile.
- Its `tools/list_changed` notification went to the blocked GET SSE stream and was dropped. The `activate_tool` response now uses SSE (only that call; other responses stay JSON) so the notification rides its own POST response stream. A client that re-lists then sees the promotion without a reconnect.

**5c0860b: batch `activate_tools` and settings promote picker**
- New `activate_tools(names[])` meta-tool activates a batch in one call and emits a single `list_changed`, instead of one client re-list per `activate_tool`.
- Settings promote picker: add tools to the adaptive `promoted` set from the MCP Connector settings, so a working set is active at connect time and no mid-session activation is needed.

## Why

On a real vault the server executes every tool in about 0.0s, measured by direct curl (including `find_broken_links` and 8 concurrent `activate_tool` calls). The blocks users hit were server-availability windows during Obsidian restarts (`ECONNREFUSED`, masked by the client's 4-minute timeout) and client-side re-list churn when the agent activates many tools one at a time. These changes let a user pre-load a working set from settings and collapse dynamic activation into one call, which removes the churn.

## Verification
- `bun run check`, `bun test` (1311 pass), `bun run build`.
- Server-side curl: `activate_tool` returns `text/event-stream` with the `list_changed` event, validated end-to-end through mcp-remote (Claude Desktop re-lists after the notification).

## Notes
Related: issue #326 closed as not planned (not a server-side handler bug).
