### PR TITLE
fix(mcp-tools): stop declaring an outputSchema for get_vault_file

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/index.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { registerTools } from "./index";
+import { ToolRegistryClass } from "$/features/mcp-transport/services/toolRegistry";
+import { mockApp } from "$/test-setup";
+import type McpToolsPlugin from "$/main";
+
+// Regression guard for the 0.27.2–0.27.6 get_vault_file breakage: the MCP
+// SDK client hard-fails (-32600) every non-error response of a tool that
+// advertises an outputSchema unless it carries structuredContent, so a
+// polymorphic tool (text OR image OR audio OR JSON-hint output) must never
+// declare one. No registered tool does today; if a future tool with a
+// uniform structured output legitimately declares a schema, allowlist it
+// here explicitly after verifying EVERY success path of its handler
+// returns a conforming structuredContent.
+test("no registered tool declares an MCP outputSchema", async () => {
+  const registry = new ToolRegistryClass();
+  // plugin is only captured lazily inside handler closures at
+  // registration time, so a bare stub is enough to enumerate the list.
+  const plugin = {} as McpToolsPlugin;
+  await registerTools(registry, {
+    app: mockApp(),
+    plugin,
+    pluginVersion: "0.0.0-test",
+  });
+
+  const { tools } = registry.list();
+  expect(tools.length).toBeGreaterThan(40);
+  const withSchema = tools.filter((t) => "outputSchema" in t);
+  expect(withSchema.map((t) => t.name)).toEqual([]);
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -35,11 +35,7 @@ import {
   listVaultFilesHandler,
   listVaultFilesSchema,
 } from "./tools/listVaultFiles";
-import {
-  getVaultFileHandler,
-  getVaultFileOutputSchema,
-  getVaultFileSchema,
-} from "./tools/getVaultFile";
+import { getVaultFileHandler, getVaultFileSchema } from "./tools/getVaultFile";
 import {
   getVaultFilesHandler,
   getVaultFilesSchema,
@@ -395,15 +391,10 @@ export async function registerTools(
   // annotations are looked up by name at list() time.
   registry.setAnnotations(TOOL_ANNOTATIONS);
 
-  // Output schemas are looked up by name at list() time, same as
-  // annotations. Only get_vault_file's format=json response is modeled.
-  registry.setOutputSchemas({
-    // toJsonSchema() returns ArkType's JsonSchema union; the registry stores
-    // an opaque JSON-schema record, so narrow it to that shape here.
-    get_vault_file:
-      getVaultFileOutputSchema.toJsonSchema() as unknown as Record<
-        string,
-        unknown
-      >,
-  });
+  // Deliberately NO registry.setOutputSchemas() call here. The MCP SDK
+  // client rejects every non-error response of a tool that advertises an
+  // outputSchema unless it carries structuredContent, so a polymorphic
+  // tool (get_vault_file returns text OR image OR audio OR a JSON hint)
+  // can never declare one — doing so in 0.27.2 broke every default-format
+  // get_vault_file call with -32600. index.test.ts guards this.
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.test.ts
@@ -54,6 +54,25 @@ describe("get_vault_file tool", () => {
     });
   });
 
+  test("polymorphic contract: default format has no structuredContent, format=json does", async () => {
+    setMockFile("a.md", "# Body");
+    const plain = await getVaultFileHandler({
+      arguments: { path: "a.md" },
+      app: mockApp(),
+    });
+    // The tool declares no MCP outputSchema (see index.test.ts), so the
+    // default text response legitimately omits structuredContent — with a
+    // declared schema this same response would be rejected client-side
+    // with -32600 (the 0.27.2–0.27.6 bug).
+    expect(plain.structuredContent).toBeUndefined();
+
+    const json = await getVaultFileHandler({
+      arguments: { path: "a.md", format: "json" },
+      app: mockApp(),
+    });
+    expect(json.structuredContent).toBeDefined();
+  });
+
   test("getVaultFileOutputSchema accepts the actual format=json structuredContent", async () => {
     setMockFile("a.md", "---\ntags: [foo]\n---\n# Body");
     setMockMetadata("a.md", {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFile.ts
@@ -115,10 +115,17 @@ export type VaultFileJson = {
 };
 
 /**
- * Output schema for the `format=json` response (the `structuredContent`
- * shape). Describes VaultFileJson only — the polymorphic text/image/audio
- * content-block cases are deliberately not modeled here. Kept structurally
- * in lockstep with VaultFileJson and readVaultFileAsJson().
+ * Internal contract for the `format=json` response's `structuredContent`
+ * shape, kept structurally in lockstep with VaultFileJson and
+ * readVaultFileAsJson() and asserted by getVaultFile.test.ts.
+ *
+ * Deliberately NOT declared as the tool's MCP outputSchema: the SDK client
+ * rejects every non-error response lacking structuredContent once a tool
+ * advertises one, and this tool is polymorphic (default text, image, audio,
+ * and binary-hint branches carry no structuredContent). Declaring it in
+ * 0.27.2 broke every default-format call with -32600; emitting
+ * structuredContent without a declared schema is spec-legal and is what the
+ * format=json branch still does via successJson().
  */
 export const getVaultFileOutputSchema = type({
   path: "string",

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/toolRegistry.ts
@@ -252,6 +252,13 @@ export class ToolRegistryClass<
    * public tool name. Same lazy-lookup / cache-invalidation contract as
    * setAnnotations: order relative to register() does not matter, and
    * entries for names that never register are simply unused.
+   *
+   * WARNING: only declare a schema for a tool whose EVERY non-error
+   * response includes a conforming `structuredContent`. The MCP SDK
+   * client hard-fails (-32600) any non-error response without it once
+   * the schema is advertised, so polymorphic tools (mixed text/image/
+   * audio outputs) must never appear here — get_vault_file did in
+   * 0.27.2–0.27.6 and every default-format call broke.
    */
   setOutputSchemas = (byName: Record<string, Record<string, unknown>>) => {
     for (const [name, outputSchema] of Object.entries(byName)) {


### PR DESCRIPTION
## Summary

`get_vault_file` was still broken on 0.27.6: every default-format call failed with `MCP error -32600: Tool get_vault_file has an output schema but did not return structured content` (reported 15/07, re-confirmed by a full connector check on 16/07).

Root cause, verified in the MCP SDK client (`client/index.js:498-501`): once a tool advertises an `outputSchema` in `tools/list`, the client rejects **every** non-error response that lacks `structuredContent`. PR #379 (0.27.4) added `structuredContent` to the `format=json` branch only, but the tool is polymorphic:

- default (markdown/text) → text block, no structuredContent → -32600 on every plain read
- `format=json` → structuredContent (the only branch #379 fixed)
- image / audio → native binary content blocks, no structuredContent → -32600
- binary-hint / oversized → JSON text hint, no structuredContent → -32600

No single schema can describe those outputs, and image/audio blocks aren't representable as structured content at all, so declaring an `outputSchema` on this tool (added in 0.27.2) is fundamentally incompatible with the spec. This PR removes the declaration:

- Drop the `registry.setOutputSchemas({ get_vault_file: ... })` registration in `mcp-tools/index.ts`. The `setOutputSchemas` registry mechanism stays (generic, tested), now with a docstring warning about the client-side MUST rule.
- `format=json` keeps emitting `structuredContent` via `successJson()` — legal without a declared schema, so structured-aware clients lose nothing.
- `getVaultFileOutputSchema` stays as the internal shape contract for the json branch, with its test.
- New regression test (`mcp-tools/index.test.ts`): registers all tools against a real registry and asserts **no** tools/list entry declares an `outputSchema`; plus a polymorphic-contract test on the handler (default → no structuredContent, json → structuredContent).

Why the suite never caught it: unit tests call the handler directly, while the -32600 validation happens inside the MCP SDK client, outside our process. The new list-level invariant test closes that gap at the declaration site.

A patch release (0.27.7) must follow so installed plugins pick the fix up.

## Test plan

- [x] `bun run check` — clean
- [x] `bun run format:check` — clean
- [x] `bun run build` — succeeds
- [x] `bun test` — 1489 pass (2 new), 0 fail
