### PR TITLE
chore: ignore local architecture doc in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,7 @@ tmp/
 CLAUDE.md
 .clinerules
 docs/deep-refactor/
+20260620_obsidian-mcp-connector_MCPB-generator_architecture_v1.md
 # Local dev tool version pin (mise/asdf) — not required for contributors
 mise.toml
 handoff*.md


### PR DESCRIPTION
## Summary

- Adds `20260620_obsidian-mcp-connector_MCPB-generator_architecture_v1.md` to `.gitignore`
- Keeps this dated planning note (a local working doc, not project documentation) out of git going forward
- Unrelated to PR #349 (get_vault_files/get_vault_overview/index_building error), this was a pre-existing uncommitted change flagged during that session and split out separately

## Test plan

- [x] Not code, no tests apply
