### PR TITLE
feat(mcp-tools): add get_vault_files and get_vault_overview tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ The plugin hosts the MCP server in-process inside Obsidian and exposes Streamabl
 
 ## Features
 
-> **Tip:** all 48 tools are active by default. You can cut the per-session token cost with [adaptive tool loading](#adaptive-tool-loading), which keeps a small core active and promotes the rest on demand.
+> **Tip:** all 51 tools are active by default. You can cut the per-session token cost with [adaptive tool loading](#adaptive-tool-loading), which keeps a small core active and promotes the rest on demand.
 
 When connected to an MCP-compatible client, this plugin enables:
 
-- **Vault access**: read, write, and patch notes through typed tools (`get_vault_file`, `create_vault_file`, `patch_vault_file`, `rename_vault_file`, `rename_heading`, `list_vault_files`, `create_vault_directory`, `delete_vault_directory`, and more) with native binary content for images and audio. Missing parent directories on a `create` or `append` path are auto-created. `rename_vault_file` preserves link integrity across the vault via `app.fileManager.renameFile`; `rename_heading` renames a heading in place and rewrites every wikilink, markdown link, and subheading-path reference pointing at it across the vault.
+- **Vault access**: read, write, and patch notes through typed tools (`get_vault_file`, `create_vault_file`, `patch_vault_file`, `rename_vault_file`, `rename_heading`, `list_vault_files`, `create_vault_directory`, `delete_vault_directory`, and more) with native binary content for images and audio. Missing parent directories on a `create` or `append` path are auto-created. `rename_vault_file` preserves link integrity across the vault via `app.fileManager.renameFile`; `rename_heading` renames a heading in place and rewrites every wikilink, markdown link, and subheading-path reference pointing at it across the vault. `get_vault_files` reads up to 20 text/markdown files in a single call, one result per path, so a multi-note task no longer costs one round-trip per file.
 - **Note properties**: `get_note_property`, `set_note_property`, `delete_note_property`, and `list_property_values` read and edit frontmatter fields directly, including listing every value a property takes across the whole vault.
 - **Semantic search**: `search_vault_smart` over an on-device embedding index. Four providers are available on demand: native MiniLM-L6-v2 (~25 MB, default), Gemma 300M (768d, recommended for non-Latin vaults), Multilingual-E5-Base (768d), and Smart Connections (if installed). Providers download once and swap live without a restart; the vault is re-indexed in the background while the previous provider keeps serving. A startup banner suggests the best provider based on your vault's character distribution. The index persists as 16 segments sharded by file path, so editing one note only rewrites that note's segment, not the whole index, keeping saves fast in large vaults.
 - **Plain-text and structured search**: `search_vault_simple` (text plus context windows) and `search_vault` (Dataview DQL or JsonLogic). `execute_dataview_query` runs Dataview DQL in-process via the plugin API and returns typed results (`table`, `list`, `task`, `calendar`). DQL needs the Dataview community plugin; the JsonLogic path needs nothing.
 - **Periodic notes**: `get_or_create_daily_note`, `get_or_create_periodic_note` (daily, weekly, monthly, quarterly, yearly), and `append_to_periodic_note`. Each call auto-creates the note with your configured template if it does not exist yet. Works with both the native Daily Notes plugin and the Periodic Notes community plugin.
-- **Vault graph and navigation**: `get_vault_file_partial` (frontmatter field, heading section, block range, or document outline, a context-efficient partial read), `list_tags` (all vault tags with usage counts), `get_files_by_tag` (hierarchical matching), `get_recent_files` (ordered by mtime), `get_outgoing_links`, `get_backlinks`, and `show_file_in_obsidian` (reveal a note in the Obsidian UI).
+- **Vault graph and navigation**: `get_vault_file_partial` (frontmatter field, heading section, block range, or document outline, a context-efficient partial read), `list_tags` (all vault tags with usage counts), `get_files_by_tag` (hierarchical matching), `get_recent_files` (ordered by mtime), `get_outgoing_links`, `get_backlinks`, and `show_file_in_obsidian` (reveal a note in the Obsidian UI). `get_vault_overview` returns a one-call snapshot (active file, note count, top-level folder distribution, top tags, recent files), replacing the 3-5 separate calls a session otherwise needs just to get oriented.
 - **Vault intelligence**: `find_broken_links` (link targets that do not resolve, with source file and line number), `find_orphaned_notes` (notes with zero incoming resolved links), `search_and_replace` (regex find-and-replace across the vault or scoped paths, `dry_run:"true"` by default for a safe preview), `get_note_outline` (heading TOC with level, text, line number, and anchor slug), and `list_bookmarks` (the full native Obsidian bookmark hierarchy: files, folders, searches, headings, blocks, groups).
 - **Canvas**: `get_canvas` reads a `.canvas` file as structured nodes and edges, capping long text-node content with a `textTruncated` flag to bound token cost. `add_canvas_node` appends a text, file, or link node with automatic placement to the right of the existing layout, creating the canvas and parent folders if the path does not exist. `connect_canvas_nodes` draws an edge between two nodes by id. Writes preserve every existing field, including styling, so a canvas edited in Obsidian round-trips through a tool write with clean diffs.
 - **Template execution**: invoke Templater templates as MCP tool calls with dynamic parameters.
@@ -38,11 +38,11 @@ When connected to an MCP-compatible client, this plugin enables:
 
 **Typed output on every tool.** Each tool result carries a `structuredContent` object next to the text payload, so clients that support it (Claude Desktop, Claude Code) get a typed object without parsing a JSON string. The text stays byte-identical, so clients that read only text keep working unchanged. Every tool also declares MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`), so a client can skip the confirmation prompt on read-only calls and gate it on destructive ones. List and scan tools take a `limit` (default 200, clamped to 1000) and flag `truncated: true` with a full `total` when a large vault would otherwise return an unbounded array.
 
-46 vault tools in total, plus two always-on meta-tools (`tool_catalog`, `activate_tool`) that power [adaptive tool loading](#adaptive-tool-loading), for 48 tools in all. Full list in the plugin's settings, **Tools available** section.
+48 vault tools in total, plus three always-on meta-tools (`tool_catalog`, `activate_tool`, `activate_tools`) that power [adaptive tool loading](#adaptive-tool-loading), for 51 tools in all. Full list in the plugin's settings, **Tools available** section.
 
 ## Adaptive tool loading
 
-Every tool a server advertises costs context-window tokens on each session: the client downloads the full JSON schema of every active tool before the model says a word. With all 48 tools active that is roughly 10K tokens per session. Adaptive tool loading lets you cut that cost without losing access to any tool.
+Every tool a server advertises costs context-window tokens on each session: the client downloads the full JSON schema of every active tool before the model says a word. With all 51 tools active that is roughly 10K tokens per session. Adaptive tool loading lets you cut that cost without losing access to any tool.
 
 ### Profiles
 
@@ -50,16 +50,17 @@ Pick a profile in **Settings, MCP Connector, Tool Loading**:
 
 | Profile | Active tools | Best for |
 |---|---|---|
-| **All** (default) | All 46 tools + both meta-tools | Maximum capability, no behavior change from earlier versions |
+| **All** (default) | All 48 tools + all three meta-tools | Maximum capability, no behavior change from earlier versions |
 | **Core** | 13 essential tools + `tool_catalog` | Minimum token cost, static surface that never changes mid-session |
-| **Adaptive** | Core + frequency-promoted tools + both meta-tools | Token savings that converge on your actual usage |
+| **Adaptive** | Core + frequency-promoted tools + all three meta-tools | Token savings that converge on your actual usage |
 
 The Core set covers the everyday operations: server info, active-file read/write/append, vault file read/create/list, both search tools, tags, note properties, and the daily note.
 
-### The two meta-tools
+### The three meta-tools
 
 - **`tool_catalog`** (always active, read-only): returns the full inventory of all tools with their status (`active`, `inactive`, `promoted`), call counts, and descriptions for inactive ones. The model always knows what exists and what is switched off, regardless of profile.
 - **`activate_tool`** (Adaptive and All profiles only): promotes an inactive tool by name. The tool becomes available immediately, no reconnect needed. By default the promotion lasts until the plugin reloads; pass `persist: true` to write it to the plugin data so it survives reloads. Every promotion shows an Obsidian notice (`MCP Connector: "<tool>" promoted to active`) so you always see when the model expands its own tool surface. In the Core profile this meta-tool is not exposed: Core means a fixed surface, and the model cannot grow it.
+- **`activate_tools`** (Adaptive and All profiles only): promotes several inactive tools in one call instead of one `activate_tool` call per tool, refreshing the client's tool list only once. Use it whenever a task needs more than one inactive tool at a time.
 
 ### Frequency promotion
 
@@ -197,7 +198,7 @@ Click **Copy config for streamable-http clients**. The snippet uses the generic 
 
 ### Verifying the setup
 
-Once configured, your client should expose **48 MCP tools** from this server (46 vault tools + 2 meta-tools, with the default **All** profile, fewer if you selected the Core or Adaptive [tool loading profile](#adaptive-tool-loading)), plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
+Once configured, your client should expose **51 MCP tools** from this server (48 vault tools + 3 meta-tools, with the default **All** profile, fewer if you selected the Core or Adaptive [tool loading profile](#adaptive-tool-loading)), plus any prompts you have tagged with `#mcp-tools-prompt` in a `Prompts/` folder at your vault root.
 
 To verify the connection works end-to-end, ask the agent to call `get_server_info`. A successful response confirms the client can reach the in-process server and the bearer token is correct. For deeper inspection (request/response logs, tool schema inspection without an LLM in the loop), use [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector):
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -37,6 +37,10 @@ import {
 } from "./tools/listVaultFiles";
 import { getVaultFileHandler, getVaultFileSchema } from "./tools/getVaultFile";
 import {
+  getVaultFilesHandler,
+  getVaultFilesSchema,
+} from "./tools/getVaultFiles";
+import {
   createVaultFileHandler,
   createVaultFileSchema,
 } from "./tools/createVaultFile";
@@ -115,6 +119,10 @@ import {
   getRecentFilesHandler,
   getRecentFilesSchema,
 } from "./tools/getRecentFiles";
+import {
+  getVaultOverviewHandler,
+  getVaultOverviewSchema,
+} from "./tools/getVaultOverview";
 import {
   getVaultFilePartialHandler,
   getVaultFilePartialSchema,
@@ -228,6 +236,9 @@ export async function registerTools(
   registry.register(getVaultFileSchema, async ({ arguments: args }) =>
     getVaultFileHandler({ arguments: args, app: ctx.app }),
   );
+  registry.register(getVaultFilesSchema, async ({ arguments: args }) =>
+    getVaultFilesHandler({ arguments: args, app: ctx.app }),
+  );
   registry.register(createVaultFileSchema, async ({ arguments: args }) =>
     createVaultFileHandler({ arguments: args, app: ctx.app }),
   );
@@ -274,6 +285,9 @@ export async function registerTools(
   );
   registry.register(getRecentFilesSchema, async ({ arguments: args }) =>
     getRecentFilesHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(getVaultOverviewSchema, async ({ arguments: args }) =>
+    getVaultOverviewHandler({ arguments: args, app: ctx.app }),
   );
   registry.register(getVaultFilePartialSchema, async ({ arguments: args }) =>
     getVaultFilePartialHandler({ arguments: args, app: ctx.app }),

--- a/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
@@ -50,6 +50,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   // Vault files
   list_vault_files: READ_ONLY,
   get_vault_file: READ_ONLY,
+  get_vault_files: READ_ONLY,
   get_vault_file_partial: READ_ONLY,
   // Overwrites when the path already exists (documented behavior).
   create_vault_file: { ...DESTRUCTIVE, idempotentHint: true },
@@ -96,6 +97,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
 
   // Periodic notes / misc
   get_recent_files: READ_ONLY,
+  get_vault_overview: READ_ONLY,
   list_bookmarks: READ_ONLY,
   get_or_create_daily_note: { ...SAFE_WRITE, idempotentHint: true },
   get_or_create_periodic_note: { ...SAFE_WRITE, idempotentHint: true },

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getRecentFiles.ts
@@ -33,21 +33,25 @@ export function _resetMissingIsUserIgnoredWarning(): void {
   _warnedMissingIsUserIgnored = false;
 }
 
-export async function getRecentFilesHandler(
-  ctx: GetRecentFilesContext,
-): Promise<{ content: Array<{ type: "text"; text: string }> }> {
-  const limit = ctx.arguments.limit ?? 20;
-
+/**
+ * Returns every visible (non-`isUserIgnored`) markdown file in the vault,
+ * sorted by `mtime` descending with a locale-pinned `path` ascending
+ * tiebreaker. Unsliced — callers apply their own limit. Exported so
+ * get_vault_overview reuses the same exclusion + sort instead of
+ * duplicating the one-shot missing-API warning below (a second copy
+ * would need its own module flag and could double-fire the warning).
+ */
+export function getSortedVisibleMarkdownFiles(app: App): TFile[] {
   // `MetadataCache.isUserIgnored(path)` is part of Obsidian's runtime API
   // but is not surfaced by the bundled `obsidian.d.ts`. The cast through
   // `unknown` keeps us aligned with the codebase pattern used for other
   // metadata-cache accessors (see listTags.ts:30). Treated as optional so
   // tests that do not stub it keep working.
   const isUserIgnored = (
-    ctx.app.metadataCache as unknown as {
+    app.metadataCache as unknown as {
       isUserIgnored?: (path: string) => boolean;
     }
-  ).isUserIgnored?.bind(ctx.app.metadataCache);
+  ).isUserIgnored?.bind(app.metadataCache);
 
   if (!isUserIgnored && !_warnedMissingIsUserIgnored) {
     _warnedMissingIsUserIgnored = true;
@@ -60,15 +64,10 @@ export async function getRecentFilesHandler(
     );
   }
 
-  const allMarkdown = ctx.app.vault.getMarkdownFiles();
+  const allMarkdown = app.vault.getMarkdownFiles();
   const visible = isUserIgnored
     ? allMarkdown.filter((f: TFile) => !isUserIgnored(f.path))
     : allMarkdown;
-
-  // `totalFiles` reports the size of the visible (post-exclusion) set,
-  // before the recency slice. Matches the contract of `get_files_by_tag`
-  // where `totalFiles` is the total match count, not the page size.
-  const totalFiles = visible.length;
 
   // Pinned locale + sensitivity for cross-platform deterministic order
   // on the tiebreaker (matches the contract used by `list_tags` /
@@ -78,25 +77,36 @@ export async function getRecentFilesHandler(
   const comparePath = (a: string, b: string): number =>
     a.localeCompare(b, "en", { sensitivity: "variant" });
 
-  const files = visible
-    .slice()
-    .sort((a, b) => {
-      // Primary: mtime descending (most-recent first).
-      if (b.stat.mtime !== a.stat.mtime) return b.stat.mtime - a.stat.mtime;
-      // Secondary: path ascending. `Array.prototype.sort` stability is
-      // guaranteed by ES2019 (V8 / Bun honour it) but the response
-      // contract should not rely on that — an explicit tiebreaker keeps
-      // the API deterministic across repeat calls when several files
-      // share an `mtime` (common on bulk imports / sync events).
-      return comparePath(a.path, b.path);
-    })
-    .slice(0, limit)
-    .map((f) => ({
-      path: f.path,
-      mtime: f.stat.mtime,
-      ctime: f.stat.ctime,
-      size: f.stat.size,
-    }));
+  return visible.slice().sort((a, b) => {
+    // Primary: mtime descending (most-recent first).
+    if (b.stat.mtime !== a.stat.mtime) return b.stat.mtime - a.stat.mtime;
+    // Secondary: path ascending. `Array.prototype.sort` stability is
+    // guaranteed by ES2019 (V8 / Bun honour it) but the response
+    // contract should not rely on that — an explicit tiebreaker keeps
+    // the API deterministic across repeat calls when several files
+    // share an `mtime` (common on bulk imports / sync events).
+    return comparePath(a.path, b.path);
+  });
+}
+
+export async function getRecentFilesHandler(
+  ctx: GetRecentFilesContext,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  const limit = ctx.arguments.limit ?? 20;
+
+  const visible = getSortedVisibleMarkdownFiles(ctx.app);
+
+  // `totalFiles` reports the size of the visible (post-exclusion) set,
+  // before the recency slice. Matches the contract of `get_files_by_tag`
+  // where `totalFiles` is the total match count, not the page size.
+  const totalFiles = visible.length;
+
+  const files = visible.slice(0, limit).map((f) => ({
+    path: f.path,
+    mtime: f.stat.mtime,
+    ctime: f.stat.ctime,
+    size: f.stat.size,
+  }));
 
   const output = { totalFiles, files };
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
@@ -1,5 +1,5 @@
 import { type } from "arktype";
-import { type App } from "obsidian";
+import { type App, type TFile } from "obsidian";
 import { resolveTFile } from "../services/resolveTFile";
 
 /**
@@ -10,7 +10,7 @@ import { resolveTFile } from "../services/resolveTFile";
  *
  * Kept in sync with BINARY_EXTENSION_MIME_TYPES in packages/mcp-server.
  */
-const MIME_BY_EXT: ReadonlyMap<
+export const MIME_BY_EXT: ReadonlyMap<
   string,
   { mime: string; kind: "image" | "audio" }
 > = new Map([
@@ -51,7 +51,7 @@ const INLINE_BYTE_CAP = 10 * 1024 * 1024; // 10 MiB
  * a plain text content block. Extensions not in this set AND not in MIME_BY_EXT
  * are treated as unsupported binary.
  */
-const TEXT_EXTENSIONS = new Set([
+export const TEXT_EXTENSIONS = new Set([
   "md",
   "txt",
   "csv",
@@ -105,6 +105,39 @@ type ImageBlock = { type: "image"; data: string; mimeType: string };
 type AudioBlock = { type: "audio"; data: string; mimeType: string };
 type ContentBlock = TextBlock | ImageBlock | AudioBlock;
 
+export type VaultFileJson = {
+  path: string;
+  content: string;
+  frontmatter: Record<string, unknown>;
+  tags: string[];
+  stat: { ctime: number; mtime: number; size: number };
+};
+
+/**
+ * Builds the `format=json` shape: `{ path, content, frontmatter, tags, stat }`.
+ * Shared with get_vault_files so both tools stay byte-identical for the
+ * same file — see the "kept in sync" note on MIME_BY_EXT above for why a
+ * second independent copy of this shape is the kind of drift to avoid.
+ */
+export async function readVaultFileAsJson(
+  app: App,
+  file: TFile,
+): Promise<VaultFileJson> {
+  const text = await app.vault.read(file);
+  const cache = app.metadataCache.getFileCache(file);
+  const frontmatter = (cache?.frontmatter as Record<string, unknown>) ?? {};
+  const tags = Array.isArray(frontmatter.tags)
+    ? (frontmatter.tags as string[])
+    : [];
+  const stat = {
+    ctime: file.stat?.ctime ?? 0,
+    mtime: file.stat?.mtime ?? 0,
+    size: file.stat?.size ?? 0,
+  };
+
+  return { path: file.path, content: text, frontmatter, tags, stat };
+}
+
 export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
   content: Array<ContentBlock>;
   isError?: boolean;
@@ -137,31 +170,9 @@ export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
   // The `stat` field was missing in the initial 0.4.0 port — folotp flagged
   // the drift between the description and the actual response.
   if (ctx.arguments.format === "json") {
-    const text = await ctx.app.vault.read(file);
-    const cache = ctx.app.metadataCache.getFileCache(file);
-    const frontmatter = (cache?.frontmatter as Record<string, unknown>) ?? {};
-    const tags = Array.isArray(frontmatter.tags)
-      ? (frontmatter.tags as string[])
-      : [];
-    const stat = {
-      ctime: file.stat?.ctime ?? 0,
-      mtime: file.stat?.mtime ?? 0,
-      size: file.stat?.size ?? 0,
-    };
-
+    const json = await readVaultFileAsJson(ctx.app, file);
     return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            path: file.path,
-            content: text,
-            frontmatter,
-            tags,
-            stat,
-          }),
-        },
-      ],
+      content: [{ type: "text", text: JSON.stringify(json) }],
     };
   }
 

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFiles.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFiles.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { getVaultFilesHandler, getVaultFilesSchema } from "./getVaultFiles";
+import {
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockFolder,
+  setMockMetadata,
+} from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+describe("get_vault_files tool", () => {
+  test("schema declares the tool name", () => {
+    expect(getVaultFilesSchema.get("name")?.toString()).toContain(
+      "get_vault_files",
+    );
+  });
+
+  test("returns one text result per path, in input order", async () => {
+    setMockFile("a.md", "# A");
+    setMockFile("b.md", "# B");
+    const result = await getVaultFilesHandler({
+      arguments: { paths: ["b.md", "a.md"] },
+      app: mockApp(),
+    });
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.results).toEqual([
+      { path: "b.md", content: "# B" },
+      { path: "a.md", content: "# A" },
+    ]);
+  });
+
+  test("format=json returns content+frontmatter+tags+stat per file", async () => {
+    setMockFile("a.md", "---\ntags: [foo]\n---\n# Body");
+    setMockMetadata("a.md", { frontmatter: { tags: ["foo"] } });
+    const result = await getVaultFilesHandler({
+      arguments: { paths: ["a.md"], format: "json" },
+      app: mockApp(),
+    });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0].path).toBe("a.md");
+    expect(parsed.results[0].frontmatter).toEqual({ tags: ["foo"] });
+    expect(parsed.results[0].tags).toEqual(["foo"]);
+    expect(parsed.results[0].stat).toEqual({
+      ctime: 0,
+      mtime: 0,
+      size: "---\ntags: [foo]\n---\n# Body".length,
+    });
+  });
+
+  test("a missing path becomes a per-entry error, batch still succeeds", async () => {
+    setMockFile("a.md", "# A");
+    const result = await getVaultFilesHandler({
+      arguments: { paths: ["a.md", "missing.md"] },
+      app: mockApp(),
+    });
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.results[0]).toEqual({ path: "a.md", content: "# A" });
+    expect(parsed.results[1].reason).toBe("not_found");
+    expect(parsed.results[1].error).toMatch(/not found/i);
+  });
+
+  test("a folder path becomes a not_a_file per-entry error", async () => {
+    setMockFolder("Notes");
+    const result = await getVaultFilesHandler({
+      arguments: { paths: ["Notes"] },
+      app: mockApp(),
+    });
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.results[0].reason).toBe("not_a_file");
+  });
+
+  test("a binary file becomes a binary_unsupported per-entry error", async () => {
+    setMockFile("a.md", "# A");
+    setMockFile("img/pic.png", "fake-png-bytes");
+    const result = await getVaultFilesHandler({
+      arguments: { paths: ["a.md", "img/pic.png"] },
+      app: mockApp(),
+    });
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.results[0]).toEqual({ path: "a.md", content: "# A" });
+    expect(parsed.results[1].reason).toBe("binary_unsupported");
+    expect(parsed.results[1].error).toMatch(/get_vault_file/);
+  });
+
+  test("duplicate input path produces duplicate output entries", async () => {
+    setMockFile("a.md", "# A");
+    const result = await getVaultFilesHandler({
+      arguments: { paths: ["a.md", "a.md"] },
+      app: mockApp(),
+    });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.results).toEqual([
+      { path: "a.md", content: "# A" },
+      { path: "a.md", content: "# A" },
+    ]);
+  });
+
+  test("empty paths array is a top-level error", async () => {
+    const result = await getVaultFilesHandler({
+      arguments: { paths: [] },
+      app: mockApp(),
+    });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.errorCode).toBe("invalid_arguments");
+  });
+
+  test("more than 20 paths is a top-level error", async () => {
+    const paths = Array.from({ length: 21 }, (_, i) => `note-${i}.md`);
+    const result = await getVaultFilesHandler({
+      arguments: { paths },
+      app: mockApp(),
+    });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.errorCode).toBe("too_many_paths");
+    expect(parsed.received).toBe(21);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFiles.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFiles.ts
@@ -1,0 +1,99 @@
+import { type } from "arktype";
+import { type App } from "obsidian";
+import { resolveTFile } from "../services/resolveTFile";
+import { errorJson, successJson } from "../services/responseBuilders";
+import { TEXT_EXTENSIONS, readVaultFileAsJson } from "./getVaultFile";
+
+const MAX_PATHS = 20;
+
+export const getVaultFilesSchema = type({
+  name: '"get_vault_files"',
+  arguments: {
+    paths: type("string[]").describe(
+      `Vault-relative paths to read, 1-${MAX_PATHS} per call. More than ${MAX_PATHS} is rejected.`,
+    ),
+    "format?": type('"text"|"json"').describe(
+      'Applied uniformly to every path. "text" returns raw content; "json" returns content + frontmatter + tags + stat per file (same shape as get_vault_file). Default: text.',
+    ),
+  },
+}).describe(
+  "Reads up to 20 vault text/markdown files in one call, returning one result per input path in the same order. A bad path never fails the whole call: missing files, folders, and binary files each produce a per-entry error instead. Binary files (images, audio, PDFs, etc.) are not supported here regardless of `format` — use get_vault_file to read one individually.",
+);
+
+export type GetVaultFilesContext = {
+  arguments: { paths: string[]; format?: "text" | "json" };
+  app: App;
+};
+
+type FileResult =
+  | { path: string; content: string }
+  | (Awaited<ReturnType<typeof readVaultFileAsJson>> & { path: string })
+  | {
+      path: string;
+      error: string;
+      reason: "not_found" | "not_a_file" | "binary_unsupported";
+    };
+
+export async function getVaultFilesHandler(ctx: GetVaultFilesContext): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: true;
+}> {
+  const { paths, format } = ctx.arguments;
+
+  if (paths.length === 0) {
+    return errorJson(
+      "paths must contain at least 1 entry.",
+      "invalid_arguments",
+      {
+        received: 0,
+      },
+    );
+  }
+  if (paths.length > MAX_PATHS) {
+    return errorJson(
+      `paths must contain at most ${MAX_PATHS} entries (got ${paths.length}).`,
+      "too_many_paths",
+      { max: MAX_PATHS, received: paths.length },
+    );
+  }
+
+  const results: FileResult[] = [];
+
+  for (const path of paths) {
+    const resolved = resolveTFile(ctx.app.vault, path);
+    if (!resolved.ok) {
+      results.push({
+        path,
+        error:
+          resolved.reason === "not_found"
+            ? `File not found: ${path}`
+            : `Path is a folder: ${path}`,
+        reason: resolved.reason,
+      });
+      continue;
+    }
+
+    const file = resolved.file;
+    const ext = file.extension.toLowerCase();
+    const isText = TEXT_EXTENSIONS.has(ext) || !ext;
+    if (!isText) {
+      results.push({
+        path: file.path,
+        error: `File is binary and not supported by get_vault_files: ${file.path}. Use get_vault_file to read it individually.`,
+        reason: "binary_unsupported",
+      });
+      continue;
+    }
+
+    if (format === "json") {
+      const json = await readVaultFileAsJson(ctx.app, file);
+      results.push(json);
+    } else {
+      const content = await ctx.app.vault.read(file);
+      results.push({ path: file.path, content });
+    }
+  }
+
+  return successJson({ results });
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultOverview.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultOverview.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  getVaultOverviewHandler,
+  getVaultOverviewSchema,
+} from "./getVaultOverview";
+import {
+  mockApp,
+  resetMockVault,
+  setMockActiveFile,
+  setMockFile,
+  setMockIgnored,
+  setMockTags,
+} from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+describe("get_vault_overview tool", () => {
+  test("schema declares the tool name", () => {
+    expect(getVaultOverviewSchema.get("name")?.toString()).toContain(
+      "get_vault_overview",
+    );
+  });
+
+  test("empty vault returns an all-empty snapshot", async () => {
+    const result = await getVaultOverviewHandler({
+      arguments: {},
+      app: mockApp(),
+    });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed).toEqual({
+      activeFile: null,
+      totalNotes: 0,
+      topFolders: [],
+      topTags: [],
+      recentFiles: [],
+    });
+  });
+
+  test("activeFile reflects the currently active note", async () => {
+    setMockFile("a.md", "# A");
+    setMockActiveFile("a.md");
+    const result = await getVaultOverviewHandler({
+      arguments: {},
+      app: mockApp(),
+    });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.activeFile).toBe("a.md");
+  });
+
+  test("totalNotes and topFolders count markdown files only", async () => {
+    setMockFile("Projects/a.md", "# A");
+    setMockFile("Projects/b.md", "# B");
+    setMockFile("Daily/c.md", "# C");
+    setMockFile("root.md", "# Root");
+    setMockFile("attachments/img.png", "fake-bytes");
+    const result = await getVaultOverviewHandler({
+      arguments: {},
+      app: mockApp(),
+    });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.totalNotes).toBe(4);
+    expect(parsed.topFolders).toEqual([
+      { folder: "Projects", count: 2 },
+      { folder: "(root)", count: 1 },
+      { folder: "Daily", count: 1 },
+    ]);
+  });
+
+  test("topFolders sorts by count desc with alphabetical tiebreak", async () => {
+    setMockFile("Zeta/a.md", "# A");
+    setMockFile("Alpha/b.md", "# B");
+    const result = await getVaultOverviewHandler({
+      arguments: {},
+      app: mockApp(),
+    });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.topFolders).toEqual([
+      { folder: "Alpha", count: 1 },
+      { folder: "Zeta", count: 1 },
+    ]);
+  });
+
+  test("topTags respects the default and an explicit limit override", async () => {
+    setMockTags({ "#a": 3, "#b": 7, "#c": 1 });
+    const defaultResult = await getVaultOverviewHandler({
+      arguments: {},
+      app: mockApp(),
+    });
+    const defaultParsed = JSON.parse(
+      (defaultResult.content[0] as { text: string }).text,
+    );
+    expect(defaultParsed.topTags).toEqual([
+      { tag: "#b", count: 7 },
+      { tag: "#a", count: 3 },
+      { tag: "#c", count: 1 },
+    ]);
+
+    const limitedResult = await getVaultOverviewHandler({
+      arguments: { topTagsLimit: 1 },
+      app: mockApp(),
+    });
+    const limitedParsed = JSON.parse(
+      (limitedResult.content[0] as { text: string }).text,
+    );
+    expect(limitedParsed.topTags).toEqual([{ tag: "#b", count: 7 }]);
+  });
+
+  test("recentFiles respects isUserIgnored exclusion and its limit override", async () => {
+    setMockFile("a.md", "# A");
+    setMockFile("b.md", "# B");
+    setMockIgnored("b.md");
+    const result = await getVaultOverviewHandler({
+      arguments: { recentFilesLimit: 1 },
+      app: mockApp(),
+    });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.recentFiles).toHaveLength(1);
+    expect(parsed.recentFiles[0].path).toBe("a.md");
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultOverview.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultOverview.ts
@@ -1,0 +1,91 @@
+import { type } from "arktype";
+import { type App } from "obsidian";
+import { successText } from "../services/responseBuilders";
+import { getTagCounts } from "./listTags";
+import { getSortedVisibleMarkdownFiles } from "./getRecentFiles";
+
+const DEFAULT_TOP_TAGS_LIMIT = 20;
+const DEFAULT_RECENT_FILES_LIMIT = 10;
+const TOP_FOLDERS_CAP = 20;
+
+export const getVaultOverviewSchema = type({
+  name: '"get_vault_overview"',
+  arguments: {
+    "topTagsLimit?": type("1<=number.integer<=100").describe(
+      "Max tags in topTags (default 20).",
+    ),
+    "recentFilesLimit?": type("1<=number.integer<=50").describe(
+      "Max files in recentFiles (default 10).",
+    ),
+  },
+}).describe(
+  "One-call snapshot of the vault: active file, total note count, top-level folder distribution, top tags, and most recently modified notes. Cheaper than calling get_active_file, list_tags, and get_recent_files separately for situational awareness at the start of a task. A bounded snapshot, not a paginated listing — call list_tags/get_recent_files directly for more than the snapshot ceiling. Always read-only.",
+);
+
+export type GetVaultOverviewContext = {
+  arguments: { topTagsLimit?: number; recentFilesLimit?: number };
+  app: App;
+};
+
+/** Groups by top-level path segment; root-level files get "(root)". */
+function topLevelFolder(path: string): string {
+  const idx = path.indexOf("/");
+  return idx === -1 ? "(root)" : path.slice(0, idx);
+}
+
+export async function getVaultOverviewHandler(
+  ctx: GetVaultOverviewContext,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  const topTagsLimit = ctx.arguments.topTagsLimit ?? DEFAULT_TOP_TAGS_LIMIT;
+  const recentFilesLimit =
+    ctx.arguments.recentFilesLimit ?? DEFAULT_RECENT_FILES_LIMIT;
+
+  const compareName = (a: string, b: string): number =>
+    a.localeCompare(b, "en", { sensitivity: "variant" });
+
+  const activeFile = ctx.app.workspace.getActiveFile()?.path ?? null;
+
+  const markdownFiles = ctx.app.vault.getMarkdownFiles();
+  const totalNotes = markdownFiles.length;
+
+  const folderCounts = new Map<string, number>();
+  for (const f of markdownFiles) {
+    const folder = topLevelFolder(f.path);
+    folderCounts.set(folder, (folderCounts.get(folder) ?? 0) + 1);
+  }
+  const topFolders = Array.from(folderCounts, ([folder, count]) => ({
+    folder,
+    count,
+  }))
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return compareName(a.folder, b.folder);
+    })
+    .slice(0, TOP_FOLDERS_CAP);
+
+  const topTags = getTagCounts(ctx.app)
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return compareName(a.tag, b.tag);
+    })
+    .slice(0, topTagsLimit);
+
+  const recentFiles = getSortedVisibleMarkdownFiles(ctx.app)
+    .slice(0, recentFilesLimit)
+    .map((f) => ({
+      path: f.path,
+      mtime: f.stat.mtime,
+      ctime: f.stat.ctime,
+      size: f.stat.size,
+    }));
+
+  const output = {
+    activeFile,
+    totalNotes,
+    topFolders,
+    topTags,
+    recentFiles,
+  };
+
+  return successText(JSON.stringify(output));
+}

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/listTags.ts
@@ -19,20 +19,28 @@ export type ListTagsContext = {
   app: App;
 };
 
