### PR TITLE
fix(mcp-client-config): wait for the mcp server before connecting

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.test.ts
@@ -150,4 +150,50 @@ describe("generateMcpb", () => {
       expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false);
     });
   });
+
+  describe("wait-for-server retry (server not listening yet)", () => {
+    test("shim probes a real TCP connection instead of assuming the port is open", () => {
+      const shim = getShimSource(
+        generateMcpb({ version: VERSION, vaultPath: VAULT_PATH }),
+      );
+      expect(shim).toContain('require("net")');
+      expect(shim).toContain("net.createConnection");
+    });
+
+    test("shim bounds the retry window instead of retrying forever", () => {
+      const shim = getShimSource(
+        generateMcpb({ version: VERSION, vaultPath: VAULT_PATH }),
+      );
+      expect(shim).toContain("RETRY_WINDOW_MS");
+      expect(shim).toContain("30000");
+      expect(shim).toContain("while (Date.now() < deadline)");
+    });
+
+    test("shim re-reads data.json on every retry attempt, not just once", () => {
+      const shim = getShimSource(
+        generateMcpb({ version: VERSION, vaultPath: VAULT_PATH }),
+      );
+      const loopStart = shim.indexOf("while (Date.now() < deadline)");
+      const readCallInLoop = shim.indexOf("readTransport()", loopStart);
+      expect(loopStart).toBeGreaterThan(-1);
+      expect(readCallInLoop).toBeGreaterThan(loopStart);
+    });
+
+    test("shim reports a clear timeout message pointing at Obsidian, not a raw connection error", () => {
+      const shim = getShimSource(
+        generateMcpb({ version: VERSION, vaultPath: VAULT_PATH }),
+      );
+      expect(shim).toContain("is Obsidian open with the vault loaded?");
+    });
+
+    test("mcp-remote is only spawned after the wait-for-server promise resolves", () => {
+      const shim = getShimSource(
+        generateMcpb({ version: VERSION, vaultPath: VAULT_PATH }),
+      );
+      const waitCall = shim.indexOf("await waitForServer()");
+      const spawnCall = shim.indexOf('spawn("npx"');
+      expect(waitCall).toBeGreaterThan(-1);
+      expect(spawnCall).toBeGreaterThan(waitCall);
+    });
+  });
 });

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.ts
@@ -18,34 +18,88 @@ const OBSIDIAN_PLUGIN_ID = "mcp-tools-istefox";
 // already-installed bundle keeps working across a token rotation or a
 // port that fell back to a different value in the range, with no
 // re-export/reinstall (see setup.ts's `livePort` write-back).
