### PR TITLE
fix(mcp-client-config): use ${__dirname} in .mcpb server args

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.test.ts
@@ -87,7 +87,7 @@ describe("generateMcpb", () => {
       expect(server.entry_point).toBe("server/index.js");
       expect(server.mcp_config).toEqual({
         command: "node",
-        args: ["server/index.js"],
+        args: ["${__dirname}/server/index.js"],
       });
     });
 

--- a/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.ts
+++ b/packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.ts
@@ -118,7 +118,7 @@ function buildManifest(input: McpbGeneratorInput): Record<string, unknown> {
       entry_point: "server/index.js",
       // Launches the shim above, which resolves port + token from
       // data.json at spawn time — no secret embedded in this manifest.
-      mcp_config: { command: "node", args: ["server/index.js"] },
+      mcp_config: { command: "node", args: ["${__dirname}/server/index.js"] },
     },
   };
 }


### PR DESCRIPTION
## Summary
- The generated `.mcpb` manifest's `mcp_config.args` used a bare relative path (`"server/index.js"`), which resolves against whatever working directory Claude Desktop spawns `node` with.
- The DXT/MCPB spec documents `${__dirname}` as the template variable for the extension's own install directory. Prefixing it makes resolution independent of Claude Desktop's working directory, a likely cause of the connector getting stuck.

## Test plan
- [x] `bun test` (1397 pass)
- [x] `bun run check` (type check green)