-export async function listTagsHandler(
-  ctx: ListTagsContext,
-): Promise<{ content: Array<{ type: "text"; text: string }> }> {
-  // `MetadataCache.getTags()` returns a `Record<string, number>` keyed by
-  // tag (with the leading `#`), value = aggregated count across the vault.
-  // The signature is part of Obsidian's public API but the cast through
-  // `unknown` keeps us aligned with the codebase pattern used for other
-  // metadata-cache accessors that the bundled `obsidian.d.ts` does not
-  // surface directly (see listObsidianCommands.ts).
+/**
+ * `MetadataCache.getTags()` returns a `Record<string, number>` keyed by
+ * tag (with the leading `#`), value = aggregated count across the vault.
+ * The signature is part of Obsidian's public API but the cast through
+ * `unknown` keeps us aligned with the codebase pattern used for other
+ * metadata-cache accessors that the bundled `obsidian.d.ts` does not
+ * surface directly (see listObsidianCommands.ts). Exported so other
+ * tools (get_vault_overview) can reuse the same lookup, unsorted.
+ */
+export function getTagCounts(app: App): Array<{ tag: string; count: number }> {
   const tagCounts = (
-    ctx.app.metadataCache as unknown as {
+    app.metadataCache as unknown as {
       getTags: () => Record<string, number>;
     }
   ).getTags();
+  return Object.entries(tagCounts).map(([tag, count]) => ({ tag, count }));
+}
+
+export async function listTagsHandler(
+  ctx: ListTagsContext,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  const tagCounts = getTagCounts(ctx.app);
 
   const sortMode = ctx.arguments.sort ?? "count";
 
@@ -42,21 +50,20 @@ export async function listTagsHandler(
   const compareName = (a: string, b: string): number =>
     a.localeCompare(b, "en", { sensitivity: "variant" });
 
-  const sorted = Object.entries(tagCounts).sort((a, b) => {
-    if (sortMode === "name") return compareName(a[0], b[0]);
+  const all = tagCounts.slice().sort((a, b) => {
+    if (sortMode === "name") return compareName(a.tag, b.tag);
     // Count desc with name-asc tiebreaker. Engine sort-stability is
     // guaranteed by ES2019 (V8/Bun honour it), but an explicit
     // tiebreaker keeps the contract independent of that guarantee
     // and gives equal-count tags a deterministic, alphabetical order.
-    if (b[1] !== a[1]) return b[1] - a[1];
-    return compareName(a[0], b[0]);
+    if (b.count !== a.count) return b.count - a.count;
+    return compareName(a.tag, b.tag);
   });
 
   const limit = Math.min(
     1000,
     Math.max(1, Math.floor(ctx.arguments.limit ?? 200)),
   );
-  const all = sorted.map(([tag, count]) => ({ tag, count }));
   const truncated = all.length > limit;
 
   const output = {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.test.ts
@@ -7,6 +7,7 @@ import {
   mockApp,
   mockPlugin,
   resetMockVault,
+  setMockFile,
   setMockIgnored,
 } from "$/test-setup";
 import { _resetIsUserIgnoredWarning } from "$/shared/isUserIgnored";
@@ -339,5 +340,58 @@ describe("search_vault_smart — provider-aware not-ready message (#99)", () => 
     expect(result.content[0]?.text).toMatch(
       /embedding model|still be loading/i,
     );
+  });
+});
+
+describe("search_vault_smart — structured index_building error (#344)", () => {
+  test("pendingProvider with no store: filesIndexed and percent are 0", async () => {
+    setMockFile("a.md", "# A");
+    setMockFile("b.md", "# B");
+    const spy = fakeProvider({ ready: false });
+    const plugin = mockPlugin({
+      semanticSearchState: {
+        provider: spy.provider,
+        pendingProvider: "embedding-gemma",
+        store: undefined,
+      },
+    } as never);
+
+    const result = await searchVaultSmartHandler({
+      arguments: { query: "x" },
+      app: mockApp(),
+      plugin,
+    });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]?.text ?? "{}");
+    expect(parsed.errorCode).toBe("index_building");
+    expect(parsed.filesTotal).toBe(2);
+    expect(parsed.filesIndexed).toBe(0);
+    expect(parsed.percent).toBe(0);
+  });
+
+  test("pendingProvider with a store: reports real indexed/total/percent", async () => {
+    setMockFile("a.md", "# A");
+    setMockFile("b.md", "# B");
+    const spy = fakeProvider({ ready: false });
+    const fakeStore = { hasRecords: (path: string) => path === "a.md" };
+    const plugin = mockPlugin({
+      semanticSearchState: {
+        provider: spy.provider,
+        pendingProvider: "embedding-gemma",
+        store: fakeStore,
+      },
+    } as never);
+
+    const result = await searchVaultSmartHandler({
+      arguments: { query: "x" },
+      app: mockApp(),
+      plugin,
+    });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]?.text ?? "{}");
+    expect(parsed.errorCode).toBe("index_building");
+    expect(parsed.filesTotal).toBe(2);
+    expect(parsed.filesIndexed).toBe(1);
+    expect(parsed.percent).toBe(50);
   });
 });

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/searchVaultSmart.ts
@@ -1,5 +1,5 @@
 import { type } from "arktype";
