### PR TITLE
fix(get-vault-file-partial): drop redundant non-null assertion (OMC-020)

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
+++ b/packages/obsidian-plugin/src/features/mcp-tools/tools/getVaultFilePartial.ts
@@ -280,7 +280,7 @@ export async function getVaultFilePartialHandler(
     // than erroring, so callers don't need to know the file's length
     // up front.
     const clampedEnd = Math.min(endLine!, lines.length - 1);
-    const section = lines.slice(startLine!, clampedEnd + 1).join("\n");
+    const section = lines.slice(startLine, clampedEnd + 1).join("\n");
     return textResponse(section);
   }
 


### PR DESCRIPTION
## Summary

- **OMC-020** — `getVaultFilePartial.ts:283` had `lines.slice(startLine!, ...)`. `Array.prototype.slice`'s `start` parameter is optional, so it already accepts `startLine`'s `number | undefined` type; the `!` was flagged by the Obsidian community-plugin reviewer as unnecessary and removing it does not change what `tsc` infers anywhere. `endLine!` on the line above is untouched: `Math.min(...values: number[])` is a rest parameter typed strictly `number`, so that assertion is load-bearing.
- **OMC-017** — not included in this PR. See note below.

## OMC-017 not done: `CLAUDE.md` is deliberately gitignored, not part of this repo

The task asked to update `CLAUDE.md` at the repo root and commit it. That file is untracked and gitignored on purpose: commit `2d74e957` ("chore: remove Claude Code artifacts from public repo") removed it from git and added it to `.gitignore` with the comment "Claude Code tooling — kept locally for development, never published" / "never committed". `git ls-files` confirms it is not tracked on current `main`, and PR #429 (the CI-steps PR this task is catching up on) did not touch it, consistent with that.

Separately, this worktree is isolated from the shared checkout and the local-only `CLAUDE.md` doesn't exist inside it at all (only in the main checkout, which this agent is blocked from touching). So there is nothing to add to git even if the policy were set aside.

Given the explicit "never committed" policy, I did not force-add the file or edit a throwaway copy inside the worktree (that edit would vanish with the worktree and accomplish nothing). If the local `CLAUDE.md` should still reflect `check:svelte`/`test:mcpb`, that's an out-of-band edit in the main checkout, not something a PR should carry.

## Test plan

- [x] `bun run check && bun test && bun run format:check`
- [x] `bun run check:svelte` (from `packages/obsidian-plugin`)
- [x] `bun run test:mcpb` (from `packages/obsidian-plugin`)