### PR TITLE
fix(mcp-tools): patch_vault_file no longer reports false success

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/services/patchHelpers.ts
@@ -599,6 +599,26 @@ export type PatchArgs = {
  * Returns:
  *   An MCP-shaped result object. Sets `isError: true` on failure.
  */
+/**
+ * Builds the standard patch response, distinguishing an actual write from a
+ * no-op (new content identical to what was already there) so callers can't
+ * report "success" when nothing on disk actually changed.
+ */
+function patchResult(changed: boolean): {
+  content: Array<{ type: "text"; text: string }>;
+} {
+  return {
+    content: [
+      {
+        type: "text",
+        text: changed
+          ? "File patched successfully"
+          : "File patched successfully — no changes detected: resulting content is identical to the existing content.",
+      },
+    ],
+  };
+}
+
 export async function applyPatch(
   app: App,
   file: TFile,
@@ -613,6 +633,25 @@ export async function applyPatch(
   const defaultCreate = args.targetType !== "block";
   const createIfMissing = args.createTargetIfMissing ?? defaultCreate;
 
+  // Frontmatter/heading targets require a markdown file: processFrontMatter and
+  // heading-section parsing both assume markdown shape, and Obsidian silently
+  // no-ops processFrontMatter on non-markdown files instead of erroring — which
+  // used to surface as a false "success" with zero actual changes. Block targets
+  // stay exempt (legitimate on non-md files per the block branch below).
+  if (args.targetType !== "block" && file.extension !== "md") {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            `Cannot patch ${args.targetType} target on non-markdown file "${file.path}": ` +
+            `frontmatter and heading operations require a markdown (.md) file (got ".${file.extension}").`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
   // ── frontmatter branch ──────────────────────────────────────────────────
   // Dispatches through the pure planners above so the policy stays testable
   // without needing the full `processFrontMatter` machinery. `rejection` is
@@ -623,9 +662,18 @@ export async function applyPatch(
   // mutation keeps the file untouched while letting us return a typed error.
   if (args.targetType === "frontmatter") {
     let rejection: string | null = null;
+    let valueChanged = false;
     await app.fileManager.processFrontMatter(file, (rawFm) => {
       const fm = rawFm as Record<string, unknown>;
       const existing = fm[args.target];
+      if (existing === undefined && !createIfMissing) {
+        rejection = `Frontmatter key "${args.target}" not found and createTargetIfMissing is false. Refusing to create it.`;
+        return;
+      }
+      const recordChange = (next: unknown) => {
+        valueChanged =
+          JSON.stringify(existing ?? null) !== JSON.stringify(next ?? null);
+      };
       if (args.operation === "replace") {
         const plan = planFrontmatterReplace(
           existing,
@@ -636,7 +684,9 @@ export async function applyPatch(
           rejection = plan.message;
           return;
         }
-        fm[args.target] = plan.kind === "ok" ? plan.value : args.content;
+        const next = plan.kind === "ok" ? plan.value : args.content;
+        fm[args.target] = next;
+        recordChange(next);
         return;
       }
       // append / prepend
@@ -646,18 +696,22 @@ export async function applyPatch(
         if (args.operation === "append") arr.push(...plan.values);
         else arr.unshift(...plan.values);
         fm[args.target] = arr;
+        recordChange(arr);
         return;
       }
       // string-concat: existing is scalar / null / undefined — keep the
       // legacy concatenation semantics for backward compatibility.
       if (existing == null) {
         fm[args.target] = args.content;
+        recordChange(args.content);
         return;
       }
-      fm[args.target] =
+      const next =
         args.operation === "append"
           ? String(existing) + args.content
           : args.content + String(existing);
+      fm[args.target] = next;
+      recordChange(next);
     });
     if (rejection !== null) {
       return {
@@ -665,7 +719,7 @@ export async function applyPatch(
         isError: true,
       };
     }
-    return { content: [{ type: "text", text: "File patched successfully" }] };
+    return patchResult(valueChanged);
   }
 
   // ── heading / block branch — read raw content ────────────────────────
@@ -702,8 +756,9 @@ export async function applyPatch(
       }
       // Append at EOF.
       const body = normalizeAppendBody(args.content, args.operation);
-      await app.vault.modify(file, rawContent + body);
-      return { content: [{ type: "text", text: "File patched successfully" }] };
+      const newContent = rawContent + body;
+      await app.vault.modify(file, newContent);
+      return patchResult(newContent !== rawContent);
     }
 
     const { line: headingLine, level: headingLevel } = found;
@@ -783,8 +838,9 @@ export async function applyPatch(
         ...lines.slice(sectionEnd),
       ];
     }
-    await app.vault.modify(file, newLines.join("\n"));
-    return { content: [{ type: "text", text: "File patched successfully" }] };
+    const newContent = newLines.join("\n");
+    await app.vault.modify(file, newContent);
+    return patchResult(newContent !== rawContent);
   }
 
   // ── block branch ─────────────────────────────────────────────────────
@@ -811,8 +867,9 @@ export async function applyPatch(
     }
     // Caller explicitly opted into createIfMissing — append at EOF.
     const body = normalizeAppendBody(args.content, args.operation);
-    await app.vault.modify(file, rawContent + body);
-    return { content: [{ type: "text", text: "File patched successfully" }] };
+    const newContent = rawContent + body;
+    await app.vault.modify(file, newContent);
+    return patchResult(newContent !== rawContent);
   }
 
   // 0.3.x parity: reject when block resolves inside a table or fenced code
@@ -872,6 +929,7 @@ export async function applyPatch(
       ...lines.slice(blockPos.endLine + 1),
     ];
   }
-  await app.vault.modify(file, newLines.join("\n"));
-  return { content: [{ type: "text", text: "File patched successfully" }] };
+  const newContent = newLines.join("\n");
+  await app.vault.modify(file, newContent);
+  return patchResult(newContent !== rawContent);
 }

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/patchVaultFile.test.ts
@@ -783,3 +783,107 @@ describe("patch_vault_file — block-in-fenced-code via regex-fallback (#84)", (
     expect(final).not.toContain("Postambule prose.");
   });
 });
