### PR TITLE
fix(scripts): set upstream when pushing new release branch

### DIFF
--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -54,7 +54,7 @@ writeFileSync(pluginVersionsPath, JSON.stringify(versions, null, "\t") + "\n");
 await $`git add package.json ${pluginManifestPath} ${pluginVersionsPath}`;
 await $`git commit -m ${json.version}`;
 await $`git tag ${json.version}`;
-await $`git push`;
+await $`git push -u origin ${currentBranch}`;
 await $`git push origin ${json.version}`;
 
 function bump(semver: [number, number, number], semverPart = "patch") {


### PR DESCRIPTION
`scripts/version.ts`'s `git push` fails with "no upstream branch" the first time it runs on a freshly created `chore/release-*` branch (reproduced during the 0.27.0 release just now, worked around manually). Use `git push -u origin ${currentBranch}` instead so the first push on a new release branch sets tracking automatically.