+//
+// Claude Desktop can launch this before Obsidian's window has finished
+// opening (the app process can be alive with no vault loaded yet, e.g.
+// after the window was closed rather than quit), so the server may not
+// be listening on the first attempt. waitForServer() polls data.json +
+// a raw TCP probe for up to 30s before giving up, instead of failing
+// immediately against a port nothing is listening on yet.
 function buildShim(input: McpbGeneratorInput): string {
   return `#!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
+const net = require("net");
 const { spawn } = require("child_process");
 
 const vaultPath = ${JSON.stringify(input.vaultPath)};
 const dataPath = path.join(vaultPath, ".obsidian", "plugins", ${JSON.stringify(OBSIDIAN_PLUGIN_ID)}, "data.json");
 
-let data;
-try {
-  data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
-} catch (err) {
-  console.error(\`obsidian-mcp-connector: could not read \${dataPath}: \${err.message}\`);
+const RETRY_WINDOW_MS = 30000;
+const RETRY_INTERVAL_MS = 1000;
+
+function readTransport() {
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
+  } catch (err) {
+    return { error: \`could not read \${dataPath}: \${err.message}\` };
+  }
+  const transport = data.mcpTransport || {};
+  const port = transport.livePort;
+  const token = transport.bearerToken;
+  if (!port || !token) {
+    return { error: \`\${dataPath} is missing mcpTransport.livePort or mcpTransport.bearerToken\` };
+  }
+  return { port, token };
+}
+
+function probePort(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ port, host: "127.0.0.1" });
+    const finish = (ok) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(ok);
+    };
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(1000, () => finish(false));
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Re-reads data.json on every attempt, not just once: a slow-starting
+// plugin can still be mid-fallback across the port range when this
+// first runs, so an early read could catch a livePort value that is
+// about to change.
+async function waitForServer() {
+  const deadline = Date.now() + RETRY_WINDOW_MS;
+  let lastError = "timed out waiting for the MCP server";
+  while (Date.now() < deadline) {
+    const resolved = readTransport();
+    if (resolved.error) {
+      lastError = resolved.error;
+    } else if (await probePort(resolved.port)) {
+      return resolved;
+    } else {
+      lastError = \`port \${resolved.port} is not accepting connections yet\`;
+    }
+    await sleep(RETRY_INTERVAL_MS);
+  }
+  console.error(\`obsidian-mcp-connector: \${lastError} — is Obsidian open with the vault loaded?\`);
   process.exit(1);
 }
 
-const transport = data.mcpTransport || {};
-const port = transport.livePort;
-const token = transport.bearerToken;
-if (!port || !token) {
-  console.error(\`obsidian-mcp-connector: \${dataPath} is missing mcpTransport.livePort or mcpTransport.bearerToken — is Obsidian running?\`);
-  process.exit(1);
-}
-
-const url = \`http://127.0.0.1:\${port}/mcp\`;
-const args = ["-y", "mcp-remote", url, "--header", \`Authorization: Bearer \${token}\`];
-spawn("npx", args, { stdio: "inherit" }).on("exit", (c) => process.exit(c ?? 0));
+(async () => {
+  const { port, token } = await waitForServer();
+  const url = \`http://127.0.0.1:\${port}/mcp\`;
+  const args = ["-y", "mcp-remote", url, "--header", \`Authorization: Bearer \${token}\`];
+  spawn("npx", args, { stdio: "inherit" }).on("exit", (c) => process.exit(c ?? 0));
+})();
 `;
 }
 


### PR DESCRIPTION
## Pull Request Description
Diagnosed a live incident on a real machine: Obsidian's window was closed while its main process stayed alive (common on macOS), so the plugin's HTTP server wasn't listening on any port. The `.mcpb` shim read the last known port from `data.json` and spawned `mcp-remote` immediately, which failed right away with nothing to retry.

Checked `mcp-remote`'s own CLI flags first (fetched its README): it has an `--auth-timeout` for the OAuth callback, but no option to retry the initial connection against a server that isn't listening yet. So the fix lives in the shim itself.

The shim now polls `data.json` and probes the resolved port with a raw TCP connection every second, for up to 30 seconds, before spawning `mcp-remote`. It re-reads `data.json` on every attempt, not just once, since a slow-starting plugin can still be mid-fallback across the port range when the shim first runs.

Scope note: the Windows Python bridge (`scripts/obsidian_mcp_bridge.py`) has a related but larger gap (no dynamic port/token resolution at all yet, let alone a retry), left out of this change since it's architecturally different and wasn't part of what was just diagnosed.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Internal/tooling change

## Testing
**How has this been tested?**
- [x] MCP server functionality verified (`bun test`, 1397 pass, plus a manual `node --check` of the generated shim source and a read-through confirming the retry loop shape)
- [ ] Local Obsidian vault testing
- [ ] Claude Desktop integration tested
- [ ] Cross-platform testing (if applicable)

## Architecture Compliance
- [x] Follows feature-based architecture patterns (see `/docs/project-architecture.md`)
- [ ] Uses ArkType for runtime validation where applicable
- [x] Implements proper error handling
- [ ] Includes setup function for new features
- [x] Follows coding standards in `.clinerules`

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Security Considerations
- [x] No hardcoded secrets or API keys
- [ ] Input validation implemented where needed
- [x] No new security vulnerabilities introduced
- [ ] Follows minimum permission principles

## Additional Context
Follow-up to #361/#362/#363 (the stale port/token fix and its docs). This addresses a second, distinct failure mode: the server genuinely not running yet, rather than a client pointed at the wrong port/token.

## For Maintainers
**Review checklist:**
- [ ] Code quality and architecture compliance
- [ ] Security review completed
- [ ] Tests adequate and passing
- [ ] Documentation updated as needed
- [ ] Ready for release

---
**Remember**: This is volunteer work. Be patient during the review process.
