### PR TITLE
ci: type-check Svelte and smoke the .mcpb bundle on both loaders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Typecheck (workspace-wide)
         run: bun run check
 
+      - name: Typecheck (Svelte)
+        run: cd packages/obsidian-plugin && bun run check:svelte
+
       - name: Build (bundle smoke)
         run: bun run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,6 @@ jobs:
 
       - name: Tests — obsidian-plugin
         run: cd packages/obsidian-plugin && bun test
+
+      - name: .mcpb bundle smoke (both loaders, #412 regression guard)
+        run: cd packages/obsidian-plugin && bun run test:mcpb

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "fs-extra": "^11.2.0",
         "moment": "^2.30.1",
         "obsidian": "latest",
+        "svelte-check": "^4.7.4",
         "tslib": "2.4.0",
         "typescript": "^5.7.2",
       },
@@ -211,6 +212,8 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
 
+    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.1", "", {}, "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/codemirror": ["@types/codemirror@5.60.8", "", { "dependencies": { "@types/tern": "*" } }, "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw=="],
@@ -279,6 +282,8 @@
 
     "chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
 
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
@@ -330,6 +335,8 @@
     "external-editor": ["external-editor@3.1.0", "", { "dependencies": { "chardet": "^0.7.0", "iconv-lite": "^0.4.24", "tmp": "^0.0.33" } }, "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
@@ -391,6 +398,8 @@
 
     "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
 
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mute-stream": ["mute-stream@1.0.0", "", {}, "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="],
@@ -411,6 +420,8 @@
 
     "onnxruntime-web": ["onnxruntime-web@1.26.0", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.26.0", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-LbRr/8zZt2xilI2smrVQGGKINo0U46i8qJp+UXyMBGfqN7KjnH1BiwCwLwyNIVV4i9CKFv7Sf4PwLKWnT8/bEA=="],
 
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
     "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
@@ -429,9 +440,13 @@
 
     "readdir-glob": ["readdir-glob@3.0.0", "", { "dependencies": { "minimatch": "^10.2.2" } }, "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw=="],
 
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 
     "rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
+
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
@@ -462,6 +477,8 @@
     "style-mod": ["style-mod@4.1.2", "", {}, "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="],
 
     "svelte": ["svelte@5.56.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.11", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA=="],
+
+    "svelte-check": ["svelte-check@4.7.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.1", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ=="],
 
     "svelte-preprocess": ["svelte-preprocess@6.0.5", "", { "peerDependencies": { "@babel/core": "^7.10.2", "coffeescript": "^2.5.1", "less": "^3.11.3 || ^4.0.0", "postcss": "^7 || ^8", "postcss-load-config": ">=3", "pug": "^3.0.0", "sass": "^1.26.8", "stylus": ">=0.55", "sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0", "svelte": "^4.0.0 || ^5.0.0-next.100 || ^5.0.0", "typescript": "^5.0.0 || ^6.0.0" }, "optionalPeers": ["@babel/core", "coffeescript", "less", "postcss", "postcss-load-config", "pug", "sass", "stylus", "sugarss", "typescript"] }, "sha512-sgwew5yV/2eMeQobIWgAxCNarKwiTUDIc3siAUbq3sp0G6ONtzk0W+wJihMdqjbYb3iGU3ubpGv0usnnuXT3qg=="],
 

--- a/docs/architecture/ADR-0013-mcpb-pure-node-shim.md
+++ b/docs/architecture/ADR-0013-mcpb-pure-node-shim.md
@@ -403,6 +403,8 @@ doubles the states to test and document.
 - SPEC.md (topic slug `mcpb-pure-node-shim`)
 - `packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.ts`
 - `packages/obsidian-plugin/src/features/mcp-client-config/services/mcpbGenerator.test.ts`
+- `packages/obsidian-plugin/scripts/mcpb-smoke.ts` (`test:mcpb`, CI): builds a real bundle and
+  exercises both loaders end to end — the both-loaders invariant addendum above
 - `packages/obsidian-plugin/src/features/mcp-client-config/assets/iconPng.ts` (precedent: checked-in generated string-constant module)
 - `packages/obsidian-plugin/bun.config.ts` (build pipeline constraints and existing workaround density, informing Alternative B's rejection)
 - `scripts/obsidian_mcp_bridge.py`, `scripts/test_obsidian_mcp_bridge.py` (pure-function pipeline and DI-seam test precedent)
@@ -642,3 +644,25 @@ per-request lines are therefore absent there even on a healthy connection, so as
 reporter on built-in Node for those lines returns nothing. The unconditional logging still
 earns its place on the system-Node path, and the README's troubleshooting entry now says
 where the lines do and do not appear.
+
+## Addendum: the both-loaders invariant now has CI coverage
+
+The 1.0.1 fix above was verified once, by hand, against an installed bundle. Nothing kept it
+verified: the `.mcpb` had no CI coverage at all, so a future edit to `isEntryPoint` (or to the
+freshness pipeline that feeds `server/index.js`) could reintroduce #412 and ship silently.
+
+`scripts/mcpb-smoke.ts` (wired as `test:mcpb`, run in CI on every push and PR) builds a real
+bundle through `generateMcpb()` — the exact production path, not a stand-in — and, with no
+Obsidian and no vault, asserts in order: the archive unzips and `manifest.json` parses;
+`server/index.js`, after undoing its per-bundle placeholder substitution, matches
+`connectorShim.js` on disk byte-for-byte (an artefact-level version of the freshness guard in
+`mcpbGenerator.test.ts` — catches shipping a stale shim after an edit that skipped
+`gen-shim-source.ts`); the shim answers `initialize` under plain `node server/index.js`; and the
+shim answers `initialize` loaded the way Claude Desktop's built-in Node loads it —
+`import(pathToFileURL(entry))`, `process.argv[1]` pointed at the entry, `process.stdin` replaced
+by a plain Readable rather than the process's own stdin — reproducing the #412 mechanism
+directly instead of only pinning `isEntryPoint`'s pure-function truth table. Both loader checks
+talk to a throwaway HTTP server bound to `127.0.0.1` standing in for the plugin's own MCP
+server; nothing leaves the loopback interface. Confirmed to fail when `isEntryPoint`'s body is
+reverted to the pre-1.0.1 `require.main === module` check: the built-in-Node step reports no
+response, the same silence a real user saw in #412, instead of green.

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -13,6 +13,7 @@
 	"scripts": {
 		"build": "bun run check && bun bun.config.ts --prod",
 		"check": "tsc --noEmit",
+		"check:svelte": "svelte-check --tsconfig ./tsconfig.json",
 		"dev": "bun --watch run bun.config.ts --watch",
 		"link": "bun scripts/link.ts",
 		"build:mcpb": "bun scripts/build-mcpb.ts",
@@ -45,6 +46,7 @@
 		"fs-extra": "^11.2.0",
 		"moment": "^2.30.1",
 		"obsidian": "latest",
+		"svelte-check": "^4.7.4",
 		"tslib": "2.4.0",
 		"typescript": "^5.7.2"
 	}

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -18,7 +18,8 @@
 		"link": "bun scripts/link.ts",
 		"build:mcpb": "bun scripts/build-mcpb.ts",
 		"release": "bun run build && bun run zip && bun run build:mcpb",
-		"zip": "bun scripts/zip.ts"
+		"zip": "bun scripts/zip.ts",
+		"test:mcpb": "bun scripts/mcpb-smoke.ts"
 	},
 	"dependencies": {
 		"@huggingface/transformers": "4.2.0",

--- a/packages/obsidian-plugin/scripts/mcpb-smoke.ts
+++ b/packages/obsidian-plugin/scripts/mcpb-smoke.ts
@@ -1,0 +1,367 @@
+#!/usr/bin/env bun
+/*
+ * Builds a real `.mcpb` bundle through the exact production path
+ * (`generateMcpb()`) and smoke-tests the shipped `server/index.js` shim
+ * end to end. No Obsidian and no vault: a throwaway HTTP server on
+ * 127.0.0.1 stands in for the plugin's own MCP server, and a temporary
+ * `data.json` stands in for the vault's plugin folder.
+ *
+ * Checks, in order:
+ *   1. the archive unzips and manifest.json parses;
+ *   2. server/index.js is present and, after undoing the per-bundle
+ *      placeholder substitution, matches scripts/connectorShim.js on disk
+ *      byte-for-byte — the artefact-level version of the freshness guard
+ *      in mcpbGenerator.test.ts. Editing the shim without re-running
+ *      scripts/gen-shim-source.ts silently ships the old one; this fails
+ *      loud instead.
+ *   3. the shim answers `initialize` under plain `node server/index.js`;
+ *   4. the shim answers `initialize` loaded the way Claude Desktop's
+ *      built-in Node loads it: `import(pathToFileURL(entry))`, with
+ *      `process.argv[1]` pointed at the entry and `process.stdin` replaced
+ *      by a plain Readable rather than the process's own stdin/tty. This
+ *      is the #412 regression (ADR-0013, "Addendum (1.0.1)"): under this
+ *      loader `require.main` is the HOST's module, never the shim's own,
+ *      so a bare `require.main === module` guard never calls `main()` and
+ *      the shim answers nothing until the client times out.
+ *
+ * Wired as `test:mcpb`. Nothing here talks to any host but 127.0.0.1.
+ */
+import { spawn } from "child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import * as http from "http";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { strFromU8, unzipSync } from "fflate";
+import { generateMcpb } from "../src/features/mcp-client-config/services/mcpbGenerator";
+
+const VAULT_PATH_PLACEHOLDER = '"__OBSIDIAN_MCP_VAULT_PATH__"';
+const CONFIG_DIR_PLACEHOLDER = '"__OBSIDIAN_MCP_CONFIG_DIR__"';
+const TOKEN_ID_PLACEHOLDER = '"__OBSIDIAN_MCP_TOKEN_ID__"';
+
+const CONFIG_DIR = ".obsidian";
+const TOKEN_ID = "mcpb-smoke-token";
+const TOKEN_SECRET = "mcpb-smoke-secret-do-not-use";
+const CHILD_TIMEOUT_MS = 15000;
+
+// Mimics Claude Desktop's `nodeHost.js`: overwrite argv[1] to point at the
+// bundle entry (not this host file), replace process.stdin with a plain
+// Readable fed from a side file (not the process's inherited stdin/tty),
+// then load the entry exactly the way the built-in-Node launcher does.
+const HOST_LOADER_SOURCE = `"use strict";
+const fs = require("fs");
+const { pathToFileURL } = require("url");
+const { Readable } = require("stream");
+
+const [, , entryPath, requestPath] = process.argv;
+process.argv = ["node", entryPath];
+
+const payload = fs.readFileSync(requestPath, "utf8");
+const stdin = new Readable({ read() {} });
+Object.defineProperty(process, "stdin", {
+  value: stdin,
+  configurable: true,
+  enumerable: true,
+  writable: true,
+});
+
+import(pathToFileURL(entryPath).href)
+  .then(() => {
+    stdin.push(payload);
+    stdin.push(null);
+  })
+  .catch((err) => {
+    console.error("host loader: import() failed:", err);
+    process.exit(1);
+  });
+`;
+
+type ChildResult = {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  timedOut: boolean;
+  spawnError: Error | null;
+};
+
+function runNode(
+  args: string[],
+  options: { stdinPayload?: string; timeoutMs?: number } = {},
+): Promise<ChildResult> {
+  const timeoutMs = options.timeoutMs ?? CHILD_TIMEOUT_MS;
+  return new Promise((resolve) => {
+    const child = spawn("node", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      resolve({ stdout, stderr, code: null, timedOut: true, spawnError: null });
+    }, timeoutMs);
+    child.stdout.on("data", (c: Buffer) => (stdout += c.toString("utf8")));
+    child.stderr.on("data", (c: Buffer) => (stderr += c.toString("utf8")));
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code: null, timedOut: false, spawnError: err });
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code, timedOut: false, spawnError: null });
+    });
+    if (options.stdinPayload !== undefined) {
+      child.stdin.write(options.stdinPayload);
+    }
+    child.stdin.end();
+  });
+}
+
+function startThrowawayServer(
+  expectedToken: string,
+): Promise<{ server: http.Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (req.method !== "POST" || req.url !== "/mcp") {
+        res.writeHead(404).end();
+        return;
+      }
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        let id: unknown = null;
+        try {
+          id = (JSON.parse(body) as { id?: unknown }).id ?? null;
+        } catch {
+          // Falls through to the error response below with id: null.
+        }
+        if (req.headers.authorization !== `Bearer ${expectedToken}`) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              error: { code: -32001, message: "unexpected bearer token" },
+            }),
+          );
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id,
+            result: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              serverInfo: { name: "mcpb-smoke-server", version: "0.0.0" },
+            },
+          }),
+        );
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({ server, port });
+    });
+  });
+}
+
+function writeDataJson(dataPath: string, port: number) {
+  mkdirSync(dirname(dataPath), { recursive: true });
+  writeFileSync(
+    dataPath,
+    JSON.stringify({
+      mcpTransport: {
+        livePort: port,
+        bearerToken: TOKEN_SECRET,
+        tokens: [
+          { id: TOKEN_ID, label: "smoke", token: TOKEN_SECRET, createdAt: 1 },
+        ],
+      },
+    }),
+  );
+}
+
+function fail(message: string, detail?: string): never {
+  throw new Error(detail ? `${message}\n${detail}` : message);
+}
+
+function assertAnswersInitialize(
+  result: ChildResult,
+  id: number,
+  label: string,
+) {
+  if (result.spawnError) {
+    fail(`${label}: could not spawn node`, String(result.spawnError));
+  }
+  if (result.timedOut) {
+    fail(
+      `${label}: timed out after ${CHILD_TIMEOUT_MS}ms waiting for a response`,
+      `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+  const line = result.stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .find((l) => {
+      try {
+        return (JSON.parse(l) as { id?: unknown }).id === id;
+      } catch {
+        return false;
+      }
+    });
+  if (!line) {
+    fail(
+      `${label}: no JSON-RPC response with id ${id} on stdout`,
+      `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+  const parsed = JSON.parse(line!) as {
+    error?: unknown;
+    result?: unknown;
+  };
+  if (parsed.error) {
+    fail(`${label}: shim answered with an error`, JSON.stringify(parsed.error));
+  }
+  if (!parsed.result) {
+    fail(`${label}: shim answered with neither result nor error`, line);
+  }
+  if (result.code !== 0) {
+    fail(
+      `${label}: shim exited with code ${result.code}, expected 0`,
+      result.stderr,
+    );
+  }
+}
+
+async function main() {
+  const vaultDir = mkdtempSync(join(tmpdir(), "mcpb-smoke-vault-"));
+  // realpath: on macOS, os.tmpdir() resolves through /var -> /private/var, a
+  // symlink. Node's CJS loader resolves __filename through the real path, so
+  // if entryDir stayed symlinked, the argv[1] we set for step 4 below would
+  // never string-equal __filename inside the shim, and isEntryPoint's argv
+  // arm would falsely read as "not the entry point" — a harness artifact
+  // that would make this test fail the exact way the #412 regression does,
+  // for an unrelated reason.
+  const entryDir = realpathSync(
+    mkdtempSync(join(tmpdir(), "mcpb-smoke-entry-")),
+  );
+  const dataPath = join(
+    vaultDir,
+    CONFIG_DIR,
+    "plugins",
+    "mcp-tools-istefox",
+    "data.json",
+  );
+
+  const { server, port } = await startThrowawayServer(TOKEN_SECRET);
+  try {
+    writeDataJson(dataPath, port);
+
+    console.log("Building .mcpb bundle via generateMcpb()...");
+    const bundleBytes = generateMcpb({
+      version: "0.0.0-smoke",
+      vaultPath: vaultDir,
+      configDir: CONFIG_DIR,
+      tokenId: TOKEN_ID,
+    });
+
+    // 1. The archive unzips and manifest.json parses.
+    const files = unzipSync(bundleBytes);
+    const manifestBytes = files["manifest.json"];
+    if (!manifestBytes) fail("manifest.json missing from the built .mcpb");
+    try {
+      JSON.parse(strFromU8(manifestBytes));
+    } catch (err) {
+      fail("manifest.json does not parse as JSON", String(err));
+    }
+    console.log("  ok  archive unzips, manifest.json parses");
+
+    // 2. server/index.js is present and matches connectorShim.js on disk.
+    const entryBytes = files["server/index.js"];
+    if (!entryBytes) fail("server/index.js missing from the built .mcpb");
+    const entrySource = strFromU8(entryBytes);
+    const reconstructed = entrySource
+      .replace(JSON.stringify(vaultDir), VAULT_PATH_PLACEHOLDER)
+      .replace(JSON.stringify(CONFIG_DIR), CONFIG_DIR_PLACEHOLDER)
+      .replace(JSON.stringify(TOKEN_ID), TOKEN_ID_PLACEHOLDER);
+    const onDiskShim = readFileSync(
+      join(import.meta.dir, "connectorShim.js"),
+      "utf8",
+    );
+    if (reconstructed !== onDiskShim) {
+      fail(
+        "server/index.js does not match scripts/connectorShim.js",
+        "assets/connectorShimSource.ts is stale — run: " +
+          "bun run packages/obsidian-plugin/scripts/gen-shim-source.ts",
+      );
+    }
+    console.log(
+      "  ok  server/index.js matches scripts/connectorShim.js (generator is up to date)",
+    );
+
+    const entryPath = join(entryDir, "index.js");
+    writeFileSync(entryPath, entrySource);
+
+    const request = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "mcpb-smoke", version: "0.0.0" },
+      },
+    };
+    const requestLine = `${JSON.stringify(request)}\n`;
+
+    // 3. Plain `node server/index.js`.
+    const plain = await runNode([entryPath], { stdinPayload: requestLine });
+    assertAnswersInitialize(plain, request.id, "plain `node server/index.js`");
+    console.log("  ok  answers initialize under plain `node server/index.js`");
+
+    // 4. Claude Desktop's built-in-Node loader (#412 regression guard).
+    const requestPath = join(entryDir, "request.json");
+    writeFileSync(requestPath, requestLine);
+    const hostPath = join(entryDir, "host.cjs");
+    writeFileSync(hostPath, HOST_LOADER_SOURCE);
+    const loaded = await runNode([hostPath, entryPath, requestPath]);
+    assertAnswersInitialize(
+      loaded,
+      request.id,
+      "Claude Desktop's built-in-Node loader (import(pathToFileURL(entry)))",
+    );
+    console.log(
+      "  ok  answers initialize under the built-in-Node loader (#412 regression guard)",
+    );
+
+    console.log("\n.mcpb bundle smoke: all checks passed.");
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(vaultDir, { recursive: true, force: true });
+    rmSync(entryDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(`FAIL  ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Two artifacts had no CI coverage: `.svelte` files (invisible to `tsc --noEmit`) and the `.mcpb` bundle (zero coverage at all — how #412 shipped).

- **Svelte type check.** `svelte-check` as a devDependency, `check:svelte` script, CI step right after the workspace-wide typecheck. Ran it first against the current codebase: 0 errors, 0 warnings, so the CI step is wired (not deferred). Verified it actually catches errors via a temporary probe (reverted before commit).
- **`.mcpb` bundle smoke.** `scripts/mcpb-smoke.ts` (`test:mcpb`) builds a real bundle through the production `generateMcpb()` path and, with no Obsidian and no vault, asserts in order: the archive unzips and `manifest.json` parses; `server/index.js` matches `connectorShim.js` on disk (catches shipping a stale shim after an edit that skipped `gen-shim-source.ts`); the shim answers `initialize` under plain `node server/index.js`; and the shim answers `initialize` loaded the way Claude Desktop's built-in Node loads it (`import(pathToFileURL(entry))`, `process.argv[1]` pointed at the entry, `process.stdin` replaced by a plain Readable) — the #412 regression, reproduced directly rather than only pinning `isEntryPoint`'s unit tests. Both loader checks talk only to a throwaway HTTP server on `127.0.0.1`.
- Documented in `docs/architecture/ADR-0013-mcpb-pure-node-shim.md` (new addendum).

## Test plan

- [x] `bun run check && bun test && bun run format:check` — all green
- [x] `bun run check:svelte` — 0 errors, 0 warnings
- [x] `bun run test:mcpb` — all 4 checks pass
- [x] Deliberately reverted `isEntryPoint()`'s call site to the pre-1.0.1 `require.main === module` check and confirmed `test:mcpb` fails on the built-in-Node-loader step (no response, matching the real #412 symptom); restored and re-ran the full gate green.
- [x] CI run on this PR (watch with `gh pr checks`)