### PR TITLE
fix(release): create the release only after the attestation exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,24 +23,6 @@ jobs:
         with:
           bun-version: 1.3.12
 
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-          # Stays a draft (mutable, not public) until the final "Publish release" step
-          # below, after every asset and attestation is already in place — required
-          # for the immutable-release attestation to snapshot the complete release
-          # instead of racing the asset-upload step.
-          draft: true
-          # Pre-release tags carry a SemVer suffix with a hyphen
-          # (`0.7.0-beta.1`, `-rc.1`, `-alpha.2`). Mark those prerelease
-          # so GitHub does NOT move `/releases/latest` to them — otherwise
-          # the community store + BRAT-default users would pull an
-          # unfinished beta as "latest". Stable tags (`0.6.0`) have no
-          # hyphen, so prerelease resolves to false.
-          prerelease: ${{ contains(github.ref_name, '-') }}
-
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
@@ -63,42 +45,34 @@ jobs:
             main.js
             obsidian-mcp-connector.mcpb
 
-      - name: Get existing release body
-        id: get_release_body
-        uses: actions/github-script@v9
+      # Community-verified attestation recipe ordering
+      # (forum.obsidian.md/t/114445): the attestation must exist BEFORE the
+      # release object is created. The release is still created as a draft and
+      # published as a separate last step because this repository enforces
+      # release immutability — a non-draft release locks its assets at
+      # publication, so assets must be attached while still in draft.
+      - name: Create Release with artifacts
+        uses: softprops/action-gh-release@v3
         with:
-          result-encoding: string
-          script: |
-            const release = await github.rest.repos.getRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: ${{ steps.create_release.outputs.id }}
-            });
-            return release.data.body || '';
-
-      - name: Upload plugin artifacts
-        env:
-          GH_WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          # Leaves the draft flag untouched on this update — the release stays a
-          # draft (set above by "Create Release") through asset upload; the explicit
-          # "Publish release" step below is the only place that flips it public.
-          omitDraftDuringUpdate: true
-          omitName: true
-          tag: ${{ github.ref_name }}
+          generate_release_notes: true
+          draft: true
+          # Pre-release tags carry a SemVer suffix with a hyphen
+          # (`0.7.0-beta.1`, `-rc.1`, `-alpha.2`). Mark those prerelease
+          # so GitHub does NOT move `/releases/latest` to them — otherwise
+          # the community store + BRAT-default users would pull an
+          # unfinished beta as "latest". Stable tags (`0.6.0`) have no
+          # hyphen, so prerelease resolves to false.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           # styles.css intentionally omitted — Svelte 5 inlines component CSS into main.js.
           # NOTE: obsidian-mcp-connector.mcpb is a Claude Desktop extension (not a plugin zip).
-          # The GH013 rule targets .zip plugin archives; .mcpb has not triggered it.
-          # If the store reviewer flags this, move the .mcpb upload to a separate step.
-          artifacts: "main.js,manifest.json,obsidian-mcp-connector.mcpb"
+          files: |
+            main.js
+            manifest.json
+            obsidian-mcp-connector.mcpb
           body: |
-            ${{ steps.get_release_body.outputs.result }}
-
             ---
             ✨ This release includes attested build artifacts.
-            📝 View attestation details in the [workflow run](${{ env.GH_WORKFLOW_URL }})
+            📝 View attestation details in the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Publish release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to **MCP Connector** (formerly `obsidian-mcp-tools`) are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.27.13] — 2026-07-17
+
+### Changed
+
+- **The release workflow now creates the GitHub release only after the artifact attestation exists.** This matches the community-verified recipe for attested plugin artifacts: attest first, then create the release with its assets in a single step, publish last. No plugin code changes.
+
 ## [0.27.12] — 2026-07-17
 
 ### Fixed


### PR DESCRIPTION
## Pull Request Description
Aligns `release.yml` with the community-verified attestation recipe (forum.obsidian.md/t/114445): the artifact attestation is generated first, then the GitHub release gets created with all its assets in a single `softprops/action-gh-release` step, and publishing stays a separate final step.

This removes the last structural difference between our flow and the recipe: until now the (draft) release object existed before the build and attestation ran. It also simplifies the workflow, dropping the early release creation, the get-release-body script step, and the separate ncipollo upload step. The release still goes through a draft phase because this repository enforces release immutability, and assets must attach before publication locks them.

Context: fifth iteration on the community-store "attestation failed cryptographic verification" false positive. Cross-repo evidence (our releases 0.27.8 to 0.27.12 plus another developer's independent plugin, choisungwook/obsidian-plugins, failing identically since Jul 16 evening with post-hoc-valid attestations) points at the review system, but this closes the one remaining delta from the known-good recipe.

## Type of Change
- [x] Internal/tooling change

## Testing
- [x] `release.yml` validated as syntactically correct YAML; step order verified: build → validate → attest → create release with assets (draft) → publish
- Exercised end to end by the 0.27.13 release that follows this merge

## Checklist
- [x] I have made corresponding changes to documentation (CHANGELOG.md)