-import { successText } from "../services/responseBuilders";
+import { errorJson, successText } from "../services/responseBuilders";
 import type { App } from "obsidian";
 import type McpToolsPlugin from "$/main";
 import { isSmartConnectionsAvailable } from "$/features/semantic-search/services/providerFactory";
@@ -109,8 +109,17 @@ export async function searchVaultSmartHandler(
   const provider = state.provider;
   if (!provider.isReady()) {
     if (state.pendingProvider) {
-      return errorResult(
+      const files = ctx.app.vault.getMarkdownFiles();
+      const filesTotal = files.length;
+      const filesIndexed = state.store
+        ? files.filter((f) => state.store!.hasRecords(f.path)).length
+        : 0;
+      const percent =
+        filesTotal > 0 ? Math.round((filesIndexed / filesTotal) * 100) : 0;
+      return errorJson(
         `Semantic search is not ready: the "${state.pendingProvider}" index is still being built. Open Settings → MCP Connector → Semantic Search and click "Rebuild now" if the build has not started yet.`,
+        "index_building",
+        { filesIndexed, filesTotal, percent },
       );
     }
     return errorResult(

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -202,6 +202,8 @@ describe("end-to-end: HTTP → McpServer", () => {
         "get_server_info",
         "get_vault_file",
         "get_vault_file_partial",
+        "get_vault_files",
+        "get_vault_overview",
         "list_bookmarks",
         "list_obsidian_commands",
         "list_property_values",
@@ -220,7 +222,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "tool_catalog",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(49);
+      expect(names).toHaveLength(51);
 
       // Annotations completeness: every exposed tool must carry MCP
       // annotations with an explicit readOnlyHint and openWorldHint.


### PR DESCRIPTION
## Summary

- `get_vault_files`: batch-read up to 20 text/markdown files in one call, one result per input path, a bad path never fails the whole call (#341)
- `get_vault_overview`: one-call vault snapshot, active file, note count, top-level folder distribution, top tags, recent files (#343)
- `search_vault_smart`: structured `index_building` error with `filesIndexed`/`filesTotal`/`percent` instead of a plain-text message when the semantic index is still being built (#344)
- Extracts `readVaultFileAsJson` (from `get_vault_file`), `getTagCounts` (from `list_tags`), and `getSortedVisibleMarkdownFiles` (from `get_recent_files`) for reuse across the new tools, behavior-preserving
- Fixes README's tool count, which had drifted since `activate_tools` was added (was showing 48/46, actually 51/48)

Closes #341, #343, #344.

## Test plan

- [x] `bun run check` — type-check clean across both packages
- [x] `bun test` — 1360 pass, 0 fail (full suite, including new `getVaultFiles.test.ts`, `getVaultOverview.test.ts`, extended `searchVaultSmart.test.ts`, updated `mcpServer.test.ts` full-registry assertion)
- [x] `bun run format:check` — Prettier clean
- [ ] Manual smoke: call `get_vault_files` with a mix of valid/missing/binary paths, `get_vault_overview` on a dev vault, `search_vault_smart` mid-rebuild
