### PR TITLE
feat(mcp-transport): support a per-vault fixed MCP port

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-transport/components/AccessControlSection.svelte
+++ b/packages/obsidian-plugin/src/features/mcp-transport/components/AccessControlSection.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
   import type McpToolsPlugin from "$/main";
   import { Notice } from "obsidian";
+  import { onMount } from "svelte";
+  import { type } from "arktype";
   import {
     setup as mcpTransportSetup,
     teardown as mcpTransportTeardown,
   } from "$/features/mcp-transport/services/setup";
   import { generateToken } from "$/features/mcp-transport/services/token";
   import { BIND_HOST, MCP_PATH_PREFIX } from "$/features/mcp-transport/constants";
+  import { PortNumber } from "$/features/mcp-transport/types";
   import { applyAutoWrite } from "$/features/mcp-client-config";
   import { globalSettingsMutex } from "$/features/command-permissions";
+  import { SettingsStore } from "$/shared/settingsStore";
 
   export let plugin: McpToolsPlugin;
 
@@ -19,6 +23,83 @@
 
   let showToken = false;
   let busy = false;
+
+  // The configured (possibly blank) fixed-port override, read from
+  // data.json on mount. Kept as a string so an empty field is
+  // representable; blank means "use the automatic range" — see
+  // resolvePorts in services/port.ts.
+  let portInput = "";
+  let portBusy = false;
+
+  onMount(async () => {
+    const raw = (await new SettingsStore(plugin).readSlice("mcpTransport")) as
+      | { port?: number }
+      | undefined;
+    portInput = raw?.port !== undefined ? String(raw.port) : "";
+  });
+
+  /**
+   * Persist the fixed-port override and restart the transport so it
+   * rebinds to the new port (see issue #337). Validates client-side
+   * before touching data.json; an invalid entry shows a Notice and
+   * changes nothing.
+   *
+   * Mirrors handleRegenerate(): persist → teardown → setup → update
+   * local/plugin state. On a busy configured port, setup() fails and
+   * the transport is left down — no silent fallback to the range.
+   */
+  async function handleSavePort(): Promise<void> {
+    const trimmed = portInput.trim();
+    let portValue: number | undefined;
+    if (trimmed) {
+      const parsed = Number(trimmed);
+      const validated = Number.isFinite(parsed) ? PortNumber(parsed) : undefined;
+      if (validated === undefined || validated instanceof type.errors) {
+        new Notice(
+          "Port must be a whole number between 1024 and 65535.",
+        );
+        return;
+      }
+      portValue = validated;
+    }
+
+    portBusy = true;
+    try {
+      await globalSettingsMutex.run(async () => {
+        const data = ((await plugin.loadData()) ?? {}) as Record<
+          string,
+          unknown
+        >;
+        const existing = (data.mcpTransport ?? {}) as Record<string, unknown>;
+        await plugin.saveData({
+          ...data,
+          mcpTransport: { ...existing, port: portValue },
+        });
+      });
+
+      if (plugin.mcpTransportState) {
+        await mcpTransportTeardown(plugin.mcpTransportState);
+        plugin.mcpTransportState = undefined;
+      }
+
+      const result = await mcpTransportSetup(plugin);
+      if (!result.success) {
+        new Notice(`MCP Connector: failed to restart — ${result.error}`);
+        return;
+      }
+
+      plugin.mcpTransportState = result.state;
+      bearerToken = result.state.bearerToken;
+      port = result.state.server.port;
+      portInput = portValue !== undefined ? String(portValue) : "";
+      new Notice("Fixed port saved.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      new Notice(`MCP Connector: failed to save port — ${message}`);
+    } finally {
+      portBusy = false;
+    }
+  }
 
   /**
    * Copy a string value to the clipboard and show a brief Notice.
@@ -173,6 +254,31 @@
       </div>
     </div>
   </div>
+
+  <div class="setting-item">
+    <div class="setting-item-info">
+      <div class="setting-item-name">Fixed port</div>
+      <div class="setting-item-description">
+        Pin this vault to one port so its MCP client config never drifts
+        across sessions. Leave blank for the automatic 27200-27205 range.
+        If the port is already in use, the server will not start.
+      </div>
+    </div>
+    <div class="setting-item-control token-control">
+      <input
+        type="number"
+        bind:value={portInput}
+        placeholder="Automatic"
+        min="1024"
+        max="65535"
+        aria-label="Fixed port"
+        class="port-input"
+      />
+      <button type="button" on:click={handleSavePort} disabled={portBusy}>
+        {portBusy ? "Saving…" : "Save"}
+      </button>
+    </div>
+  </div>
 </div>
 
 <style>
@@ -198,6 +304,11 @@
     color: var(--text-muted);
     font-size: 0.9em;
     font-style: italic;
+  }
+
+  .port-input {
+    flex: 1;
+    min-width: 120px;
   }
 
   code {

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, afterEach } from "bun:test";
-import type { Server } from "node:http";
+import { createServer, type Server } from "node:http";
 import {
   startHttpServer,
   stopHttpServer,
@@ -11,6 +11,18 @@ const running: RunningServer[] = [];
 afterEach(async () => {
   for (const s of running.splice(0)) await stopHttpServer(s);
 });
+
+// Bind to port 0 to let the OS assign a free ephemeral port, then
+// release it immediately so it can be reused as a fixed `ports`
+// override below. Small TOCTOU window, acceptable for a unit test
+// (same approach as port.test.ts's occupyFreePort).
+async function freePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const port = (server.address() as { port: number }).port;
+  await new Promise<void>((r) => server.close(() => r()));
+  return port;
+}
 
 describe("startHttpServer", () => {
   test("binds to a port in range and exposes it", async () => {
@@ -24,6 +36,20 @@ describe("startHttpServer", () => {
     running.push(server);
     expect(server.port).toBeGreaterThanOrEqual(27200);
     expect(server.port).toBeLessThanOrEqual(27205);
+  });
+
+  test("honors a custom ports override instead of PORT_RANGE (#337)", async () => {
+    const port = await freePort();
+    const server = await startHttpServer({
+      bearerToken: "test-token-12345678901234567890abcd",
+      requestHandler: async (_req, res) => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("ok");
+      },
+      ports: [port],
+    });
+    running.push(server);
+    expect(server.port).toBe(port);
   });
 
   test("rejects POST /mcp without auth (401)", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.ts
@@ -17,6 +17,8 @@ export type RequestHandler = (
 export type HttpServerConfig = {
   bearerToken: string;
   requestHandler: RequestHandler;
+  /** Ports to try, in order. Defaults to PORT_RANGE. */
+  ports?: readonly number[];
 };
 
 export type RunningServer = {
@@ -26,7 +28,9 @@ export type RunningServer = {
 
 /**
  * Start an HTTP server bound to 127.0.0.1 on the first available port
- * in PORT_RANGE.
+ * in `config.ports` (defaults to PORT_RANGE). A single-element `ports`
+ * list (a fixed port configured by the user) throws instead of falling
+ * back elsewhere — see resolvePorts in port.ts.
  *
  * The server runs a middleware chain (method/path → origin → bearer auth)
  * before delegating to the caller-provided requestHandler. This keeps auth
@@ -90,7 +94,7 @@ export async function startHttpServer(
 
   let port: number;
   try {
-    port = await bindWithFallback(server, [...PORT_RANGE]);
+    port = await bindWithFallback(server, [...(config.ports ?? PORT_RANGE)]);
   } catch (err) {
     // Best-effort cleanup; no-op if server never listened.
     try {

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/port.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/port.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { createServer, type Server } from "node:http";
-import { bindWithFallback } from "./port";
+import { bindWithFallback, resolvePorts } from "./port";
+import { PORT_RANGE } from "../constants";
 
 const openServers: Server[] = [];
 
@@ -52,5 +53,36 @@ describe("bindWithFallback", () => {
     await expect(bindWithFallback(server, [p0, p1])).rejects.toThrow(
       /no free port/i,
     );
+  });
+
+  test("throws immediately when a single fixed port is busy, no fallback (#337)", async () => {
+    const { port } = await occupyFreePort();
+
+    const server = createServer();
+    openServers.push(server);
+    await expect(bindWithFallback(server, [port])).rejects.toThrow(
+      /no free port/i,
+    );
+  });
+});
+
+describe("resolvePorts", () => {
+  test("returns the default range when unset", () => {
+    expect(resolvePorts(undefined)).toEqual(PORT_RANGE);
+  });
+
+  test("returns a single-element list for a valid configured port", () => {
+    expect(resolvePorts(27210)).toEqual([27210]);
+  });
+
+  test("falls back to the default range for an out-of-range port", () => {
+    expect(resolvePorts(80)).toEqual(PORT_RANGE);
+    expect(resolvePorts(70000)).toEqual(PORT_RANGE);
+  });
+
+  test("falls back to the default range for a non-integer or non-numeric value", () => {
+    expect(resolvePorts(27200.5)).toEqual(PORT_RANGE);
+    expect(resolvePorts("27200")).toEqual(PORT_RANGE);
+    expect(resolvePorts(null)).toEqual(PORT_RANGE);
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/port.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/port.ts
@@ -1,5 +1,31 @@
+import { type } from "arktype";
 import type { Server } from "node:http";
-import { BIND_HOST } from "../constants";
+import { logger } from "$/shared";
+import { BIND_HOST, PORT_RANGE } from "../constants";
+import { PortNumber } from "../types";
+
+/**
+ * Resolve the port list to try when starting the HTTP server: a single
+ * user-configured port when valid, else the default range. A configured
+ * port is deliberately never combined with the range — falling back to
+ * the range on a busy configured port would reintroduce the same
+ * cross-session drift a fixed port is meant to fix (see issue #337).
+ * Invalid/corrupt persisted data (not a valid port at all) is a
+ * different failure mode and safely falls back to the range, logging a
+ * warning, same as SettingsStore.loadSlice does for other settings.
+ */
+export function resolvePorts(configured: unknown): readonly number[] {
+  if (configured === undefined) return PORT_RANGE;
+  const validated = PortNumber(configured);
+  if (validated instanceof type.errors) {
+    logger.warn("configured mcp port is invalid, using default range", {
+      configured,
+      summary: validated.summary,
+    });
+    return PORT_RANGE;
+  }
+  return [validated];
+}
 
 /**
  * Bind an HTTP server to the first available port in the given range.

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/setup.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/setup.ts
@@ -11,6 +11,7 @@ import {
   destroyMcpService,
   type McpService,
 } from "./mcpServer";
+import { resolvePorts } from "./port";
 import { generateToken } from "./token";
 
 export type McpTransportState = {
@@ -61,15 +62,38 @@ export async function setup(plugin: McpToolsPlugin): Promise<SetupResult> {
       return current; // NO_CHANGE: keep the existing valid token
     });
 
+    const mcpTransportSlice = (await new SettingsStore(plugin).readSlice(
+      "mcpTransport",
+    )) as { port?: unknown } | undefined;
+    const ports = resolvePorts(mcpTransportSlice?.port);
+
     const mcp = await createMcpService({
       app: plugin.app,
       plugin,
       pluginVersion: plugin.manifest.version,
     });
-    const server = await startHttpServer({
-      bearerToken,
-      requestHandler: mcp.handleRequest,
-    });
+    let server: RunningServer;
+    try {
+      server = await startHttpServer({
+        bearerToken,
+        requestHandler: mcp.handleRequest,
+        ports,
+      });
+    } catch (err) {
+      // A single-element `ports` list means the user configured a fixed
+      // port: bindWithFallback's own "range exhausted" error (no .code)
+      // means that one port was busy. Any other error (e.g. a genuine
+      // EACCES/EADDRNOTAVAIL, which carries a .code) passes through
+      // unchanged — only the busy-fixed-port case gets the friendlier
+      // message. No fallback to the range: that would reintroduce the
+      // cross-session port drift a fixed port is meant to fix (#337).
+      if (ports.length === 1 && err instanceof Error && !("code" in err)) {
+        throw new Error(
+          `Port ${ports[0]} is in use — the MCP server did not start. Free it or change the port in settings.`,
+        );
+      }
+      throw err;
+    }
 
     logger.info("MCP Connector HTTP server listening", {
       port: server.port,


### PR DESCRIPTION
## Summary
- With two or more vaults open, the port each one gets depends on startup order, so it can flip between sessions and a client config pinned to a URL ends up pointing at the wrong vault.
- The `mcpTransport` settings slice now takes an optional `port`. When set, the server binds only to that port and refuses to start if it is already in use, with a clear message pointing at settings. No silent fallback to the automatic range, which would just reintroduce the same drift. Unset behaves exactly as before.

Closes #337

## Test plan
- [x] `bun run check` (type-check, both packages)
- [x] `bun test` (1338 pass, 6 new: `resolvePorts` validation branches, single-fixed-port-busy-throws, `startHttpServer` honoring a custom `ports` override)
- [x] `bun run format:check` (Prettier clean)