+
+// ── Non-markdown guard + false-success fix ──────────────────────────────
+describe("patch_vault_file — non-markdown guard and change detection", () => {
+  test("rejects frontmatter target on a non-markdown (.json) file", async () => {
+    setMockFile("state/data.json", '{"key": "value"}');
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "state/data.json",
+        operation: "replace",
+        targetType: "frontmatter",
+        target: "none",
+        content: "x",
+      },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/markdown/i);
+    const file = app.vault.getAbstractFileByPath("state/data.json");
+    if (!file) throw new Error("expected file");
+    const final = await app.vault.read(file as never);
+    expect(final).toBe('{"key": "value"}');
+  });
+
+  test("block target on a non-markdown (.json) file is exempt from the guard", async () => {
+    setMockFile("state/data.json", "para one.\n^my-block\n\npara two.\n");
+    setMockMetadata("state/data.json", {
+      blocks: { "my-block": { startLine: 1, endLine: 1 } },
+    });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "state/data.json",
+        operation: "replace",
+        targetType: "block",
+        target: "my-block",
+        createTargetIfMissing: false,
+        content: "REPLACED.",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+  });
+
+  test("frontmatter createTargetIfMissing:false + missing key returns an error, not success", async () => {
+    setMockFile("Notes/x.md", "---\nstatus: draft\n---\nBody");
+    setMockMetadata("Notes/x.md", { frontmatter: { status: "draft" } });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "replace",
+        targetType: "frontmatter",
+        target: "none",
+        createTargetIfMissing: false,
+        content: "x",
+      },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not found/i);
+    const file = app.vault.getAbstractFileByPath("Notes/x.md");
+    const cache = app.metadataCache.getFileCache(file as never);
+    expect(cache?.frontmatter?.none).toBeUndefined();
+  });
+
+  test("frontmatter replace with a value identical to the existing one reports no change", async () => {
+    setMockFile("Notes/x.md", "---\nstatus: draft\n---\nBody");
+    setMockMetadata("Notes/x.md", { frontmatter: { status: "draft" } });
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/x.md",
+        operation: "replace",
+        targetType: "frontmatter",
+        target: "status",
+        content: "draft",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toMatch(/no changes detected/i);
+  });
+
+  test("heading replace with content identical to the existing section reports no change", async () => {
+    // Fixture chosen so the reconstructed text (heading + normalized blank
+    // separators + body + next heading) is byte-identical to the original —
+    // replacing "old" with "old" under the same blank-line rules is a true no-op.
+    setMockFile("Notes/h.md", "## A\n\nold\n\n## B\n");
+    const app = mockApp();
+    const result = await patchVaultFileHandler({
+      arguments: {
+        path: "Notes/h.md",
+        operation: "replace",
+        targetType: "heading",
+        target: "A",
+        content: "old",
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toMatch(/no changes detected/i);
+  });
+});


### PR DESCRIPTION
## Pull Request Description
Fixes `patch_vault_file` reporting "File patched successfully" even when nothing was actually written to disk.

Two independent bugs, both in `patchHelpers.ts`:
1. `createTargetIfMissing` was computed but never read by the frontmatter branch, so `createTargetIfMissing: false` had no effect there (it already worked correctly for heading/block).
2. There was no file-type guard: a frontmatter or heading patch against a non-markdown file (e.g. `.json`) would call `app.fileManager.processFrontMatter`, which Obsidian silently no-ops on non-markdown files, so the mutation never reached disk, yet the handler still returned an unconditional success string (duplicated at 5 call sites).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] MCP server functionality verified
- Added 5 new test cases in `patchVaultFile.test.ts`: non-markdown frontmatter target rejected, non-markdown block target still allowed, `createTargetIfMissing:false` on a missing frontmatter key now errors instead of succeeding, and two true no-op cases (frontmatter and heading) that now report "no changes detected" instead of blind success.
- Full suite: 1494/1494 tests pass. `bun run check` and `bun run format:check` both clean.

## Checklist
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

## Security Considerations
- [x] No hardcoded secrets or API keys
- [x] Input validation implemented where needed (file-type guard)
- [x] No new security vulnerabilities introduced

## Additional Context
No behavior change for the existing create-on-missing-key default (`createTargetIfMissing: true`, unchanged) or for the already-correct heading/block gating. Block targets stay exempt from the new file-type guard since patching a block reference on a non-markdown file is legitimate.