### PR TITLE
fix(mcp-transport): carry a JSON-RPC error body on the protocol-version 400 (OMC-018)

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-transport/constants.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/constants.ts
@@ -36,3 +36,18 @@ export const ERROR_CODES = {
   UNAUTHORIZED: 401,
   PAYLOAD_TOO_LARGE: 413,
 } as const;
+
+// JSON-RPC `error.code` values that accompany the transport's 400 rejection
+// for an unsupported/malformed MCP-Protocol-Version request (SEP-2575
+// `server-stateless` conformance, OMC-018). Distinct from ERROR_CODES
+// (HTTP statuses, all positive): these sit in the JSON-RPC body alongside
+// the same HTTP 400. -32020 is the spec's HeaderMismatch /
+// unsupported-protocol-version code; -32602 is the standard JSON-RPC
+// Invalid Params code, reused here when the request's own `_meta` is
+// present but not an object. Neither is the local-error convention
+// (`-33000`, see ADR-0012/ADR-0013) — those are proxy-local failures with
+// no protocol meaning, these two are spec-defined wire codes.
+export const JSONRPC_ERROR_CODES = {
+  INVALID_PARAMS: -32602,
+  PROTOCOL_VERSION_UNSUPPORTED: -32020,
+} as const;

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.test.ts
@@ -144,6 +144,126 @@ describe("startHttpServer", () => {
   });
 });
 
