### PR TITLE
Add create_vault_binary_file tool for writing binary content to the vault

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -45,6 +45,10 @@ import {
   createVaultFileSchema,
 } from "./tools/createVaultFile";
 import {
+  createVaultBinaryFileHandler,
+  createVaultBinaryFileSchema,
+} from "./tools/createVaultBinaryFile";
+import {
   appendToVaultFileHandler,
   appendToVaultFileSchema,
 } from "./tools/appendToVaultFile";
@@ -241,6 +245,11 @@ export async function registerTools(
   );
   registry.register(createVaultFileSchema, async ({ arguments: args }) =>
     createVaultFileHandler({ arguments: args, app: ctx.app }),
+  );
+  registry.register(
+    createVaultBinaryFileSchema,
+    async ({ arguments: args }) =>
+      createVaultBinaryFileHandler({ arguments: args, app: ctx.app }),
   );
   registry.register(appendToVaultFileSchema, async ({ arguments: args }) =>
     appendToVaultFileHandler({ arguments: args, app: ctx.app }),

--- a/packages/obsidian-plugin/src/features/mcp-tools/index.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/index.ts
@@ -246,10 +246,8 @@ export async function registerTools(
   registry.register(createVaultFileSchema, async ({ arguments: args }) =>
     createVaultFileHandler({ arguments: args, app: ctx.app }),
   );
-  registry.register(
-    createVaultBinaryFileSchema,
-    async ({ arguments: args }) =>
-      createVaultBinaryFileHandler({ arguments: args, app: ctx.app }),
+  registry.register(createVaultBinaryFileSchema, async ({ arguments: args }) =>
+    createVaultBinaryFileHandler({ arguments: args, app: ctx.app }),
   );
   registry.register(appendToVaultFileSchema, async ({ arguments: args }) =>
     appendToVaultFileHandler({ arguments: args, app: ctx.app }),

--- a/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/toolAnnotations.ts
@@ -54,6 +54,8 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   get_vault_file_partial: READ_ONLY,
   // Overwrites when the path already exists (documented behavior).
   create_vault_file: { ...DESTRUCTIVE, idempotentHint: true },
+  // Same overwrite semantics as create_vault_file, for binary content.
+  create_vault_binary_file: { ...DESTRUCTIVE, idempotentHint: true },
   append_to_vault_file: SAFE_WRITE,
   patch_vault_file: DESTRUCTIVE,
   delete_vault_file: DESTRUCTIVE,

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultBinaryFile.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultBinaryFile.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  base64ToBuf,
+  createVaultBinaryFileHandler,
+  createVaultBinaryFileSchema,
+} from "./createVaultBinaryFile";
+import {
+  getMockFolders,
+  mockApp,
+  resetMockVault,
+  setMockFile,
+  setMockFolder,
+} from "$/test-setup";
+
+beforeEach(() => resetMockVault());
+
+function b64(text: string): string {
+  return Buffer.from(text, "utf-8").toString("base64");
+}
+
+describe("create_vault_binary_file tool", () => {
+  test("schema declares the tool name", () => {
+    expect(createVaultBinaryFileSchema.get("name")?.toString()).toContain(
+      "create_vault_binary_file",
+    );
+  });
+
+  test("base64ToBuf round-trips through btoa/atob-style encoding", () => {
+    const original = "hello binary world";
+    const buf = base64ToBuf(b64(original));
+    const decoded = new TextDecoder().decode(buf);
+    expect(decoded).toBe(original);
+  });
+
+  test("creates new binary file at root path", async () => {
+    const app = mockApp();
+    const result = await createVaultBinaryFileHandler({
+      arguments: { path: "sketch.png", content: b64("fake-png-bytes") },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("sketch.png");
+    expect(file).not.toBeNull();
+    const bytes = await app.vault.readBinary(file as never);
+    expect(new TextDecoder().decode(bytes)).toBe("fake-png-bytes");
+  });
+
+  test("auto-creates missing parent directories", async () => {
+    const app = mockApp();
+    const result = await createVaultBinaryFileHandler({
+      arguments: {
+        path: "Images/Journal/sketch.png",
+        content: b64("bytes"),
+      },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(getMockFolders()).toEqual(["Images", "Images/Journal"]);
+    const file = app.vault.getAbstractFileByPath("Images/Journal/sketch.png");
+    expect(file).not.toBeNull();
+  });
+
+  test("overwrites existing file when target exists", async () => {
+    setMockFile("sketch.png", "OLD");
+    const app = mockApp();
+    const result = await createVaultBinaryFileHandler({
+      arguments: { path: "sketch.png", content: b64("NEW") },
+      app,
+    });
+    expect(result.isError).toBeUndefined();
+    const file = app.vault.getAbstractFileByPath("sketch.png");
+    const bytes = await app.vault.readBinary(file as never);
+    expect(new TextDecoder().decode(bytes)).toBe("NEW");
+  });
+
+  test("returns isError (does not throw) when path is a folder", async () => {
+    setMockFolder("Images");
+    const app = mockApp();
+    const result = await createVaultBinaryFileHandler({
+      arguments: { path: "Images", content: b64("x") },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/folder, not a file/i);
+  });
+
+  test("returns isError (does not throw) on invalid base64", async () => {
+    const app = mockApp();
+    const result = await createVaultBinaryFileHandler({
+      arguments: { path: "bad.png", content: "not-valid-base64!!!" },
+      app,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not valid base64/i);
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultBinaryFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultBinaryFile.ts
@@ -14,7 +14,7 @@ export const createVaultBinaryFileSchema = type({
     ),
   },
 }).describe(
-  "Creates or overwrites a binary file (image, audio, or any other non-text file) at the given vault-relative path from base64-encoded content. Missing parent directories along the path are created automatically. Use create_vault_file instead for plain text content.",
+  "Creates or overwrites a binary file (image, audio, or any other non-text file) at the given vault-relative path from base64-encoded content. Missing parent directories along the path are created automatically. Use create_vault_file instead for plain text content. Note: the plugin's HTTP transport caps request bodies at 1 MiB, so the maximum writable file is roughly 750 KB after base64 overhead; larger uploads fail with HTTP 413 before reaching this tool.",
 );
 
 export type CreateVaultBinaryFileContext = {

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultBinaryFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultBinaryFile.ts
@@ -47,9 +47,7 @@ export async function createVaultBinaryFileHandler(
   try {
     buf = base64ToBuf(ctx.arguments.content);
   } catch {
-    return errorText(
-      `Content for ${ctx.arguments.path} is not valid base64.`,
-    );
+    return errorText(`Content for ${ctx.arguments.path} is not valid base64.`);
   }
 
   const existing = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);

--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultBinaryFile.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultBinaryFile.ts
@@ -1,0 +1,66 @@
+import { type } from "arktype";
+import { errorText, successText } from "../services/responseBuilders";
+import { TFile, type App } from "obsidian";
+import { ensureParentFolderExists } from "$/features/mcp-tools/services/ensureFolderExists";
+
+export const createVaultBinaryFileSchema = type({
+  name: '"create_vault_binary_file"',
+  arguments: {
+    path: type("string>0").describe(
+      "Vault-relative path including extension (e.g. 'Images/Journal/sketch.png'). Any missing parent directories are created automatically.",
+    ),
+    content: type("string.base64").describe(
+      "Base64-encoded file bytes. Full content of the file; if the path already exists, it is overwritten.",
+    ),
+  },
+}).describe(
+  "Creates or overwrites a binary file (image, audio, or any other non-text file) at the given vault-relative path from base64-encoded content. Missing parent directories along the path are created automatically. Use create_vault_file instead for plain text content.",
+);
+
+export type CreateVaultBinaryFileContext = {
+  arguments: { path: string; content: string };
+  app: App;
+};
+
+/**
+ * Decode a base64 string to an ArrayBuffer using the browser-compatible
+ * atob() built-in, mirroring the encode direction in getVaultFile.ts's
+ * bufToBase64 — avoids a Node.js Buffer dependency so the same code runs
+ * inside the Obsidian plugin (renderer process / Bun test runtime).
+ */
+export function base64ToBuf(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+export async function createVaultBinaryFileHandler(
+  ctx: CreateVaultBinaryFileContext,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  let buf: ArrayBuffer;
+  try {
+    buf = base64ToBuf(ctx.arguments.content);
+  } catch {
+    return errorText(
+      `Content for ${ctx.arguments.path} is not valid base64.`,
+    );
+  }
+
+  const existing = ctx.app.vault.getAbstractFileByPath(ctx.arguments.path);
+  if (existing) {
+    if (!(existing instanceof TFile)) {
+      return errorText(`Path ${ctx.arguments.path} is a folder, not a file.`);
+    }
+    await ctx.app.vault.modifyBinary(existing, buf);
+  } else {
+    await ensureParentFolderExists(ctx.app, ctx.arguments.path);
+    await ctx.app.vault.createBinary(ctx.arguments.path, buf);
+  }
+  return successText("OK");
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -178,6 +178,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "append_to_periodic_note",
         "append_to_vault_file",
         "connect_canvas_nodes",
+        "create_vault_binary_file",
         "create_vault_directory",
         "create_vault_file",
         "delete_active_file",
@@ -223,7 +224,7 @@ describe("end-to-end: HTTP → McpServer", () => {
         "tool_catalog",
         "update_active_file",
       ]);
-      expect(names).toHaveLength(51);
+      expect(names).toHaveLength(52);
 
       // Annotations completeness: every exposed tool must carry MCP
       // annotations with an explicit readOnlyHint and openWorldHint.

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -1046,7 +1046,10 @@ export function mockApp(): App {
       _mockState.files.set(path, content);
       return fileFromPath(path) as unknown as ApiTFile;
     },
-    createBinary: async (path: string, data: ArrayBuffer): Promise<ApiTFile> => {
+    createBinary: async (
+      path: string,
+      data: ArrayBuffer,
+    ): Promise<ApiTFile> => {
       // Same ENOENT-on-missing-parent semantics as create(). Storage
       // reuses the string-keyed files map via TextDecoder, the inverse
       // of readBinary's TextEncoder — a round trip for any valid UTF-8

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -1046,6 +1046,23 @@ export function mockApp(): App {
       _mockState.files.set(path, content);
       return fileFromPath(path) as unknown as ApiTFile;
     },
+    createBinary: async (path: string, data: ArrayBuffer): Promise<ApiTFile> => {
+      // Same ENOENT-on-missing-parent semantics as create(). Storage
+      // reuses the string-keyed files map via TextDecoder, the inverse
+      // of readBinary's TextEncoder — a round trip for any valid UTF-8
+      // byte sequence (sufficient for tests, which control the bytes).
+      const slash = path.lastIndexOf("/");
+      if (slash > 0) {
+        const parent = path.slice(0, slash);
+        if (!_mockState.folders.has(parent)) {
+          throw new Error(
+            `ENOENT: no such file or directory, open '<vault>/${path}'`,
+          );
+        }
+      }
+      _mockState.files.set(path, new TextDecoder().decode(data));
+      return fileFromPath(path) as unknown as ApiTFile;
+    },
     createFolder: async (path: string): Promise<ApiTFolder> => {
       // Real Obsidian throws "Folder already exists" on a duplicate.
       // The production helper swallows that case, so the mock must
@@ -1055,6 +1072,13 @@ export function mockApp(): App {
       }
       _mockState.folders.add(path);
       return folderFromPath(path) as unknown as ApiTFolder;
+    },
+    modifyBinary: async (file: ApiTFile, data: ArrayBuffer): Promise<void> => {
+      const path = (file as unknown as MockTFile).path;
+      if (_mockState.modifyFailPaths.has(path)) {
+        throw new Error(`mock modify failure: ${path}`);
+      }
+      _mockState.files.set(path, new TextDecoder().decode(data));
     },
     modify: async (file: ApiTFile, content: string): Promise<void> => {
       const path = (file as unknown as MockTFile).path;


### PR DESCRIPTION
## Pull Request Description

`create_vault_file` only accepts string content, so there's currently no way for an MCP client to write an image, audio file, or any other binary asset into the vault — generated images have to be handed to the user as a chat download and placed in the vault manually.

This adds `create_vault_binary_file`, a binary counterpart that mirrors `create_vault_file`'s create-or-overwrite semantics and auto-created parent directory behavior, but takes base64-encoded content and calls `vault.createBinary` / `vault.modifyBinary` instead of the text `vault.create` / `vault.modify`.

The plugin already invests a lot in the read side of this (the 10 MiB inline cap and MIME-type detection for images/audio in `get_vault_file`), so this felt like a natural, missing complement rather than new scope.

**Changes:**
- New tool: `packages/obsidian-plugin/src/features/mcp-tools/tools/createVaultBinaryFile.ts`
- Registered in `index.ts`, annotated in `toolAnnotations.ts` (same `DESTRUCTIVE` + `idempotentHint: true` as `create_vault_file`)
- Tests in `createVaultBinaryFile.test.ts`, following the existing `createVaultFile.test.ts` structure
- Extended the mock vault test harness (`test-setup.ts`) with `createBinary`/`modifyBinary` — it previously only had `readBinary`
- Updated the full-registry regression test in `mcpServer.test.ts` to include the new tool (52 tools, up from 51)

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Internal/tooling change

## Testing
**How has this been tested?**
- [x] Local Obsidian vault testing (wrote a generated PNG into a real vault via the new tool: base64 decoded correctly, the missing parent folder was auto-created, and reading the file back through `get_vault_file` returned a valid, rendering image)
- [x] MCP server functionality verified (full-registry e2e test in `mcpServer.test.ts` exercises the tool over the HTTP → McpServer wire path)
- [x] Claude Desktop integration tested (the live-vault test above was driven through Claude Desktop's MCP connection to the running plugin)
- [ ] Cross-platform testing (if applicable)

Verified in a clean environment (fresh clone, fresh `bun install`): all 7 new tests pass, the full suite is 1499/1501 (the 2 failures are a pre-existing port-binding test in `connectorShim.test.ts`, present on the base commit in that environment too), and `bun run build` (`tsc --noEmit` + bundle) is clean.

## Architecture Compliance
- [x] Follows feature-based architecture patterns (see `/docs/project-architecture.md`)
- [x] Uses ArkType for runtime validation where applicable (`string.base64` on content)
- [x] Implements proper error handling (invalid base64 and folder-collision return `isError` rather than throwing)
- [ ] Includes setup function for new features (N/A — adds a tool to the existing mcp-tools feature, no new feature folder)
- [x] Follows coding standards in `.clinerules`

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Security Considerations
- [x] No hardcoded secrets or API keys
- [x] Input validation implemented where needed
- [x] No new security vulnerabilities introduced
- [x] Follows minimum permission principles

## Additional Context

The base64 decode uses the browser-compatible `atob()` built-in, mirroring the encode direction in `getVaultFile.ts`'s `bufToBase64`, so no Node.js `Buffer` dependency is introduced into shipped code.

**Size limit:** the HTTP transport's `MAX_REQUEST_BODY_BYTES` (1 MiB) caps a single write at roughly 750 KB of binary after base64 overhead — oversized uploads get a 413 before reaching the tool. This is documented in the tool's schema description so MCP clients can avoid the attempt. There's an asymmetry with the read side (10 MiB inline cap in `get_vault_file`); if larger writes are ever wanted, a chunked/append-binary variant would be the natural follow-up, but that felt like separate scope.

Happy to adjust naming, scope, or behavior if you'd rather shape this differently — first time touching this codebase, so I've tried to match existing patterns as closely as possible (`createVaultFile.ts` was the direct template).