### PR TITLE
feat(mcp-transport): make serverInfo.name configurable

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-transport/components/AccessControlSection.svelte
+++ b/packages/obsidian-plugin/src/features/mcp-transport/components/AccessControlSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type McpToolsPlugin from "$/main";
   import { Notice } from "obsidian";
+  import { onMount } from "svelte";
   import {
     setup as mcpTransportSetup,
     teardown as mcpTransportTeardown,
@@ -9,6 +10,7 @@
   import { BIND_HOST, MCP_PATH_PREFIX } from "$/features/mcp-transport/constants";
   import { applyAutoWrite } from "$/features/mcp-client-config";
   import { globalSettingsMutex } from "$/features/command-permissions";
+  import { SettingsStore } from "$/shared/settingsStore";
 
   export let plugin: McpToolsPlugin;
 
@@ -19,6 +21,66 @@
 
   let showToken = false;
   let busy = false;
+
+  // The configured (possibly blank) server-name override, read from
+  // data.json on mount. Blank means "use the computed default" — see
+  // resolveServerName in services/setup.ts.
+  let serverNameInput = "";
+  let serverNameBusy = false;
+
+  onMount(async () => {
+    const raw = (await new SettingsStore(plugin).readSlice("mcpTransport")) as
+      | { serverName?: string }
+      | undefined;
+    serverNameInput = raw?.serverName ?? "";
+  });
+
+  /**
+   * Persist the server-name override and restart the transport so the
+   * next MCP `initialize` handshake reports it (see issue #329).
+   *
+   * Mirrors handleRegenerate(): persist → teardown → setup → update
+   * local/plugin state.
+   */
+  async function handleSaveServerName(): Promise<void> {
+    serverNameBusy = true;
+    try {
+      const trimmed = serverNameInput.trim();
+      await globalSettingsMutex.run(async () => {
+        const data = ((await plugin.loadData()) ?? {}) as Record<
+          string,
+          unknown
+        >;
+        const existing = (data.mcpTransport ?? {}) as Record<string, unknown>;
+        await plugin.saveData({
+          ...data,
+          mcpTransport: { ...existing, serverName: trimmed },
+        });
+      });
+
+      if (plugin.mcpTransportState) {
+        await mcpTransportTeardown(plugin.mcpTransportState);
+        plugin.mcpTransportState = undefined;
+      }
+
+      const result = await mcpTransportSetup(plugin);
+      if (!result.success) {
+        new Notice(`MCP Connector: failed to restart — ${result.error}`);
+        return;
+      }
+
+      plugin.mcpTransportState = result.state;
+      bearerToken = result.state.bearerToken;
+      port = result.state.server.port;
+      serverNameInput = trimmed;
+      new Notice("Server name saved.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      new Notice(`MCP Connector: failed to save server name — ${message}`);
+    } finally {
+      serverNameBusy = false;
+    }
+  }
 
   /**
    * Copy a string value to the clipboard and show a brief Notice.
@@ -173,6 +235,32 @@
       </div>
     </div>
   </div>
+
+  <div class="setting-item">
+    <div class="setting-item-info">
+      <div class="setting-item-name">Server name</div>
+      <div class="setting-item-description">
+        Shown as this server's identity in MCP clients that list multiple
+        servers. Leave blank to use "Obsidian - &lt;vault name&gt;".
+      </div>
+    </div>
+    <div class="setting-item-control token-control">
+      <input
+        type="text"
+        bind:value={serverNameInput}
+        placeholder="Obsidian - {plugin.app.vault.getName()}"
+        aria-label="Server name"
+        class="server-name-input"
+      />
+      <button
+        type="button"
+        on:click={handleSaveServerName}
+        disabled={serverNameBusy}
+      >
+        {serverNameBusy ? "Saving…" : "Save"}
+      </button>
+    </div>
+  </div>
 </div>
 
 <style>
@@ -198,6 +286,11 @@
     color: var(--text-muted);
     font-size: 0.9em;
     font-style: italic;
+  }
+
+  .server-name-input {
+    flex: 1;
+    min-width: 180px;
   }
 
   code {

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -5,6 +5,7 @@ import {
   destroyMcpService,
   type McpService,
 } from "./mcpServer";
+import { resolveServerName } from "./setup";
 
 beforeEach(() => resetMockVault());
 
@@ -19,6 +20,7 @@ describe("createMcpService", () => {
       app: mockApp(),
       plugin: mockPlugin(),
       pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
     });
     active.push(svc);
     expect(typeof svc.handleRequest).toBe("function");
@@ -32,6 +34,7 @@ describe("end-to-end: HTTP → McpServer", () => {
       app: mockApp(),
       plugin: mockPlugin(),
       pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
     });
     active.push(svc);
 
@@ -72,6 +75,7 @@ describe("end-to-end: HTTP → McpServer", () => {
       app: mockApp(),
       plugin: mockPlugin(),
       pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
     });
     active.push(svc);
 
@@ -135,6 +139,7 @@ describe("end-to-end: HTTP → McpServer", () => {
       app: mockApp(),
       plugin: mockPlugin(),
       pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
     });
     active.push(svc);
 
@@ -245,6 +250,7 @@ describe("end-to-end: HTTP → McpServer", () => {
       app: mockApp(),
       plugin: mockPlugin(),
       pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
     });
     active.push(svc);
 
@@ -289,6 +295,7 @@ describe("end-to-end: HTTP → McpServer", () => {
       app: mockApp(),
       plugin: mockPlugin(),
       pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
     });
     active.push(svc);
 
@@ -331,5 +338,103 @@ describe("end-to-end: HTTP → McpServer", () => {
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }
+  });
+
+  test("initialize reports the configured serverInfo.name", async () => {
+    const { startHttpServer } = await import("./httpServer");
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin: mockPlugin(),
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "Obsidian - Test Vault",
+    });
+    active.push(svc);
+
+    const server = await startHttpServer({
+      bearerToken: "t".repeat(32),
+      requestHandler: svc.handleRequest,
+    });
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${"t".repeat(32)}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "0.0.0" },
+          },
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body?.result?.serverInfo?.name).toBe("Obsidian - Test Vault");
+    } finally {
+      await new Promise<void>((r) => server.server.close(() => r()));
+    }
+  });
+
+  test("initialize reports a custom serverInfo.name override", async () => {
+    const { startHttpServer } = await import("./httpServer");
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin: mockPlugin(),
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "My Custom Name",
+    });
+    active.push(svc);
+
+    const server = await startHttpServer({
+      bearerToken: "t".repeat(32),
+      requestHandler: svc.handleRequest,
+    });
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${"t".repeat(32)}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "0.0.0" },
+          },
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body?.result?.serverInfo?.name).toBe("My Custom Name");
+    } finally {
+      await new Promise<void>((r) => server.server.close(() => r()));
+    }
+  });
+});
+
+describe("resolveServerName", () => {
+  test('falls back to "Obsidian - <vault name>" when unset, empty, or whitespace-only', () => {
+    const app = mockApp();
+    expect(resolveServerName(app, undefined)).toBe("Obsidian - Test Vault");
+    expect(resolveServerName(app, "")).toBe("Obsidian - Test Vault");
+    expect(resolveServerName(app, "   ")).toBe("Obsidian - Test Vault");
+  });
+
+  test("uses the configured name, trimmed", () => {
+    const app = mockApp();
+    expect(resolveServerName(app, "  Foo  ")).toBe("Foo");
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -24,6 +24,8 @@ export type McpServiceConfig = {
   app: App;
   plugin: McpToolsPlugin;
   pluginVersion: string;
+  /** Reported as `serverInfo.name` in the MCP `initialize` handshake (see issue #329). */
+  serverName: string;
 };
 
 export type McpService = {
@@ -71,7 +73,7 @@ export async function createMcpService(
   ): Promise<void> => {
     const server = new McpServer(
       {
-        name: "mcp-connector",
+        name: config.serverName,
         version: config.pluginVersion,
       },
       {

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/setup.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/setup.ts
@@ -1,3 +1,4 @@
+import type { App } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import { SettingsStore } from "$/shared/settingsStore";
 import { logger } from "$/shared";
@@ -22,6 +23,21 @@ export type McpTransportState = {
 export type SetupResult =
   | { success: true; state: McpTransportState }
   | { success: false; error: string };
+
+/**
+ * Resolve the effective MCP `serverInfo.name` reported during the
+ * `initialize` handshake: the user's configured value if non-blank,
+ * else "Obsidian - <vault name>" so multi-vault setups are
+ * distinguishable in MCP clients that display this field verbatim
+ * (see issue #329).
+ */
+export function resolveServerName(
+  app: App,
+  configured: string | undefined,
+): string {
+  const trimmed = configured?.trim();
+  return trimmed ? trimmed : `Obsidian - ${app.vault.getName()}`;
+}
 
 /**
  * Initialize the MCP HTTP transport for the plugin.
@@ -61,10 +77,19 @@ export async function setup(plugin: McpToolsPlugin): Promise<SetupResult> {
       return current; // NO_CHANGE: keep the existing valid token
     });
 
+    const mcpTransportSlice = (await new SettingsStore(plugin).readSlice(
+      "mcpTransport",
+    )) as { serverName?: string } | undefined;
+    const serverName = resolveServerName(
+      plugin.app,
+      mcpTransportSlice?.serverName,
+    );
+
     const mcp = await createMcpService({
       app: plugin.app,
       plugin,
       pluginVersion: plugin.manifest.version,
+      serverName,
     });
     const server = await startHttpServer({
       bearerToken,

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -988,6 +988,7 @@ import type {
 
 export function mockApp(): App {
   const vault = {
+    getName: (): string => "Test Vault",
     getAbstractFileByPath: (path: string): TAbstractFile | null => {
       const f = fileFromPath(path);
       if (f) return f as unknown as TAbstractFile;


### PR DESCRIPTION
## Summary
- The MCP `initialize` handshake reported a fixed "mcp-connector" name. Clients that aggregate multiple servers into one list (VS Code, Continue.dev) show this field verbatim instead of the user's own client-side label, so multi-vault setups showed indistinguishable entries.
- Settings now expose a "Server name" field under Access Control, defaulting to "Obsidian - <vault name>" when left blank.

Closes #329

## Test plan
- [x] `bun run check` (type-check, both packages)
- [x] `bun test` (1336 pass, 4 new: default fallback, custom override, empty-string fallback via `resolveServerName`)
- [x] `bun run format:check` (Prettier clean)