### PR TITLE
fix(get-vault-file): add missing structuredContent for format=json

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.test.ts
@@ -54,7 +54,7 @@ describe("get_vault_file tool", () => {
     });
   });
 
-  test("getVaultFileOutputSchema accepts the actual format=json output shape", async () => {
+  test("getVaultFileOutputSchema accepts the actual format=json structuredContent", async () => {
     setMockFile("a.md", "---\ntags: [foo]\n---\n# Body");
     setMockMetadata("a.md", {
       frontmatter: { tags: ["foo"] },
@@ -64,13 +64,15 @@ describe("get_vault_file tool", () => {
       arguments: { path: "a.md", format: "json" },
       app: mockApp(),
     });
-    const parsed = JSON.parse((result.content[0] as { text: string }).text);
 
     // Schema-vs-actual consistency: the real handler output must satisfy the
     // declared outputSchema, or clients validating structuredContent break.
-    const validated = getVaultFileOutputSchema(parsed);
+    expect(result.structuredContent).toBeDefined();
+    const validated = getVaultFileOutputSchema(result.structuredContent);
     expect(validated instanceof type.errors).toBe(false);
-    expect(validated).toEqual(parsed);
+    expect(result.structuredContent).toEqual(
+      JSON.parse((result.content[0] as { text: string }).text),
+    );
   });
 
   test("returns image content block for .png file", async () => {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 import { type App, type TFile } from "obsidian";
 import { resolveTFile } from "../services/resolveTFile";
+import { successJson } from "../services/responseBuilders";
 
 /**
  * Maps lowercased file extensions to their MIME type and MCP content-block
@@ -158,6 +159,7 @@ export async function readVaultFileAsJson(
 
 export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
   content: Array<ContentBlock>;
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }> {
   const resolved = resolveTFile(ctx.app.vault, ctx.arguments.path);
@@ -189,9 +191,7 @@ export async function getVaultFileHandler(ctx: GetVaultFileContext): Promise<{
   // the drift between the description and the actual response.
   if (ctx.arguments.format === "json") {
     const json = await readVaultFileAsJson(ctx.app, file);
-    return {
-      content: [{ type: "text", text: JSON.stringify(json) }],
-    };
+    return successJson(json);
   }
 
   // ── Text content ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `get_vault_file` declares an `outputSchema` for its `format=json` response (`mcp-tools/index.ts:400`), but the handler only wrote the JSON into `content[0].text` and never set `structuredContent` — MCP clients validating the response against the declared schema (this is how Cowork surfaced it: "get_vault_file ha un bug con l'output schema") saw the field missing.
- Fixed by switching the `format=json` branch to the shared `successJson()` helper (`responseBuilders.ts`), already used by the plural sibling `get_vault_files`. Same wire text on `content[0].text`, now with `structuredContent` populated too.
- The existing `getVaultFileOutputSchema` test validated `content[0].text` re-parsed as JSON instead of `structuredContent` itself, so it passed despite the bug. Fixed the test to check `structuredContent` directly.

## Test plan

- [x] `bun run check` — clean
- [x] `bun test` — 1486 pass, 0 fail
