### PR TITLE
fix(release): publish releases only after assets are attached

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,11 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
-          draft: false
+          # Stays a draft (mutable, not public) until the final "Publish release" step
+          # below, after every asset and attestation is already in place — required
+          # for the immutable-release attestation to snapshot the complete release
+          # instead of racing the asset-upload step.
+          draft: true
           # Pre-release tags carry a SemVer suffix with a hyphen
           # (`0.7.0-beta.1`, `-rc.1`, `-alpha.2`). Mark those prerelease
           # so GitHub does NOT move `/releases/latest` to them — otherwise
@@ -78,6 +82,10 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
+          # Leaves the draft flag untouched on this update — the release stays a
+          # draft (set above by "Create Release") through asset upload; the explicit
+          # "Publish release" step below is the only place that flips it public.
+          omitDraftDuringUpdate: true
           omitName: true
           tag: ${{ github.ref_name }}
           # styles.css intentionally omitted — Svelte 5 inlines component CSS into main.js.
@@ -91,3 +99,8 @@ jobs:
             ---
             ✨ This release includes attested build artifacts.
             📝 View attestation details in the [workflow run](${{ env.GH_WORKFLOW_URL }})
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to **MCP Connector** (formerly `obsidian-mcp-tools`) are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.27.9] — 2026-07-17
+
+### Changed
+
+- **Releases now publish only after every asset is attached, with release immutability enabled.** The release workflow used to create the GitHub release as public before the build even ran, then attach `main.js`, `manifest.json`, and the `.mcpb` afterward, leaving a window where the published release had no assets yet. Releases are now created as a draft, get the build, the artifact attestation, and all assets attached first, and only then get published, with this repository's release-immutability setting turned on. This makes the release's build-provenance attestation verifiable end to end by third parties, instead of racing the asset upload.
+
 ## [0.27.8] — 2026-07-17
 
 ### Fixed


### PR DESCRIPTION
## Pull Request Description
Fixes the root cause behind Obsidian's automated review flagging 0.27.8's `main.js` attestation as failing cryptographic verification, even though the artifact itself is genuinely authentic (its downloaded SHA-256 matches the attestation's recorded digest exactly, and Obsidian's own independent build-verification check separately confirmed the release was reproducible byte-for-byte from source).

The actual problem: `release.yml` created the GitHub release as public (`draft: false`) immediately after checkout, before the build even ran, then attached `main.js`/`manifest.json`/`obsidian-mcp-connector.mcpb` in a later, separate step. That's the exact anti-pattern GitHub's own docs warn against for reliable release attestations, which require the recommended flow: create the release as a draft, attach every asset to the draft, then publish. Without that, this repo's release-immutability setting (now enabled in repo settings) couldn't provide its verification guarantee, and third-party verifiers likely fell back to a more failure-prone direct Sigstore/Rekor check of the manual build-provenance attestation, explaining the intermittent pattern (0.27.5 failed, 0.27.6/0.27.7 passed, 0.27.8 failed, with zero code changes in between).

## Type of Change
- [x] Internal/tooling change

## Testing
- [x] `release.yml` validated as syntactically correct YAML
- Not unit-testable (GitHub Actions workflow); will be exercised end to end by the next tagged release (0.27.9), which is the real verification of this change

## Checklist
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to documentation (CHANGELOG.md)

## Additional Context
Companion change (already applied, not part of this diff): "Enable release immutability" turned on in `Settings → General → Releases`. Per GitHub's docs this only affects releases published after enabling it, so 0.27.0–0.27.8 are unaffected.