+describe("MCP-Protocol-Version 400 carries a JSON-RPC body (SEP-2575 server-stateless, OMC-018)", () => {
+  const token = "t".repeat(32);
+
+  test("an unsupported version answers 400 with a -32020 JSON-RPC error, echoing the request id", async () => {
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(token),
+      requestHandler: async () => {
+        throw new Error("should not reach the handler");
+      },
+    });
+    running.push(server);
+
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "mcp-protocol-version": "1.0.0",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 42,
+        method: "initialize",
+        params: {},
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.json()).toEqual({
+      jsonrpc: "2.0",
+      error: { code: -32020, message: "Unsupported MCP-Protocol-Version" },
+      id: 42,
+    });
+  });
+
+  test("a malformed `_meta` (present but not an object) answers 400 with -32602 Invalid Params", async () => {
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(token),
+      requestHandler: async () => {
+        throw new Error("should not reach the handler");
+      },
+    });
+    running.push(server);
+
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "mcp-protocol-version": "2026-07-28",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "req-1",
+        method: "initialize",
+        params: { _meta: "not-an-object" },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      jsonrpc: "2.0",
+      error: {
+        code: -32602,
+        message: "Invalid params: `_meta` must be an object",
+      },
+      id: "req-1",
+    });
+  });
+
+  test("an unparseable body still 400s with -32020 and a null id, not a crash", async () => {
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(token),
+      requestHandler: async () => {
+        throw new Error("should not reach the handler");
+      },
+    });
+    running.push(server);
+
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "mcp-protocol-version": "1.0.0",
+      },
+      body: "{not valid json",
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      jsonrpc: "2.0",
+      error: { code: -32020, message: "Unsupported MCP-Protocol-Version" },
+      id: null,
+    });
+  });
+
+  test("an absent MCP-Protocol-Version header is still legal and reaches the handler unchanged", async () => {
+    let handlerCalled = false;
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(token),
+      requestHandler: async (_req, res) => {
+        handlerCalled = true;
+        res.writeHead(200);
+        res.end("ok");
+      },
+    });
+    running.push(server);
+
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(handlerCalled).toBe(true);
+  });
+});
+
 describe("stopHttpServer — connection draining", () => {
   test("force-drops keep-alive/SSE sockets before close()", async () => {
     const order: string[] = [];

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.ts
@@ -5,7 +5,8 @@ import {
   type ServerResponse,
 } from "node:http";
 import { logger } from "$/shared";
-import { runMiddleware } from "./middleware";
+import { buildProtocolVersionErrorBody, runMiddleware } from "./middleware";
+import { readBodyWithCap } from "./parseRequestBody";
 import type { TokenRecord } from "./tokenStore";
 import { bindWithFallback } from "./port";
 import { ERROR_CODES, MAX_REQUEST_BODY_BYTES, PORT_RANGE } from "../constants";
@@ -87,8 +88,29 @@ export async function startHttpServer(
       );
 
       if (!check.ok) {
-        // Middleware rejected the request — return the status and close.
-        // No body needed: these are machine-to-machine errors.
+        // Most rejections (401/403/404/405) are machine-to-machine errors
+        // with no body. The protocol-version 400 is the one the spec wants
+        // to carry a JSON-RPC error body (SEP-2575 `server-stateless`
+        // conformance, OMC-018): read the body (capped, best-effort — an
+        // unparseable or over-cap body just falls back to a null id and
+        // the version-mismatch code) so the error can echo the request's
+        // id and, when `_meta` is malformed, name that instead.
+        if (check.status === ERROR_CODES.PROTOCOL_VERSION_UNSUPPORTED) {
+          const rawBody = await readBodyWithCap(
+            req,
+            MAX_REQUEST_BODY_BYTES,
+          ).catch(() => null);
+          let parsedBody: unknown;
+          try {
+            parsedBody = rawBody === null ? undefined : JSON.parse(rawBody);
+          } catch {
+            parsedBody = undefined;
+          }
+          res.writeHead(check.status, { "content-type": "application/json" });
+          res.end(JSON.stringify(buildProtocolVersionErrorBody(parsedBody)));
+          if (rawBody === null) req.destroy();
+          return;
+        }
         res.writeHead(check.status);
         res.end();
         return;

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/middleware.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/middleware.test.ts
@@ -386,3 +386,107 @@ describe("runMiddleware — N-token bearer matching (issue #348, ADR-0014 §2)",
     }
   });
 });
+
+import { buildProtocolVersionErrorBody } from "./middleware";
+
+describe("buildProtocolVersionErrorBody (SEP-2575 server-stateless, OMC-018)", () => {
+  test("an unparseable body (undefined) answers -32020 with a null id", () => {
+    expect(buildProtocolVersionErrorBody(undefined)).toEqual({
+      jsonrpc: "2.0",
+      error: { code: -32020, message: "Unsupported MCP-Protocol-Version" },
+      id: null,
+    });
+  });
+
+  test("a well-formed request with no _meta at all answers -32020 (absent _meta is legal)", () => {
+    const body = buildProtocolVersionErrorBody({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "initialize",
+      params: {},
+    });
+    expect(body.error.code).toBe(-32020);
+    expect(body.id).toBe(7);
+  });
+
+  test("_meta present as an object, missing protocolVersion/clientCapabilities, still answers -32020 — those subfields are never required (out of scope, OMC-008)", () => {
+    const body = buildProtocolVersionErrorBody({
+      jsonrpc: "2.0",
+      id: "abc",
+      method: "initialize",
+      params: { _meta: {} },
+    });
+    expect(body.error.code).toBe(-32020);
+    expect(body.id).toBe("abc");
+  });
+
+  test("_meta present but a string answers -32602 (Invalid Params)", () => {
+    const body = buildProtocolVersionErrorBody({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { _meta: "not-an-object" },
+    });
+    expect(body).toEqual({
+      jsonrpc: "2.0",
+      error: {
+        code: -32602,
+        message: "Invalid params: `_meta` must be an object",
+      },
+      id: 1,
+    });
+  });
+
+  test("_meta present but an array answers -32602 (arrays are typeof object but not a valid _meta)", () => {
+    const body = buildProtocolVersionErrorBody({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "initialize",
+      params: { _meta: [] },
+    });
+    expect(body.error.code).toBe(-32602);
+  });
+
+  test("_meta present but null answers -32602", () => {
+    const body = buildProtocolVersionErrorBody({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "initialize",
+      params: { _meta: null },
+    });
+    expect(body.error.code).toBe(-32602);
+  });
+
+  test("echoes a string id", () => {
+    const body = buildProtocolVersionErrorBody({
+      jsonrpc: "2.0",
+      id: "request-42",
+      method: "tools/list",
+      params: {},
+    });
+    expect(body.id).toBe("request-42");
+  });
+
+  test("a response (has id, no method) never echoes its id — id stays null", () => {
+    const body = buildProtocolVersionErrorBody({ jsonrpc: "2.0", id: 9 });
+    expect(body.id).toBeNull();
+  });
+
+  test("a non-string/number id (e.g. an object) is not echoed", () => {
+    const body = buildProtocolVersionErrorBody({
+      jsonrpc: "2.0",
+      id: { nested: true },
+      method: "initialize",
+      params: {},
+    });
+    expect(body.id).toBeNull();
+  });
+
+  test("a batch array body is not treated as malformed _meta — falls back to -32020", () => {
+    const body = buildProtocolVersionErrorBody([
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: { _meta: "x" } },
+    ]);
+    expect(body.error.code).toBe(-32020);
+    expect(body.id).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/middleware.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/middleware.ts
@@ -1,5 +1,6 @@
 import {
   ERROR_CODES,
+  JSONRPC_ERROR_CODES,
   MCP_PATH_PREFIX,
   SUPPORTED_PROTOCOL_VERSIONS,
 } from "../constants";
@@ -126,6 +127,86 @@ function checkProtocolVersion(headers: RequestHeaders): CheckResult {
   return (SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(version)
     ? { ok: true }
     : { ok: false, status: ERROR_CODES.PROTOCOL_VERSION_UNSUPPORTED };
+}
+
+export type JsonRpcErrorBody = {
+  jsonrpc: "2.0";
+  error: { code: number; message: string };
+  id: string | number | null;
+};
+
+/**
+ * A value shaped enough like a JSON-RPC request to read `id`/`params` off
+ * of. Guards against echoing a response's `id` (responses have no
+ * `method`) — same convention the SDK's own `echoableRequestId` uses.
+ */
+function isJsonRpcRequestShape(
+  value: unknown,
+): value is { method: string; id?: unknown; params?: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { method?: unknown }).method === "string"
+  );
+}
+
+/**
+ * `_meta` is present but not an object (a string, number, array, ...).
+ * `_meta` is always optional and, per the wire schema every MCP request
+ * shares, must be an object when present — this is ordinary JSON-RPC
+ * shape validation, not the 2026 stateless lifecycle. An ABSENT `_meta`,
+ * or one present as an object missing `protocolVersion`/`clientCapabilities`,
+ * is never malformed by this check: requiring those subfields is the 2026
+ * per-request envelope and is out of scope here (see checkProtocolVersion's
+ * own docs and OMC-008).
+ */
+function hasMalformedMeta(parsedBody: unknown): boolean {
+  if (!isJsonRpcRequestShape(parsedBody)) return false;
+  const { params } = parsedBody;
+  if (typeof params !== "object" || params === null) return false;
+  if (!("_meta" in params)) return false;
+  const meta = (params as { _meta?: unknown })._meta;
+  return typeof meta !== "object" || meta === null || Array.isArray(meta);
+}
+
+/**
+ * Build the JSON-RPC error body for the transport's HTTP 400 rejection
+ * when `checkProtocolVersion` fails (SEP-2575 `server-stateless`
+ * conformance, OMC-018). This server has no per-request `_meta` lifecycle
+ * (gated on OMC-008), so there is no separate envelope-validation rung —
+ * both spec-defined codes are read off the one already-rejected request:
+ *
+ * - `_meta` present but not an object → `-32602` (Invalid Params).
+ * - Everything else, including an unparseable body → `-32020`, the code
+ *   for the version mismatch that made `checkProtocolVersion` reject the
+ *   request in the first place.
+ *
+ * `id` is echoed when the body parsed as a JSON-RPC request with a
+ * string/number `id`, `null` otherwise (the suite has a separate check
+ * that error responses preserve the request's id). Pure and synchronous:
+ * the caller is responsible for reading and JSON-parsing the body
+ * (`undefined` when reading/parsing failed).
+ */
+export function buildProtocolVersionErrorBody(
+  parsedBody: unknown,
+): JsonRpcErrorBody {
+  const malformedMeta = hasMalformedMeta(parsedBody);
+  return {
+    jsonrpc: "2.0",
+    error: {
+      code: malformedMeta
+        ? JSONRPC_ERROR_CODES.INVALID_PARAMS
+        : JSONRPC_ERROR_CODES.PROTOCOL_VERSION_UNSUPPORTED,
+      message: malformedMeta
+        ? "Invalid params: `_meta` must be an object"
+        : "Unsupported MCP-Protocol-Version",
+    },
+    id:
+      isJsonRpcRequestShape(parsedBody) &&
+      (typeof parsedBody.id === "string" || typeof parsedBody.id === "number")
+        ? parsedBody.id
+        : null,
+  };
 }
 
 /**


### PR DESCRIPTION
Closes OMC-018. Running conformance's `server-stateless` (SEP-2575) showed two checks passing at
the HTTP level and failing at the JSON-RPC level: the transport's `MCP-Protocol-Version` rejection
answered HTTP 400 with an empty body, where the spec wants a JSON-RPC error envelope with the
request's `id` preserved.

Both codes are read off the one existing rejection in `checkProtocolVersion()` — this server has no
per-request `_meta` lifecycle (that's the 2026 stateless lifecycle, OMC-008, gated on its own ADR
and explicitly out of scope here):

- `_meta` present but not an object (string/array/null) → `-32602` (Invalid Params).
- Everything else, including an unparseable body → `-32020`, the spec's unsupported-protocol-version
  code.

An absent `_meta`, or one present as a well-formed object missing `protocolVersion`/
`clientCapabilities`, is never treated as malformed — those subfields are never required, so
today's clients are unaffected. An absent `MCP-Protocol-Version` header stays legal, unchanged.

`httpServer.ts` reads the (capped, best-effort) body only for this one rejection to build the error
and echo the id; the other four rejections (401/403/404/405) stay bodyless as before.

## Testing
- `bun run check && bun test && bun run format:check` — green (1727 tests)
- `bun run check:svelte` — 0 errors
- `bun run test:mcpb` — mcpb smoke passes

## Deliberately not changed
- No `_meta.protocolVersion`/`_meta.clientCapabilities` requirement on incoming requests — that's
  the 2026 stateless lifecycle (OMC-008), a separate ADR-gated decision.
- Absent `MCP-Protocol-Version` header still resolves to the default version, per spec.