### PR TITLE
feat(mcp-transport): serve MCP 2026-07-28 as an additive second era

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,47 @@
+name: Conformance
+
+# Runs the MCP conformance suite's `server-stateless` scenario against a
+# headless instance of the plugin's MCP server, judged against
+# packages/obsidian-plugin/scripts/conformance/expected-failures.yml.
+#
+# Nightly and on demand, never on push or pull_request. Each run is a git
+# clone, a dependency install and a from-source build of an external
+# pre-release repository, on a repo that pays for its Actions minutes, to
+# re-measure a surface that changes only when the transport does
+# (ADR-0016 §9, Alternative H). The accepted trade: a conformance
+# regression surfaces on the next nightly rather than on the PR that
+# caused it, and the pre-merge signal is a local
+# `bun run test:conformance` on any change that touches the transport.
+
+on:
+  schedule:
+    - cron: "27 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      # modelcontextprotocol/conformance @ 0.2.0-alpha.10. Pinned, never
+      # `main`: the suite is pre-release, and an upstream scenario change
+      # would otherwise turn this job red for reasons unrelated to any
+      # commit here. scripts/conformance/run.sh defaults to the same sha;
+      # the two move together.
+      MCP_CONFORMANCE_REF: 81eb1c3edaed87d7fd585d7b80186da7a2960660
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Conformance (server-stateless, against the expected-failures baseline)
+        run: cd packages/obsidian-plugin && bun run test:conformance

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,12 @@
-<!-- project-tasks: prefix=OMC lastId=22 -->
+<!-- project-tasks: prefix=OMC lastId=24 -->
 # PROJECT TASKS
 
-Updated: 2026-08-08 · Open: 5 (P1: 0) · In progress: 0
+Updated: 2026-08-09 · Open: 6 (P1: 0) · In progress: 0
 
 ## Next — measured gaps, actionable now
 
+- [ ] `OMC-024` **P2** The transport settings report per-era request counts as a single global pair, so they cannot answer the question a user actually asks: *which protocol is this client speaking?* The transport is stateless and the era is decided per request, so there is no one answer for the server — on 2026-08-09 the Labs vault was genuinely serving both at once (Claude Desktop on 2025, hand-built probes on 2026). The answer is only well-defined per client, and the identity to key it on already exists: ADR-0014 gives every client a token id, and `eraCounters` is the last thing in the slice that stayed global. Make it a map keyed by token id and render one settings row per token. This also turns ADR-0016 §8's `legacy: 'reject'` trigger from a number into a decision: you would know *which* client is holding the legacy era open. Needs a migration from the flat `{legacy, modern}` shape already persisted in real vaults — absent must read as zero, existing values must not be lost. Deferred out of OMC-008 deliberately: that work was green, reviewed and conformance-verified, and this is a data-model change, not a wording fix <!-- src:session opened:2026-08-09 -->
+- [ ] `OMC-023` **P3** The server advertises a prompts capability it does not honour, on both protocol eras. `mcpServer.ts` declares `prompts: {}`, but `McpServer`'s constructor calls `setPromptRequestHandlers()` for any declared prompts capability (`mcp-DXXb3Vv3.mjs:1351`), which registers `listChanged: … ?? true` (`:1550`) — so the declared set is upgraded before anything reads it. The legacy `initialize` reply and the 2026 `server/discover` result both report `prompts: { listChanged: true }`, and nothing in the codebase ever sends `notifications/prompts/list_changed` (`tools/list_changed` is sent from `activateTool.ts:127`; there is no prompts equivalent). Found during OMC-008 and deliberately not fixed there: declaring `listChanged: false` would change the legacy `initialize` bytes, which that work's Invariant 1 forbids. Either honour it by sending the notification when the prompt set changes, or declare it false in a release that is allowed to move the legacy reply <!-- src:session opened:2026-08-08 -->
 - [ ] `OMC-022` **P3** The conformance CI job is no longer blocked. It was excluded from the Fase 1 run because there was no way to boot the MCP service headless, and that is now solved: `createMcpService` + `startHttpServer` + the `test-setup` mocks serve the real surface on a fixed port with no Obsidian and no vault (proven against `server-stateless` during the OMC-018 verification). Two pieces are still missing before it can be a CI step — the harness lives in a scratchpad rather than in `scripts/`, and the suite has to be run from the conformance repo's `main` since the published CLI has no 2026 scenarios. An expected-failures baseline (`--expected-failures`) is what would make it a gate rather than a report <!-- src:session opened:2026-08-08 -->
 - [ ] `OMC-016` **P3** #427 MCP Apps: **answered, it works.** The spike on `spike/427-mcp-apps-ui-resource` proved Claude Desktop reads and renders a `ui://` resource from this connector. What mattered was declaring `capabilities.extensions` with `io.modelcontextprotocol/ui`; the generic `resources` capability alone did nothing. Two hard requirements: mime type exactly `text/html;profile=mcp-app`, and the view must complete the `ui/initialize` → `ui/notifications/initialized` handshake or the host leaves the iframe blank. Real implementation is the remaining work: a proper resources capability, the handshake via `@modelcontextprotocol/ext-apps` (1.7.5 on npm) rather than hand-rolled `postMessage`, then the ranked search list <!-- src:session opened:2026-08-06 updated:2026-08-07 -->
 
@@ -18,14 +20,17 @@ _none_
 
 ## Blocked / Decisions Needed
 
-**The `2026-07-28` lifecycle break.** Running conformance's `server-stateless` (SEP-2575) from
-source showed that six of its thirty checks require `initialize`, `ping`, `logging/setLevel`,
-`resources/subscribe` and `resources/unsubscribe` to **stop existing**, answering HTTP 404 with
-`-32601`. A conformant 2026 server has no `initialize` handshake: the lifecycle moves to
-per-request `_meta`. So adopting the revision is a migration that breaks every configured client,
-not a capability we add, and it cannot be half-done. That is an ADR-sized decision and it gates
-both entries below. What is NOT blocked: the 2026 mechanisms that ride per-request `_meta` already
-work — #427 proved extensions do, under a 2025 negotiated version.
+**The `2026-07-28` lifecycle break — resolved by OMC-008, and its central premise was wrong.**
+This entry read: *"adopting the revision is a migration that breaks every configured client, not a
+capability we add, and it cannot be half-done."* Measured against the shipped implementation, all
+three clauses are false. The two eras coexist on one endpoint, chosen per request by whether the
+body carries a `_meta` envelope claim, so a claim-less client is served exactly as before. The five
+removed-method checks pass **without** retiring `initialize`: the suite only ever probes the modern
+era, where the SDK's 2026 wire registry answers `404`/`-32601`, while a legacy client keeps its
+handshake. `server-stateless` went 7/27 → 26/28 with no client reconfigured and no `.mcpb`
+re-exported. Verified end-to-end against the Labs vault on 2026-08-09, where both eras served
+traffic in the same session. See ADR-0016 §8, which records the falsified prediction rather than
+deleting it. What this leaves open is only OMC-007 below.
 
 **Correction to how OMC-018 was scoped.** That entry described the suite as wanting `-32602` for a
 "malformed `_meta`", as if it were the same size of job as the `-32020`. Reading the checks
@@ -35,7 +40,6 @@ or missing `protocolVersion`/`clientCapabilities`. Requiring those is the 2026 l
 those three checks belong to OMC-008 and cannot move before it. The `-32602` branch OMC-018 did
 ship — `_meta` present but not an object — is ordinary shape validation the suite never exercises.
 
-- [ ] `OMC-008` **P2** #407 adopt MCP spec `2026-07-28`. The SDK is not the blocker it looked like: `@modelcontextprotocol/{core,server}@2.0.0` shipped 2026-07-27 with every 2026 schema (`SubscriptionsListenRequestSchema`, `DiscoverRequestSchema`, tasks, `extensions`), though `LATEST_PROTOCOL_VERSION` is still `2025-11-25` even on `main`. Measured gaps beyond the lifecycle question: per-request `_meta` validation (4 checks), `server/discover` (3 + a warning for the missing `serverInfo` in result `_meta`). Baseline is now 7/27 rather than 4/27 after OMC-018, measured in the headless harness <!-- src:session opened:2026-08-05 updated:2026-08-08 -->
 - [ ] `OMC-007` **P2** #419 cross-client `tools/list` staleness. Closed by `subscriptions/listen`, whose acceptance criteria now come from conformance rather than from us: the ack notification must be the stream's first message, later notifications must carry a matching `subscriptionId`, and notification types outside the client's filter must not be sent. The SDK already exports every schema needed. Gated on the lifecycle decision above; the untested narrow question is whether a listen stream can coexist with today's `initialize` rather than replace it. Careful with the scoreboard here: `sep-2575-server-honors-notification-filter` reads green today only because we have no listen stream and therefore nothing that can leak — it is a vacuous pass and will become a real check the moment this lands <!-- src:session opened:2026-08-05 updated:2026-08-08 -->
 
 **Conformance tooling note.** The published CLI (`0.1.16`) has no 2026 scenarios at all — no
@@ -56,6 +60,7 @@ that call) and resource subscriptions.
 
 ## Done
 
+- [x] `OMC-008` #407 adopt MCP spec `2026-07-28` as an additive second era (ADR-0016). Two eras on one endpoint, classified per request off a single body read; the legacy path is unchanged and no configured client or distributed `.mcpb` needed touching. `server-stateless` 7/27 → 26/28, baseline down to four entries. Conformance harness now in-repo under `scripts/conformance/`, run nightly by `.github/workflows/conformance.yml`, never per PR. Per-era request counters ship in the transport settings; `legacy: 'reject'` stays a future decision with a trigger. Follow-ups: OMC-023, OMC-024 (2026-08-09)
 - [x] `OMC-018` PR #437. Verified against `server-stateless` with a controlled baseline: the pre-fix commit and the fix were each served by the same headless harness, so the delta is attributable. 4/27 → 7/27. Two passes are real — `http-server-header-mismatch-400` (a version mismatch now answers 400 with `-32020`) and `http-server-error-jsonrpc-id` (every error response echoes the request id). The third, `server-honors-notification-filter`, is vacuous: it failed before only because the empty 400 body left the suite no frame to inspect, and we still do not implement `subscriptions/listen` (see OMC-007). The `-32602` checks did not move, by design — see the correction under Blocked (2026-08-08)
 - [x] `OMC-019` PR #436. Split rather than resolved wholesale, which was the right call. `require("fs/promises")` became a static import: it only runs after the native dialog returns, so there is nothing left to guard lazily, and Bun's cjs output is byte-identical. `require("electron")` stays, now with the reasoning in the code — it runs unconditionally before we know the host, its `try`/`catch` is load-bearing (a top-level import would crash the file's whole suite instead of degrading), and dynamic `import()` is already documented as unreliable under Obsidian's loader. The reviewer finding is gone from `src/**` for the one that could move (2026-08-08)
 - [x] `OMC-020` PR #435, the redundant non-null assertion on `startLine` dropped (2026-08-08)

--- a/docs/architecture/ADR-0016-omc-008-adopt-mcp-spec-2026-07-28.md
+++ b/docs/architecture/ADR-0016-omc-008-adopt-mcp-spec-2026-07-28.md
@@ -173,12 +173,25 @@ the first time a capability is added.
 
 ### 7. Per-era counters are diagnostic and batched
 
-`mcpTransport.eraCounters = { legacy: number, modern: number }`, incremented in memory and
-flushed through `SettingsStore.updateSlice` under the process-wide mutex — the same
-batching discipline `ToolLoadingManager` already uses, because a settings write per request
-is a disk write per request. Nothing reads the counter to make a runtime decision. It is
-surfaced read-only in the transport settings section so the trigger below can be observed
-rather than guessed at.
+`mcpTransport.eraCounters = { legacy: number, modern: number }`, incremented in memory by
+`record(era)` and flushed by `flush(plugin)` through `SettingsStore.updateSlice` under the
+process-wide mutex — the same batching discipline `ToolLoadingManager` already uses, because
+a settings write per request is a disk write per request. Nothing reads the counter to make a
+runtime decision. It is surfaced read-only in the transport settings section so the trigger
+below can be observed rather than guessed at.
+
+**The counting rule**, written down because the `legacy: 'reject'` trigger is only as
+meaningful as it is: a request is counted **at the point of classification**, for whatever era
+it classified as, however it is later answered. The deferred version rung's 400 is counted as
+legacy, because that request classified legacy; a modern request the SDK's ladder rejects is
+counted as modern, for the same reason. A request short-circuited **before** classification —
+the 413 over-cap path, and anything `runMiddleware` turns down — counts as neither. The
+counter answers one question and only one: is anyone still reaching this server on the legacy
+era. A request whose era was never determined has no era to attribute, and inventing one would
+corrupt exactly the signal the decision rests on.
+
+The settings row has been type-checked (`check:svelte`) and never rendered in a real vault. A
+type check is not a look at the UI; that row needs a vault before release.
 
 ### 8. `legacy: 'reject'` on the endpoint is a recorded future decision, not this one
 
@@ -186,10 +199,37 @@ It breaks every client that does not probe `server/discover`, and no measured ne
 
 **Trigger:** the legacy-era counter stays at zero across a stated observation period — two
 consecutive minor releases, or 60 days of use, whichever is longer — on a vault with the
-user's real client set configured. Until then the five removed-method conformance checks
-(`initialize`, `ping`, `logging/setLevel`, `resources/subscribe`, `resources/unsubscribe`
-must be absent) stay red **by choice, not by defect**: they measure the removal this ADR
-declines to perform.
+user's real client set configured. The counter is the one this work ships: `record(era)` and
+`flush(plugin)` in `mcp-transport/services/eraCounters.ts`, persisted as
+`mcpTransport.eraCounters = { legacy, modern }` (§7).
+
+**The five removed-method conformance checks do not wait for that trigger. This ADR
+predicted they would, and the prediction was falsified by measurement.**
+
+The prediction, written before the handler was wired, was that the five checks asserting
+`initialize`, `ping`, `logging/setLevel`, `resources/subscribe` and `resources/unsubscribe`
+are absent would stay red until `legacy: 'reject'` was taken, and were therefore red **by
+choice, not by defect**. Against the running endpoint all five pass, with the legacy path
+untouched:
+
+- `initialize` carrying a modern `_meta` envelope → `HTTP/1.1 404`, JSON-RPC `-32601`.
+- `initialize` carrying no envelope → `HTTP/1.1 200` and the legacy handshake, with
+  `protocolVersion: "2025-06-18"` and
+  `serverInfo: { name: "mcp-connector", version: "1.0.1" }`.
+
+The reason is the era split itself, and it is worth stating plainly rather than letting the
+old claim disappear. The suite only ever probes the modern era: every request it sends
+carries an envelope, so every one of them classifies modern, and on that era the SDK's 2026
+wire registry does not admit those five methods — it answers `404`/`-32601` before anything
+this project wrote runs. A legacy client carries no envelope, classifies legacy, and keeps
+being served by the transport that has always served it. **The endpoint reaches conformance
+on the modern era without breaking a single configured client.** That is a better outcome
+than this ADR predicted, not a loophole in the measurement.
+
+What it changes: `legacy: 'reject'` stays a future decision with the trigger above, but it is
+now a decision about the product alone — which clients this server refuses to serve — with no
+conformance score attached to it. Taking it would buy nothing on the suite. Alternative A is
+revised accordingly.
 
 ### 9. Conformance runs nightly against an expected-failures baseline, not on every PR
 
@@ -205,18 +245,78 @@ repository on every commit, and this repo pays for its Actions minutes. The suit
 regression alarm on a surface that changes rarely, not a merge gate; nightly is the
 proportionate cadence for it.
 
-Target: **≥18/27** on `server-stateless`, with 5 removed-method checks red by design, 2
-subscription checks deferred to OMC-007, and 2 `test_missing_capability` checks declared
-unreachable.
+Target at plan time was **≥18/27** on `server-stateless`, with 5 removed-method checks red by
+design, 2 subscription checks deferred to OMC-007, and 2 `test_missing_capability` checks
+declared unreachable.
+
+Measured after implementation: **26/28, exit 0, baseline satisfied** — no unexpected red, and
+no baseline entry that has started passing. (The scenario reports 28 checks at the pinned
+ref; the 7/27 in Context is the pre-change measurement at the plan-time ref.)
+
+**The baseline is four entries, not the nine planned for.** The five removed-method entries
+were never written, because the checks pass (§8). What remains, and why each one is there:
+
+- the two `test_missing_capability` checks — unreachable while the SDK's
+  `REQUIRED_CLIENT_CAPABILITIES_BY_METHOD` is `{}` (`src-CX2iR2pK.mjs:452`). No spec method
+  carries a static client-capability requirement, so only a shipped fixture tool could
+  satisfy them, and that tool would sit in `tools/list` in every user's vault forever
+  (Alternative F);
+- the two `list-changed-on-subscription` checks — the listen stream now opens, SDK-owned, and
+  the acknowledgement and `subscriptionId` checks pass with nothing written here. What is
+  missing is **fan-out onto an already-open stream**: this server delivers
+  `notifications/tools/list_changed` on the calling request's own response and has no
+  broadcast path (§5, ADR-0011). That is OMC-007's work, which this ADR unblocks and defers.
+
+All four carry their reason in the file itself, and the file is kept honest **by hand** —
+never regenerated from a failing run (see Consequences).
+
+## Call-site facts found during implementation
+
+Three things the plan's contract table did not have. Each was found by a failing run rather
+than by grep, and each is recorded here so the next change to this transport does not have to
+rediscover it.
+
+**1. The malformed-`_meta` test depends on `checkProtocolVersion` *rejecting*.**
+`services/httpServer.test.ts` asserts `-32602` for a `_meta` that is present but not an
+object, and that body comes from `buildProtocolVersionErrorBody` — whose `-32602` path is
+reachable only behind a version rejection, because the helper builds the body for a request
+the rung has already turned down at 400. The test pinned `2026-07-28` precisely because that
+value was unsupported when it was written. Adding the revision to
+`SUPPORTED_PROTOCOL_VERSIONS` made the header pass the rung and took the assertion with it,
+so it now pins a pre-2026 value (`2023-01-01`) and carries a comment against "modernising" it
+back. Any future addition to `SUPPORTED_PROTOCOL_VERSIONS` hits this the same way: a version
+header chosen because it would be rejected stops being rejected, and an assertion quietly
+stops testing what it names.
+
+**2. `applyDeferredVersionRung` is reachable only for an unparseable body and for a JSON-RPC
+batch.** §3 describes the deferred rung as answering "a deferred header that then classifies
+legacy". That is true, but wider than the reachable set. `classifyRequestBody`
+(`src-CX2iR2pK.mjs:5101-5140`) classifies on the header as well as the body, so a
+single-request POST carrying a 2026-era `MCP-Protocol-Version` classifies **modern** whatever
+its body looks like, and the SDK's ladder owns the answer. Only two inputs reach the helper:
+a body that failed `JSON.parse` (short-circuited to legacy before any `Request` is built) and
+a batch. It is not dead code and it still protects the `unsupported-version-400` answer, but
+it protects a narrower case than the prose suggests.
+
+**3. `Mcp-Method` is mandatory on every 2026-era request, `Mcp-Name` on three of them.**
+`validateStandardRequestHeaders` (`src-CX2iR2pK.mjs:5044`) rejects a modern request whose
+body names a method but which carries no `Mcp-Method` header —
+`crossCheckMismatch("method-header-missing")`, before the request reaches any handler.
+`Mcp-Name` is mandatory for the methods in `MCP_NAME_HEADER_SOURCE` (`:4990-4994`) —
+`tools/call`, `prompts/get`, `resources/read` — where it mirrors `params.name`, or
+`params.uri` for `resources/read`. Nothing derives either header from the body. A modern-era
+request written by hand, in a test or in a client, has to set both explicitly or it never
+gets past that validator.
 
 ## Alternatives considered
 
 **A. `legacy: 'reject'` on the endpoint now, one era only.**
 Rejected: it removes `initialize` from a server whose entire installed base reaches it that
 way — every configured Claude Desktop, Cursor and Cline client, plus every already
-distributed `.mcpb` bundle, stops working the moment the plugin updates. The conformance
-score would jump by five checks and the product would break. The decision is recorded with
-a measurable trigger instead of taken blind.
+distributed `.mcpb` bundle, stops working the moment the plugin updates. It would also buy
+nothing on the suite: the five removed-method checks already pass, because the modern era is
+the only era the suite probes (§8). The trade is a broken product for no measured gain, so
+the decision is recorded with a trigger instead of taken blind.
 
 **B. Plain `createMcpHandler(factory)` with the SDK's default stateless legacy fallback,
 no user-land routing.**
@@ -287,6 +387,9 @@ change that touches the transport.
   baseline, instead of a number someone measures by hand in a scratch directory.
 - The `legacy: 'reject'` decision now has a trigger and a counter that will fire it, rather
   than an argument that recurs every release.
+- Conformance on the modern era cost the legacy era nothing. All five removed-method checks
+  pass while a claim-less client still gets the handshake, byte for byte — the outcome
+  Alternative A was expected to be the only route to (§8).
 
 ### Negative
 
@@ -300,6 +403,10 @@ change that touches the transport.
   the SDK does not export it. If the SDK ever changes the era boundary from a lexicographic
   ISO-date comparison, this copy goes stale silently. It sits next to
   `SUPPORTED_PROTOCOL_VERSIONS`, which is already a project-owned copy for the same reason.
+- A test that needs a *rejected* protocol version has to pick one this server will never
+  serve. Widening `SUPPORTED_PROTOCOL_VERSIONS` broke exactly such an assertion under this
+  work, silently rather than loudly, and the next widening will do it again (Call-site
+  facts, 1).
 - **A conformance regression is caught by the next nightly run, not by the PR that caused
   it.** Nothing blocks a merge on the suite. The mitigations are the expected-failures
   baseline (which makes a nightly failure readable rather than a wall of red) and a local
@@ -317,8 +424,9 @@ change that touches the transport.
 
 ### Neutral
 
-- The conformance score moves from 7/27 to ≥18/27. Nine checks stay red on purpose and the
-  baseline says which and why; the score is not expected to reach 27 under this ADR.
+- The conformance score moves from 7/27 at plan time to a measured **26/28** on the pinned
+  ref, exit 0. The baseline planned for nine entries and needed four — two unreachable, two
+  deferred to OMC-007 (§9). The score is not expected to reach 28 under this ADR.
 - `SUPPORTED_PROTOCOL_VERSIONS` gains a modern revision, but the `initialize` handshake
   still offers `2025-11-25` at most: the SDK keeps the two lists structurally separate, and
   the instance-level modern version is appended by the entry, per request, on the modern

--- a/docs/architecture/ADR-0016-omc-008-adopt-mcp-spec-2026-07-28.md
+++ b/docs/architecture/ADR-0016-omc-008-adopt-mcp-spec-2026-07-28.md
@@ -1,0 +1,348 @@
+# ADR-0016: Adopt MCP spec 2026-07-28 (SEP-2575) as an additive second era
+
+**Status:** Accepted
+**Date:** 2026-08-08
+**Deciders:** Stefano Ferri
+**Issue:** OMC-008 (closes OMC-022)
+
+---
+
+## Context
+
+Protocol revision `2026-07-28` is not reachable through `initialize`. A client probes
+`server/discover`; a client that finds no such handler falls back to the handshake. That
+fallback lives in the client — the Python SDK's v2 `Client` defaults to `mode='auto'` and
+degrades on its own — so adopting the revision is additive by construction, and nothing
+about it requires removing `initialize`.
+
+This server today serves one era. `SUPPORTED_PROTOCOL_VERSIONS`
+(`packages/obsidian-plugin/src/features/mcp-transport/constants.ts`) tops out at
+`2025-11-25`, the middleware answers 400 to any header value outside that list, and the
+per-request `McpServer` in `mcpServer.ts` is connected to a stateless
+`NodeStreamableHTTPServerTransport`. Measured today against a headless harness, the
+`server-stateless` conformance scenario scores **7/27**: three `-meta-invalid-400`
+variants, `-unsupported-version-400`, `-header-mismatch-400`, `-error-jsonrpc-id`, and
+`-server-honors-notification-filter` (the last passing vacuously — no subscription surface
+exists, so nothing can leak).
+
+### What the installed SDK actually provides
+
+Verified by reading `node_modules/@modelcontextprotocol/{core,server,node}@2.0.0`, not from
+memory:
+
+- `Server`'s constructor installs a `server/discover` handler only when
+  `modernProtocolVersions(this._supportedProtocolVersions).length > 0`
+  (`server/dist/mcp-DXXb3Vv3.mjs:733`). The default supported list is the handshake list,
+  so a hand-constructed instance answers `-32601` to `server/discover`.
+- The modern leg of `createMcpHandler` calls the package-internal
+  `installModernOnlyHandlers(server, SUPPORTED_MODERN_PROTOCOL_VERSIONS)`
+  (`server/dist/index.mjs:1287`) on whatever instance the factory returned: it appends
+  `2026-07-28` to that instance's supported list and registers the discover handler.
+  Nothing else calls it.
+- `_ondiscover` (`mcp-DXXb3Vv3.mjs:1034`) returns
+  `{ supportedVersions: modernProtocolVersions(...), capabilities:
+  discoverAdvertisedCapabilities(getCapabilities()), instructions? }`.
+  `discoverAdvertisedCapabilities` is `{ ...capabilities }` — the declared set verbatim,
+  `listChanged`/`subscribe` bits included. Server identity is **not** in the discover
+  result body: the 2026 encode seam stamps `io.modelcontextprotocol/serverInfo` into every
+  outbound result's `_meta` (`_outboundServerInfo`).
+- The whole envelope validation ladder is SDK-owned and lives in `classifyRequestBody`
+  (`server/dist/src-CX2iR2pK.mjs:5101`): a malformed envelope behind a present claim →
+  `-32602` with `data.envelope`; a modern header without a claim → `-32602` naming the
+  missing keys; a header/body revision disagreement → `-32020` via `crossCheckMismatch`;
+  a legacy-classified request on a strict endpoint → `UnsupportedProtocolVersionError`
+  carrying `{ supported, requested }` (`modernOnlyStrictRejection`, `:5227`). All at HTTP
+  400. `clientInfo` is absent from every "missing" branch — it is never required.
+- `isLegacyRequest(request, parsedBody?)` is documented as *the entry's own classification
+  step exported as a predicate*, running the same code, so a hand-wired router cannot
+  disagree with the entry. Its `parsedBody` argument is required — not merely faster —
+  when the request's own body has already been read, because the internal clone then
+  throws.
+- `CreateMcpHandlerOptions.legacy` takes `'stateless' | 'reject'` only. There is no
+  handler-valued option; the documented user-land pattern is `isLegacyRequest` in front of
+  a `legacy: 'reject'` handler.
+- `toNodeHandler(handler)` returns `(req, res, parsedBody?)` and forwards `req.auth` as the
+  handler's pass-through `authInfo`. `McpServerFactory` receives
+  `{ era, authInfo?, requestInfo? }`.
+- The 2026 wire registry (`src-CX2iR2pK.mjs:3910`) admits `tools/*`, `prompts/*`,
+  `resources/*`, `completion/complete`, `server/discover`, `subscriptions/listen`, and the
+  notifications `progress`, `message`, `cancelled`, the three `list_changed` variants,
+  `resources/updated`, `subscriptions/acknowledged`. `initialize`, `ping`,
+  `logging/setLevel`, `resources/subscribe` and `resources/unsubscribe` are absent — the
+  five removed methods.
+- `REQUIRED_CLIENT_CAPABILITIES_BY_METHOD` is `{}` (`src-CX2iR2pK.mjs:452`). No spec method
+  carries a static client-capability requirement, so the suite's two
+  `test_missing_capability` checks are unreachable without shipping a fixture tool.
+- `IncompleteResult` does not appear anywhere in the installed SDK, although the suite's
+  stream check refers to it. Modern-path stream behaviour is therefore measured against a
+  running server, never inferred from the SDK's surface.
+- `LATEST_PROTOCOL_VERSION` is `2025-11-25` in both `core@2.0.0` and the TypeScript SDK's
+  main branch. It is the `initialize` offer and by construction can never name
+  `2026-07-28`. It says nothing about modern-era support and must not be used to reason
+  about it.
+
+## Decision
+
+Serve both eras on the same endpoint, behind the same middleware chain, from one server
+factory.
+
+### 1. Routing lives in user land, in `mcpServer.handleRequest`
+
+After the HTTP chain resolves a token id, `handleRequest` reads the body once (it already
+does), then calls `isLegacyRequest(toWebRequest(req, parsedBody), parsedBody)`. Legacy
+classification keeps today's path byte-for-byte; everything else goes to a strict modern
+handler.
+
+Routing sits in `mcpServer.ts` rather than `httpServer.ts` because that is where the single
+body read already happens. Moving it up would widen `RequestHandler` to carry a parsed body
+and churn ~30 test call-sites for no behavioural gain.
+
+A body that fails `JSON.parse` short-circuits to legacy without constructing a `Request` at
+all. `toWebRequest(req, undefined)` would try to read the stream `readBodyWithCap` has
+already drained; the SDK classifies unparseable bodies as legacy anyway, so the
+short-circuit is both safe and identical to the entry's own answer.
+
+### 2. The modern handler is strict; the endpoint is not
+
+`createMcpHandler(factory, { legacy: 'reject', responseMode: 'auto' })`. Strict mode on the
+handler and strict mode on the endpoint are different decisions. The predicate has already
+separated the traffic, so the modern handler must never see legacy traffic — `'reject'`
+makes a routing bug loud instead of silently double-serving 2025 requests through a second,
+differently-configured stateless transport. The endpoint stays permissive because the
+legacy branch exists in front of it.
+
+One handler is built per `McpService`, wrapped once by `toNodeHandler`, and closed in
+`destroyMcpService`. It allocates an event bus; building one per request would be waste.
+
+### 3. The protocol-version rung splits by era, and only the legacy half stays in `runMiddleware`
+
+`2026-07-28` joins `SUPPORTED_PROTOCOL_VERSIONS`, without which every modern request is
+rejected at 400 before it can be classified.
+
+`checkProtocolVersion` keeps rejecting a header naming a **pre-2026 revision this server
+does not serve** — unchanged, in the same position in the chain, before auth. A header
+naming a **2026-era revision** (lexicographic `>= "2026-07-28"`, the SDK's own
+`isModernProtocolVersion` rule, reimplemented here because the helper is not a public
+export) is **deferred**: only classification can tell whether the SDK's ladder owns the
+answer, and the ladder's answer carries `{ supported, requested }` where this server's
+`buildProtocolVersionErrorBody` carries neither. A deferred header that then classifies
+legacy is answered by that same helper after classification, so no
+`unsupported-version-400` answer is lost.
+
+The alternative reading — move the whole rung below classification — reorders 400 and 401
+for unauthenticated callers and changes an observable status code for no gain. The split
+keeps every legacy-era case byte-identical.
+
+### 4. One factory, both eras
+
+The per-request `McpServer` construction is extracted to `buildMcpServer(tokenId)` and
+called by both branches: the legacy branch directly, the modern branch through the
+`McpServerFactory`. `ToolScope` resolution, the registry wiring, the counter recording and
+the prompt handlers therefore exist once. Per-token tool surfaces (ADR-0014) and the
+`tools/list` stability invariant (ADR-0015) hold on both paths because there is only one
+implementation of them.
+
+The token id reaches the factory as pass-through `AuthInfo`:
+`req.auth = { token: "", clientId: tokenId, scopes: [] }`, read back as
+`ctx.authInfo?.clientId`. The bearer **secret** deliberately does not travel into handler
+context — the identity downstream of auth is the token id, never the string
+(ADR-0014 §2), and a future handler that logged its context must not be able to leak a
+credential.
+
+`buildMcpServer` closes nothing. The legacy branch keeps its own `finally` teardown; on the
+modern branch the SDK entry owns the instance lifecycle.
+
+### 5. Notifications stay request-scoped on both eras
+
+`responseMode: 'auto'` upgrades a modern response to SSE when the handler emits a related
+message before its result — which is exactly what `activate_tool` and `search_vault_smart`
+do through `ctx.mcpReq.notify`. The `bodyTargetsSseNotificationTool` pre-inspection stays
+legacy-only. There is no back-channel at `2026-07-28` and none is needed.
+
+Both notification methods are in the 2026 wire registry, but that is a schema fact, not a
+delivery fact: the SSE upgrade is verified against a running server before this is
+considered done.
+
+### 6. `server/discover` is not hand-written
+
+The advertisement is whatever the instance's declared capabilities are. The current
+declaration is `{ tools: { listChanged: true }, prompts: {} }`; both are honoured by
+registered handlers, so the discover result is truthful as-is and prompts appears without
+any extra work. Hand-writing the handler would create a second source of truth that drifts
+the first time a capability is added.
+
+### 7. Per-era counters are diagnostic and batched
+
+`mcpTransport.eraCounters = { legacy: number, modern: number }`, incremented in memory and
+flushed through `SettingsStore.updateSlice` under the process-wide mutex — the same
+batching discipline `ToolLoadingManager` already uses, because a settings write per request
+is a disk write per request. Nothing reads the counter to make a runtime decision. It is
+surfaced read-only in the transport settings section so the trigger below can be observed
+rather than guessed at.
+
+### 8. `legacy: 'reject'` on the endpoint is a recorded future decision, not this one
+
+It breaks every client that does not probe `server/discover`, and no measured need exists.
+
+**Trigger:** the legacy-era counter stays at zero across a stated observation period — two
+consecutive minor releases, or 60 days of use, whichever is longer — on a vault with the
+user's real client set configured. Until then the five removed-method conformance checks
+(`initialize`, `ping`, `logging/setLevel`, `resources/subscribe`, `resources/unsubscribe`
+must be absent) stay red **by choice, not by defect**: they measure the removal this ADR
+declines to perform.
+
+### 9. Conformance runs nightly against an expected-failures baseline, not on every PR
+
+The harness moves into the repository. The suite is run from source at a pinned ref — the
+published CLI (0.1.16) has no 2026 scenarios — against a YAML baseline naming every
+expected red check and its reason. An unexpected red fails the job; a baseline entry that
+starts passing is a signal to remove it.
+
+The job lives in its own workflow (`.github/workflows/conformance.yml`), triggered on a
+nightly `schedule` and on `workflow_dispatch`, never on `push` or `pull_request`. Running
+it per-PR means a clone, install and from-source build of an external pre-release
+repository on every commit, and this repo pays for its Actions minutes. The suite is a
+regression alarm on a surface that changes rarely, not a merge gate; nightly is the
+proportionate cadence for it.
+
+Target: **≥18/27** on `server-stateless`, with 5 removed-method checks red by design, 2
+subscription checks deferred to OMC-007, and 2 `test_missing_capability` checks declared
+unreachable.
+
+## Alternatives considered
+
+**A. `legacy: 'reject'` on the endpoint now, one era only.**
+Rejected: it removes `initialize` from a server whose entire installed base reaches it that
+way — every configured Claude Desktop, Cursor and Cline client, plus every already
+distributed `.mcpb` bundle, stops working the moment the plugin updates. The conformance
+score would jump by five checks and the product would break. The decision is recorded with
+a measurable trigger instead of taken blind.
+
+**B. Plain `createMcpHandler(factory)` with the SDK's default stateless legacy fallback,
+no user-land routing.**
+Rejected: the SDK's fallback constructs its own streamable transport with only
+`sessionIdGenerator: undefined`. It has no equivalent of `bodyTargetsSseNotificationTool`,
+so `activate_tool` would answer JSON and its `notifications/tools/list_changed` would have
+nowhere to go — a silent regression of ADR-0011's activation contract on the path that
+serves every current client. The 405-on-GET behaviour mcp-remote depends on, and the 413
+handling for chunked over-cap bodies, would also move under SDK control. Routing in user
+land keeps the legacy path exactly as it is.
+
+**C. Hand-write a `server/discover` handler on the existing `McpServer` and skip
+`createMcpHandler` entirely.**
+Rejected: `server/discover` is the visible tip of the revision, not the revision. The
+per-request `_meta` envelope validation, the `-32602`/`-32020` ladder, the
+`{ supported, requested }` error data, the `io.modelcontextprotocol/serverInfo` stamping on
+every outbound result, and the modern wire codec's method registry would all have to be
+reimplemented against a spec this project does not own. `installModernOnlyHandlers` is
+package-internal precisely because the discover handler is meant to be installed by the
+serving entry, not by hand.
+
+**D. Move the whole protocol-version rung below classification (the SPEC's literal
+reading).**
+Rejected as written, adopted in part. Below classification the rung necessarily runs after
+auth, which flips an unauthenticated request with a bad version header from 400 to 401 —
+an observable status-code change, asserted today in `middleware.test.ts`'s end-to-end
+order test, bought for nothing. Splitting the rung by era achieves the same goal (the SDK's
+ladder owns the modern answers) with zero change to any legacy-era case.
+
+**E. Serve the modern era on a separate path, e.g. `/mcp/2026`.**
+Rejected: `server/discover` is a probe against the endpoint the client is already
+configured for. A client that has to be told a different URL to find the modern era has
+already been reconfigured, which is the exact cost this additive adoption exists to avoid.
+It would also duplicate the middleware chain and split the per-token identity resolution in
+two.
+
+**F. Ship the `test_missing_capability` diagnostic tool the suite wants, for +2 checks.**
+Rejected: it would appear in `tools/list` in every user's vault, in every client's tool
+picker, forever. A fixture tool in a shipped product to satisfy a test harness is a worse
+outcome than two red checks that are honestly explained in the baseline.
+
+**G. Write per-era counters on every request.**
+Rejected: a `data.json` read-modify-write under the process-wide mutex per request would
+serialize the transport behind disk I/O and make the counter the slowest thing in the hot
+path — for a number nothing reads at runtime. Batched in memory, flushed on a debounce and
+at teardown, matching `ToolLoadingManager`.
+
+**H. Run the conformance suite as a step inside `ci.yml`, on every push and PR.**
+Rejected on cost. Each run is a git clone, a dependency install and a from-source build of
+an external pre-release repository, on a repo that pays for its Actions minutes, to
+re-measure a surface that changes only when the transport does. The accepted trade is
+stated in Consequences: a regression is caught on the next nightly rather than on the PR
+that introduced it, and the pre-merge signal is a local `bun run test:conformance` on any
+change that touches the transport.
+
+## Consequences
+
+### Positive
+
+- A client probing `server/discover` reaches the modern path today; every currently
+  configured client keeps working with no re-export, no reconfiguration, and no change to
+  the bytes on the legacy path.
+- The envelope ladder, the discover advertisement, the unsupported-version error data and
+  the `serverInfo` stamping are all SDK-owned. This project writes routing, not protocol.
+- One `buildMcpServer` means per-token tool surfaces and the `tools/list` invariant cannot
+  drift between eras — there is no second implementation to drift.
+- The conformance suite becomes a recurring, automated signal with an explicit annotated
+  baseline, instead of a number someone measures by hand in a scratch directory.
+- The `legacy: 'reject'` decision now has a trigger and a counter that will fire it, rather
+  than an argument that recurs every release.
+
+### Negative
+
+- Two serving paths exist on one endpoint, with different response-mode machinery
+  (`bodyTargetsSseNotificationTool` vs `responseMode: 'auto'`). A future change to
+  notification delivery has to be made twice or consciously scoped to one era.
+- The protocol-version rung is split across two sites — `checkProtocolVersion` for
+  pre-2026 revisions, the era router for deferred modern ones. The rule is crisp but it is
+  a rule someone has to read before touching either site.
+- `isModernProtocolVersion` is reimplemented locally as `version >= "2026-07-28"` because
+  the SDK does not export it. If the SDK ever changes the era boundary from a lexicographic
+  ISO-date comparison, this copy goes stale silently. It sits next to
+  `SUPPORTED_PROTOCOL_VERSIONS`, which is already a project-owned copy for the same reason.
+- **A conformance regression is caught by the next nightly run, not by the PR that caused
+  it.** Nothing blocks a merge on the suite. The mitigations are the expected-failures
+  baseline (which makes a nightly failure readable rather than a wall of red) and a local
+  `bun run test:conformance` before merging any transport change — a discipline, not an
+  enforcement.
+- **The baseline file is maintained by hand and can rot.** It is the only artifact carrying
+  *why* each red check is red, and nothing regenerates it. Pasting a failing run's output
+  back into it would convert a statement of intent into a snapshot of whatever is currently
+  broken. Every edit is deliberate and carries a reason.
+- The nightly job depends on a network clone of an external repository at a pinned
+  pre-release ref, built from source. It is the first scheduled workflow in this project and
+  the first to depend on a third-party repo at build time.
+- `AuthInfo.token` is populated with the empty string. It is a pass-through field the SDK
+  never inspects, but it is a shape that looks wrong to a reader who does not know why.
+
+### Neutral
+
+- The conformance score moves from 7/27 to ≥18/27. Nine checks stay red on purpose and the
+  baseline says which and why; the score is not expected to reach 27 under this ADR.
+- `SUPPORTED_PROTOCOL_VERSIONS` gains a modern revision, but the `initialize` handshake
+  still offers `2025-11-25` at most: the SDK keeps the two lists structurally separate, and
+  the instance-level modern version is appended by the entry, per request, on the modern
+  branch only.
+- `ci.yml` is unchanged by this work. The per-PR gate stays what it is today; the
+  conformance workflow is additive and independent.
+- The `.mcpb` shim is untouched and keeps speaking the handshake era. Its `data.json` read
+  contract is unaffected.
+- `subscriptions/listen` remains unimplemented. This work unblocks OMC-007; it does not
+  perform it. Two conformance checks stay red for that reason.
+- MCP Apps (OMC-016) and Tasks (OMC-010) ride `_meta` and are unaffected either way.
+
+## References
+
+- `SPEC.md` (repo root) — OMC-008 requirements R-01 … R-17
+- `docs/superpowers/plans/2026-08-08-omc-008-adopt-mcp-spec-2026-07-28.md`
+- ADR-0011 — self-healing inactive-tool error (`activate_tool`'s notification contract)
+- ADR-0014 — per-client tool profiles (per-token `ToolScope` at the mcpServer boundary)
+- ADR-0015 — the `tools/list` stability invariant and adaptive loading
+- `node_modules/@modelcontextprotocol/server/dist/createMcpHandler-CLhGwQTn.d.mts` —
+  `createMcpHandler`, `isLegacyRequest`, `CreateMcpHandlerOptions`, `McpServerFactory`
+- `node_modules/@modelcontextprotocol/server/dist/src-CX2iR2pK.mjs:5101` —
+  `classifyRequestBody`, the envelope validation ladder
+- `node_modules/@modelcontextprotocol/server/dist/mcp-DXXb3Vv3.mjs:733,1034` — discover
+  handler installation and `_ondiscover`
+- `node_modules/@modelcontextprotocol/node/dist/index.d.mts:224,249,271` —
+  `NodeMcpRequestHandler`, `toNodeHandler`, `toWebRequest`

--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -104,3 +104,27 @@ The core feature provides a `PluginSettingTab` that loads UI from each feature, 
 ### Error Handling
 
 Features implement consistent error handling: they return descriptive error messages, log detailed information for debugging, give the user feedback through the Obsidian Notice API, and clean up resources on failure.
+
+## MCP Request Path
+
+The transport serves two protocol eras on one endpoint, `POST /mcp` (ADR-0016). Every request goes through one chain, is classified once, and is then served by the era it belongs to:
+
+```
+POST /mcp
+ └─ runMiddleware        method + path → Origin → MCP-Protocol-Version (pre-2026 half)
+    (httpServer.ts)      → bearer auth (tokenId); then the declared-length body cap
+ └─ readBodyWithCap      the body is read ONCE, here, and shared from here on
+    (mcpServer.ts)
+ └─ classifyEra          isLegacyRequest, from that single read
+    (eraRouter.ts)
+     ├─ legacy → NodeStreamableHTTPServerTransport, per request, stateless
+     └─ modern → createMcpHandler(factory, { legacy: "reject" }) via toNodeHandler
+          └─ buildMcpServer(tokenId)   ← reached by both branches, built in one place
+```
+
+- **The body is read once.** `readBodyWithCap` drains the stream before anything else runs, so the classifier and whichever handler serves the request are both fed the same parsed value. A second read yields an empty stream and a spurious parse error. A body that fails `JSON.parse` classifies legacy without a `Request` being constructed at all.
+- **The protocol-version rung is split by era.** `checkProtocolVersion` (`middleware.ts`) rejects a pre-2026 revision this server does not serve, at 400, in the chain, before auth. A 2026-era revision is deferred instead: only classification can tell whether the SDK's validation ladder owns the answer, and that answer carries `supported` and `requested` where this project's error body carries neither. `applyDeferredVersionRung` (`eraRouter.ts`) answers the deferred case that then classifies legacy, so no unsupported-version 400 is lost.
+- **`buildMcpServer(tokenId)` is the single construction site for both eras.** The legacy branch calls it directly; the modern branch reaches it through the SDK's `McpServerFactory`, which receives the token id as pass-through `AuthInfo.clientId` — never the bearer secret. Tool-scope resolution, registry wiring, prompt handlers and usage counting exist once, so per-token tool surfaces cannot drift between the two paths.
+- **Lifecycle differs by branch.** `buildMcpServer` closes nothing. The legacy branch owns its own `finally` teardown; on the modern branch the SDK entry owns the instance.
+- **`server/discover` is not hand-written.** The SDK's serving entry installs it on whatever instance the factory returns, and stamps server identity into every modern result's `_meta`. A hand-built `McpServer` answers `-32601` to it.
+- Each classified request is counted against its era in `mcpTransport.eraCounters`, batched in memory and flushed through `SettingsStore.updateSlice`. The counter is diagnostic: nothing reads it at runtime.

--- a/docs/specs/omc-008-adopt-mcp-spec-2026-07-28.spec.md
+++ b/docs/specs/omc-008-adopt-mcp-spec-2026-07-28.spec.md
@@ -1,0 +1,190 @@
+# OMC-008 — Adopt MCP spec 2026-07-28 (SEP-2575) as an additive second era
+
+**Topic slug:** omc-008-adopt-mcp-spec-2026-07-28
+
+## Objective
+
+Serve protocol revision `2026-07-28` alongside the existing `initialize`-handshake era on the same
+endpoint, so that a client probing `server/discover` reaches the modern path while every currently
+configured client keeps working unchanged.
+
+The revision is not reachable through `initialize`. It is reached by probing `server/discover`, and
+a client that finds no such handler falls back to the handshake. That fallback lives in the client,
+not in this server: the reference client defaults to `mode='auto'` and degrades on its own. Adopting
+the revision is therefore additive, and nothing about it requires removing `initialize`.
+
+Removing `initialize`, `ping`, `logging/setLevel`, `resources/subscribe` and `resources/unsubscribe`
+is a separate decision, expressed in the SDK as a single option (`legacy: 'reject'`). This work does
+not take it. It records the condition under which it would later be taken.
+
+## Scope
+
+In scope:
+
+- `server/discover`, answering with `supportedVersions`, capabilities that match the handlers
+  actually registered, and server identity in the result's `_meta`.
+- Per-request `_meta` envelope validation on the modern path: `protocolVersion` and
+  `clientCapabilities` required, `clientInfo` optional and never required.
+- Request routing between the two eras, with the existing legacy path left byte-for-byte unchanged.
+- Instrumentation counting how much traffic each era serves, as the evidence that would later
+  justify strict mode.
+- The conformance suite wired into CI against an expected-failures baseline (closes OMC-022).
+
+Out of scope, each for a stated reason:
+
+- `legacy: 'reject'`. It breaks every client that does not probe `server/discover`, and no measured
+  need exists. The trigger is recorded instead.
+- `subscriptions/listen` and its acknowledgement and filter semantics. That is OMC-007, unblocked by
+  this work but not performed by it.
+- The `test_missing_capability` diagnostic tool the suite requires for its two client-capability
+  checks. Shipping a fixture tool would put it in the tool list of every user's vault, which is a
+  worse outcome than two red checks.
+- MCP Apps (OMC-016) and Tasks (OMC-010), which ride `_meta` and are unaffected either way.
+
+## Stack
+
+Bun workspace monorepo, TypeScript, `@modelcontextprotocol/{core,server,node}@2.0.0`, `node:http`.
+Verified present in the installed SDK: `createMcpHandler`, `isLegacyRequest`,
+`classifyInboundRequest` from `@modelcontextprotocol/server`, `toNodeHandler` from
+`@modelcontextprotocol/node`, and the `io.modelcontextprotocol/{protocolVersion, clientCapabilities,
+clientInfo, serverInfo, logLevel, subscriptionId}` `_meta` keys from `@modelcontextprotocol/core`.
+
+## Architecture
+
+A request keeps entering through the existing HTTP server and its middleware chain: method and path,
+Origin validation, bearer authentication, body cap. Both eras sit behind that chain, so
+authentication and per-token identity are resolved once and apply to both.
+
+After the chain, `isLegacyRequest` classifies the request. A request carrying no `_meta` envelope
+claim — including `initialize`, 2025-era notification POSTs, and body-less GET or DELETE — routes to
+the path that exists today, untouched. Everything else routes to a strict modern handler built with
+`createMcpHandler(factory, { legacy: 'reject' })` and adapted to `node:http` by `toNodeHandler`.
+
+Strict mode on the modern handler is deliberate and is not the same decision as strict mode on the
+endpoint. The predicate has already separated the traffic, so the modern handler must never see
+legacy traffic, and the SDK is explicit that the modern path owns the error answers for malformed
+envelopes and header mismatches.
+
+The factory the modern handler receives is the same per-request `McpServer` construction the
+transport performs today. That construction already resolves a `ToolScope` from the calling token
+and serves a shared registry, so per-token tool surfaces (ADR-0014) hold on both paths without a
+second implementation.
+
+Notifications on the modern path stay request-scoped. There is no back-channel at `2026-07-28`, and
+none is needed: the two notifications this server emits — `activate_tool`'s
+`notifications/tools/list_changed` and `search_vault_smart`'s progress — already ride the response
+stream of the request that triggered them, through the SDK's own per-request notify channel.
+
+## Data model
+
+No change to any existing settings slice's meaning. One additive counter pair records how many
+requests each era served, written through `SettingsStore.updateSlice` under the process-wide mutex
+like every other settings write. The counter is diagnostic: nothing reads it to make a runtime
+decision.
+
+Counting rule: a request is counted at the point of classification, for whatever era it classified
+as, however it is later answered. A request short-circuited before classification — the 413 over-cap
+path, and anything the middleware chain rejects — counts as neither era. The trigger in R-17 is only
+as meaningful as that rule.
+
+## API
+
+`server/discover` returns the supported versions, the server's capabilities, and identity under
+`_meta['io.modelcontextprotocol/serverInfo']`. The capabilities it reports must correspond to
+handlers that are actually registered — the suite calls the advertised methods and compares. Prompts
+are served, so the prompts capability must appear in the discover result.
+
+Requests on the modern path carry `_meta` with `io.modelcontextprotocol/protocolVersion` matching
+the `MCP-Protocol-Version` header and `io.modelcontextprotocol/clientCapabilities`. A missing or
+malformed envelope answers `-32602`; a header and body that name different revisions answer `-32020`;
+an unsupported revision answers the unsupported-version error carrying the versions this server does
+support.
+
+Every modern-era request also carries the SEP-2243 standard request headers: `Mcp-Method` on every
+call, and `Mcp-Name` mirroring `params.name` (or `params.uri` for `resources/read`) on `tools/call`,
+`prompts/get` and `resources/read`. The SDK derives neither from the body and rejects before any
+handler runs when one is missing.
+
+## UI flows
+
+One read-only line in the transport settings section reporting how many requests each era has
+served, so the trigger condition below can be observed rather than guessed at.
+
+## Edge cases
+
+The body is read once. The existing transport already drains the request body under a cap before
+handing it to the SDK; the classifier accepts a pre-parsed body for exactly this reason, and both
+the predicate and the chosen handler must be fed from that single read. A second read returns an
+empty stream and produces a parse error instead of a routed request.
+
+`2026-07-28` is absent from this project's `SUPPORTED_PROTOCOL_VERSIONS`. The middleware answers 400
+to an unsupported `MCP-Protocol-Version` before any routing happens, so until that list is extended
+every modern request is rejected before it can reach the modern handler.
+
+The protocol-version error body added by OMC-018 must not preempt the modern path. It answers
+`-32020` for a header the middleware rejects; on the modern path those same rejections belong to the
+SDK's validation ladder, which produces richer error data than this server's own helper does.
+
+The `.mcpb` shim is unchanged and keeps speaking the handshake era. Bundles already distributed must
+continue to work, and no re-export may be required by this change.
+
+`IncompleteResult` does not exist in the installed SDK, although the suite's stream check refers to
+it. What the modern path does with a response stream carrying a notification is therefore measured
+against a running server, never inferred from the SDK's surface.
+
+## Success criteria
+
+- [ ] R-01 — A request carrying a valid `_meta` envelope is served by the modern path, and a request
+      without one is served by the existing path with byte-identical behaviour to before this change.
+- [ ] R-02 — `server/discover` answers with `supportedVersions`, capabilities matching the registered
+      handlers, and server identity under `_meta['io.modelcontextprotocol/serverInfo']`.
+- [ ] R-03 — The prompts capability appears in the discover result, and every capability it advertises
+      is honoured when the corresponding method is called.
+- [ ] R-04 — A request whose `_meta` is absent, or which omits `protocolVersion` or
+      `clientCapabilities`, is rejected with `-32602` and HTTP 400.
+- [ ] R-05 — A request whose `_meta` omits `clientInfo` is served normally; `clientInfo` is never
+      required.
+- [ ] R-06 — An unsupported protocol revision answers the unsupported-version error carrying this
+      server's supported versions and echoing the requested one.
+- [ ] R-07 — `2026-07-28` is present in this project's supported-version list, so a modern request
+      passes the middleware instead of being rejected at 400 before routing.
+- [ ] R-08 — The request body is read exactly once per request and shared between the classifier and
+      whichever handler serves it.
+- [ ] R-09 — Per-token tool surfaces resolve identically on both paths: a token's `tools/list` returns
+      the same set whether reached through the handshake era or the modern one.
+- [ ] R-10 — `activate_tool` still delivers `notifications/tools/list_changed` on the calling
+      request's own response stream when reached through the modern path, verified against a running
+      server.
+- [ ] R-11 — `search_vault_smart` still delivers progress notifications when reached through the
+      modern path, verified against a running server.
+- [ ] R-12 — An already-distributed `.mcpb` bundle continues to work with no re-export.
+- [ ] R-13 — The `server-stateless` conformance scenario reaches at least 18 of 27 checks, with the
+      two `test_missing_capability` checks declared unreachable and the two subscription checks
+      deferred to OMC-007. **Measured: 26/28, exit 0, baseline satisfied.** This requirement was
+      written expecting the five removed-method checks to be red by design as well; they pass, so
+      the baseline is four entries rather than nine. See R-17 and ADR-0016 §8, §9.
+- [ ] R-14 — No conformance check that passes today regresses, and the full project gate stays green:
+      type check, unit tests, Prettier, Svelte check, and the `.mcpb` smoke test.
+- [ ] R-15 — The headless conformance harness lives in the repository rather than a scratch
+      directory, and CI runs the suite against an expected-failures baseline that names each expected
+      red check and why.
+- [ ] R-16 — Per-era request counters are recorded through `SettingsStore.updateSlice` and surfaced
+      read-only in the transport settings section.
+- [ ] R-17 — The ADR records `legacy: 'reject'` as a future decision whose trigger is the legacy-era
+      counter (`services/eraCounters.ts` → `mcpTransport.eraCounters`) staying at zero over a stated
+      observation period: two consecutive minor releases or 60 days of use, whichever is longer.
+
+      The second half of this requirement as originally written — that the five removed-method checks
+      stay red until then, by choice rather than by defect — was a prediction, and measurement
+      falsified it. All five pass. The conformance suite only ever probes the modern era, where the
+      SDK's 2026 wire registry does not admit `initialize`, `ping`, `logging/setLevel`,
+      `resources/subscribe` or `resources/unsubscribe` and answers `404`/`-32601`; a legacy client
+      carries no envelope, classifies legacy, and keeps being served by the legacy transport.
+      Measured: `initialize` with a modern `_meta` envelope → HTTP 404 + `-32601`; without one →
+      HTTP 200 and the legacy handshake (`protocolVersion: "2025-06-18"`,
+      `serverInfo: {name: "mcp-connector", version: "1.0.1"}`).
+
+      The requirement is therefore satisfied by the ADR recording the prediction, the measurement
+      and the reason it changed — not by deleting the falsified claim. `legacy: 'reject'` remains a
+      future decision with the trigger above, but it is now a decision about which clients this
+      server refuses to serve, with no conformance score attached to it.

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -19,7 +19,8 @@
 		"build:mcpb": "bun scripts/build-mcpb.ts",
 		"release": "bun run build && bun run zip && bun run build:mcpb",
 		"zip": "bun scripts/zip.ts",
-		"test:mcpb": "bun scripts/mcpb-smoke.ts"
+		"test:mcpb": "bun scripts/mcpb-smoke.ts",
+		"test:conformance": "bash scripts/conformance/run.sh"
 	},
 	"dependencies": {
 		"@huggingface/transformers": "4.2.0",

--- a/packages/obsidian-plugin/scripts/conformance/expected-failures.yml
+++ b/packages/obsidian-plugin/scripts/conformance/expected-failures.yml
@@ -1,0 +1,47 @@
+# Conformance baseline for the `server-stateless` scenario.
+#
+# Every entry names one check that is red on purpose, with the reason it
+# is red. The suite fails the run on anything red that is NOT listed here,
+# and also on a listed check that has started passing.
+#
+# This file is maintained by hand and is never regenerated from a failing
+# run: pasting the current failures back in would turn the one artifact
+# that carries intent into a snapshot of whatever happens to be broken.
+# A check that starts passing gets its entry removed. A check that starts
+# failing gets investigated, then either fixed or added with a reason.
+#
+# Entry grammar is `<scenario>:<check-id>`, no space after the colon.
+# Checks that report SKIPPED or are absent need no entry: the suite
+# already tolerates both.
+
+server:
+  # --- The two capability checks, unreachable -----------------------------
+  # Both drive a diagnostic tool named `test_missing_capability` that the
+  # suite expects a server to expose. The SDK's
+  # REQUIRED_CLIENT_CAPABILITIES_BY_METHOD is `{}`
+  # (@modelcontextprotocol/server@2.0.0, dist/src-CX2iR2pK.mjs:452), so no
+  # spec method carries a static client-capability requirement and only a
+  # shipped fixture tool could satisfy these. That tool would appear in
+  # tools/list in every user's vault, in every client's tool picker,
+  # forever — a worse outcome than two honestly explained red checks
+  # (ADR-0016, Alternative F).
+
+  # Needs a shipped `test_missing_capability` fixture tool to reject; refusing to ship one.
+  - server-stateless:sep-2575-server-rejects-undeclared-capability
+  # Same fixture tool, so the -32021 response's HTTP 400 can never be exercised.
+  - server-stateless:sep-2575-missing-capability-http-400
+
+  # --- List-changed on a subscription stream, deferred to OMC-007 ---------
+  # The SDK's modern entry owns `subscriptions/listen`, so the stream opens
+  # and the acknowledgement and subscriptionId checks pass without this
+  # project implementing anything. What does not exist is the fan-out that
+  # would push a list-changed notification onto an already-open stream:
+  # this server delivers `notifications/tools/list_changed` on the calling
+  # request's own response stream and has no broadcast path (ADR-0016 §5,
+  # ADR-0011). Both checks are SHOULD-level. Adopting 2026-07-28 unblocks
+  # OMC-007; it does not perform it.
+
+  # No fan-out to open listen streams; tools/list_changed rides the caller's own response.
+  - server-stateless:sep-2575-server-sends-tools-list-changed-on-subscription
+  # Same missing fan-out on the prompts side.
+  - server-stateless:sep-2575-server-sends-prompts-list-changed-on-subscription

--- a/packages/obsidian-plugin/scripts/conformance/harness.ts
+++ b/packages/obsidian-plugin/scripts/conformance/harness.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+/*
+ * Headless harness for the MCP conformance suite.
+ *
+ * Boots the real MCP service (`createMcpService` + `startHttpServer`, the
+ * same pair mcpServer.test.ts drives end to end) on a fixed loopback port
+ * with a fixed bearer token, then puts an auth-injecting reverse proxy in
+ * front of it and blocks. No Obsidian and no vault: the Obsidian runtime
+ * comes from the package's own test mocks (src/test-setup.ts), which is
+ * why this file imports them before anything that touches "obsidian".
+ *
+ * Why a proxy at all: `conformance server --url <url>` has no flag for
+ * request headers, and every request to this connector must carry a
+ * bearer token. Weakening auth for the run would measure a server nobody
+ * ships, so the token is added in front instead and everything else is
+ * forwarded verbatim — method, path, query, headers and body — with the
+ * response streamed back untouched so SSE frames arrive as they are
+ * produced.
+ *
+ * Lives under scripts/, never under src/: the community-plugin review
+ * lints src/** only and non-plugin code belongs outside it (CLAUDE.md,
+ * ADR-0013).
+ *
+ * Driven by scripts/conformance/run.sh. To run it by hand:
+ *
+ *   cd packages/obsidian-plugin
+ *   bun scripts/conformance/harness.ts
+ */
+
+// Order matters and the two static imports below carry it. test-preload.js
+// aliases `window` onto the global object, and test-setup.ts registers the
+// synthetic "obsidian" module; both must have run before any transport
+// module is loaded, which is why those are pulled in dynamically further
+// down rather than imported at the top of the file.
+import "../../test-preload.js";
+import { mockApp, mockPlugin } from "../../src/test-setup";
+
+/** Port the plugin's own HTTP server binds. Not what the suite talks to. */
+const UPSTREAM_PORT = Number(process.env.CONFORMANCE_UPSTREAM_PORT ?? 27310);
+/** Port the auth-injecting proxy binds. This is the suite's `--url`. */
+const PROXY_PORT = Number(process.env.CONFORMANCE_PROXY_PORT ?? 27300);
+/**
+ * Fixed 32-char token. The middleware requires 32 characters; the value is
+ * inert — this process serves mock data on loopback and dies with the run.
+ */
+const TOKEN = "c".repeat(32);
+
+const { createMcpService } =
+  await import("../../src/features/mcp-transport/services/mcpServer");
+const { startHttpServer } =
+  await import("../../src/features/mcp-transport/services/httpServer");
+const { staticTokenProvider } =
+  await import("../../src/features/mcp-transport/services/tokenStore");
+
+const service = await createMcpService({
+  app: mockApp(),
+  plugin: mockPlugin(),
+  pluginVersion: "1.0.1",
+  serverName: "mcp-connector",
+});
+
+const upstream = await startHttpServer({
+  resolveTokens: staticTokenProvider(TOKEN),
+  requestHandler: service.handleRequest,
+  ports: [UPSTREAM_PORT],
+});
+
+const proxy = Bun.serve({
+  port: PROXY_PORT,
+  hostname: "127.0.0.1",
+  async fetch(request) {
+    const incoming = new URL(request.url);
+    // Path and query are preserved rather than pinned to /mcp, so a
+    // scenario probing an unknown path still measures the server's own
+    // answer instead of the proxy's.
+    const target = `http://127.0.0.1:${upstream.port}${incoming.pathname}${incoming.search}`;
+
+    const headers = new Headers(request.headers);
+    headers.set("authorization", `Bearer ${TOKEN}`);
+
+    const body =
+      request.method === "GET" || request.method === "HEAD"
+        ? undefined
+        : await request.arrayBuffer();
+
+    const response = await fetch(target, {
+      method: request.method,
+      headers,
+      body,
+    });
+
+    return new Response(response.body, {
+      status: response.status,
+      headers: response.headers,
+    });
+  },
+});
+
+// Exit on the signal rather than closing the two servers first. A
+// conformance run leaves `subscriptions/listen` SSE streams open, and
+// awaiting a graceful close on those never returns — the process then
+// ignores SIGTERM, outlives run.sh's trap and holds the port against the
+// next run. There is nothing here to flush: the vault is a mock and the
+// process is disposable.
+const exit = () => process.exit(0);
+process.on("SIGINT", exit);
+process.on("SIGTERM", exit);
+
+// run.sh polls the proxy port; this line is for a human reading the log.
+console.log(
+  `[conformance-harness] http://127.0.0.1:${proxy.port}/mcp -> http://127.0.0.1:${upstream.port}/mcp`,
+);

--- a/packages/obsidian-plugin/scripts/conformance/run.sh
+++ b/packages/obsidian-plugin/scripts/conformance/run.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Run the MCP conformance suite's `server-stateless` scenario against a
+# headless instance of this plugin's MCP server.
+#
+# The suite is built from source at a pinned ref: the published CLI
+# (0.1.16) has none of the 2026-07-28 scenarios. The ref is pinned rather
+# than tracking main because the suite is pre-release — an upstream
+# scenario change must not turn this job red for reasons unrelated to any
+# commit here. .github/workflows/conformance.yml sets the same ref
+# explicitly; the two move together.
+#
+# Failures are judged against expected-failures.yml, not against zero.
+# That file carries WHY each red check is red; it is edited by hand and
+# never regenerated from a failing run.
+#
+# Written for bash 3.2 (the /bin/bash macOS ships): no associative
+# arrays, no mapfile, no ${var^^}, no [[ -v ]], no local -n.
+#
+# Environment:
+#   MCP_CONFORMANCE_DIR    use this checkout instead of cloning; must
+#                          already be built (dist/index.js present)
+#   MCP_CONFORMANCE_REF    override the pinned ref
+#   MCP_CONFORMANCE_CACHE  where clones live (default: $TMPDIR)
+#   CONFORMANCE_PROXY_PORT port the harness's proxy binds (default 27300)
+
+# `set -eu`, not `set -euo pipefail`: this script contains no pipeline, so
+# pipefail would be inert. Add it together with the first pipeline whose
+# left-hand failure must not be swallowed, rather than as a header habit.
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PACKAGE_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+CONFORMANCE_REPO="https://github.com/modelcontextprotocol/conformance.git"
+# modelcontextprotocol/conformance @ 0.2.0-alpha.10.
+CONFORMANCE_REF="${MCP_CONFORMANCE_REF:-81eb1c3edaed87d7fd585d7b80186da7a2960660}"
+
+SCENARIO="server-stateless"
+BASELINE="$SCRIPT_DIR/expected-failures.yml"
+PROXY_PORT="${CONFORMANCE_PROXY_PORT:-27300}"
+PROXY_URL="http://127.0.0.1:$PROXY_PORT/mcp"
+READY_TIMEOUT_S=90
+
+for tool in bun node git curl; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "conformance: $tool is required but not on PATH" >&2
+    exit 1
+  fi
+done
+
+# --- resolve the suite -----------------------------------------------------
+
+if [ -n "${MCP_CONFORMANCE_DIR:-}" ]; then
+  CONFORMANCE_DIR="$MCP_CONFORMANCE_DIR"
+  if [ ! -f "$CONFORMANCE_DIR/dist/index.js" ]; then
+    echo "conformance: MCP_CONFORMANCE_DIR=$CONFORMANCE_DIR has no dist/index.js." >&2
+    echo "conformance: build it there first (npm ci && npm run build)." >&2
+    exit 1
+  fi
+  echo "conformance: using $CONFORMANCE_DIR"
+else
+  CACHE_ROOT="${MCP_CONFORMANCE_CACHE:-${TMPDIR:-/tmp}}/mcp-conformance"
+  CONFORMANCE_DIR="$CACHE_ROOT/$CONFORMANCE_REF"
+
+  if [ -d "$CONFORMANCE_DIR" ] && [ ! -d "$CONFORMANCE_DIR/.git" ]; then
+    echo "conformance: $CONFORMANCE_DIR exists but is not a git checkout." >&2
+    echo "conformance: remove it, or point MCP_CONFORMANCE_DIR elsewhere." >&2
+    exit 1
+  fi
+
+  if [ ! -d "$CONFORMANCE_DIR/.git" ]; then
+    echo "conformance: fetching $CONFORMANCE_REF into $CONFORMANCE_DIR"
+    mkdir -p "$CONFORMANCE_DIR"
+    git -C "$CONFORMANCE_DIR" init -q
+    git -C "$CONFORMANCE_DIR" remote add origin "$CONFORMANCE_REPO"
+    # Fetching one commit by sha keeps the pin exact and the download small.
+    git -C "$CONFORMANCE_DIR" fetch -q --depth 1 origin "$CONFORMANCE_REF"
+    git -C "$CONFORMANCE_DIR" checkout -q FETCH_HEAD
+  fi
+
+  if [ ! -f "$CONFORMANCE_DIR/dist/index.js" ]; then
+    echo "conformance: building the suite (npm ci)"
+    # `prepare` builds on install; `npm run build` after it is idempotent
+    # and covers an install that skipped lifecycle scripts.
+    (cd "$CONFORMANCE_DIR" && npm ci && npm run build)
+  fi
+fi
+
+# --- boot the harness ------------------------------------------------------
+
+cd "$PACKAGE_DIR"
+bun scripts/conformance/harness.ts &
+HARNESS_PID=$!
+
+# Ask first, then insist. A harness that outlives this script holds the
+# port and the next run fails to bind, so the exit path may not be
+# best-effort.
+cleanup() {
+  kill "$HARNESS_PID" 2>/dev/null || true
+  WAITED=0
+  while [ "$WAITED" -lt 10 ] && kill -0 "$HARNESS_PID" 2>/dev/null; do
+    sleep 1
+    WAITED=$((WAITED + 1))
+  done
+  kill -9 "$HARNESS_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+READY=""
+ELAPSED=0
+while [ "$ELAPSED" -lt "$READY_TIMEOUT_S" ]; do
+  if ! kill -0 "$HARNESS_PID" 2>/dev/null; then
+    echo "conformance: the harness exited before it started listening" >&2
+    exit 1
+  fi
+  # Any HTTP answer means the proxy is up, and the proxy binds after the
+  # plugin's own server does, so one probe covers both. curl without -f
+  # succeeds on a 405, which is what GET /mcp returns by design.
+  if curl -s -o /dev/null --max-time 2 "$PROXY_URL"; then
+    READY="yes"
+    break
+  fi
+  sleep 1
+  ELAPSED=$((ELAPSED + 1))
+done
+
+if [ -z "$READY" ]; then
+  echo "conformance: $PROXY_URL did not answer within ${READY_TIMEOUT_S}s" >&2
+  exit 1
+fi
+
+# --- run -------------------------------------------------------------------
+
+set +e
+node "$CONFORMANCE_DIR/dist/index.js" server \
+  --url "$PROXY_URL" \
+  --scenario "$SCENARIO" \
+  --expected-failures "$BASELINE"
+STATUS=$?
+set -e
+
+exit "$STATUS"

--- a/packages/obsidian-plugin/src/features/mcp-transport/components/AccessControlSection.svelte
+++ b/packages/obsidian-plugin/src/features/mcp-transport/components/AccessControlSection.svelte
@@ -16,6 +16,10 @@
   } from "$/features/mcp-transport/services/tokenStore";
   import { parsePortInput } from "$/features/mcp-transport/services/portInput";
   import {
+    readEraCounters,
+    type EraCounters,
+  } from "$/features/mcp-transport/services/eraCounters";
+  import {
     BIND_HOST,
     MAX_TOKENS,
     MCP_PATH_PREFIX,
@@ -94,12 +98,19 @@
   let serverNameInput = "";
   let serverNameBusy = false;
 
+  // How many requests each protocol era has served, as persisted at the
+  // moment this pane opened. Diagnostic and read-only: the value exists so
+  // the `legacy: 'reject'` trigger (ADR-0016 §8) can be observed rather
+  // than guessed at, and nothing here writes it back.
+  let eraCounters: EraCounters = { legacy: 0, modern: 0 };
+
   onMount(async () => {
     const raw = (await new SettingsStore(plugin).readSlice("mcpTransport")) as
-      | { port?: number; serverName?: string }
+      | { port?: number; serverName?: string; eraCounters?: unknown }
       | undefined;
     portInput = raw?.port ?? null;
     serverNameInput = raw?.serverName ?? "";
+    eraCounters = readEraCounters(raw?.eraCounters);
     const registry = plugin.mcpTransportState?.mcp.registry;
     allToolNames = registry ? registry.listAll().map((t) => t.name) : [];
     await refreshTokens();
@@ -593,6 +604,23 @@
         {:else}
           HTTP transport not running — port unavailable.
         {/if}
+      </div>
+    </div>
+  </div>
+
+  <div class="setting-item">
+    <div class="setting-item-info">
+      <div class="setting-item-name">Requests served</div>
+      <!-- The non-breaking spaces keep each era's label glued to its own
+           number, and the separator glued to the count before it, so a
+           narrow pane or a five-digit count cannot wrap a bare number or a
+           lone `·` onto a line of its own. The single ordinary space
+           between the two groups is the one break point left, which is
+           also the only one that reads correctly. -->
+      <div class="setting-item-description">
+        2025&nbsp;era&nbsp;{eraCounters.legacy}&nbsp;· 2026-07-28&nbsp;era&nbsp;{eraCounters.modern}.
+        Read when this pane opened, so requests still batched in memory are
+        not counted yet.
       </div>
     </div>
   </div>

--- a/packages/obsidian-plugin/src/features/mcp-transport/constants.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/constants.ts
@@ -20,13 +20,34 @@ export const ALLOWED_ORIGINS_PATTERN =
 // (node_modules/@modelcontextprotocol/core/dist/internal.mjs, the package's
 // "./internal" subpath export), kept here so it is visible and testable in
 // this project's own suite. Newest first.
+//
+// This list spans BOTH eras, unlike the SDK's, which keeps its modern
+// revisions in a separate SUPPORTED_MODERN_PROTOCOL_VERSIONS so a modern
+// string can never leak into a 2025-era handshake. The distinction does not
+// apply here: this list is only ever read by the MCP-Protocol-Version header
+// rung (middleware.ts), never to build an `initialize` reply — that offer is
+// the SDK's own LATEST_PROTOCOL_VERSION (2025-11-25) and is untouched by
+// this entry. The 2026 era is reached by probing `server/discover`, never by
+// the handshake (ADR-0016).
 export const SUPPORTED_PROTOCOL_VERSIONS = [
+  "2026-07-28",
   "2025-11-25",
   "2025-06-18",
   "2025-03-26",
   "2024-11-05",
   "2024-10-07",
 ] as const;
+
+// The first protocol revision of the modern era. Project-owned copy of the
+// SDK's FIRST_MODERN_PROTOCOL_VERSION
+// (node_modules/@modelcontextprotocol/server/dist/src-CX2iR2pK.mjs:544),
+// copied for the same reason as the version list above: it lives in
+// core-internal and is exported from no public entry point. Revision
+// identifiers are ISO dates, so the SDK orders eras with a lexicographic
+// comparison against this value (`isModernProtocolVersion`, :553) and so
+// does middleware.ts. If the SDK ever moves the era boundary off that
+// comparison, both copies go stale silently (ADR-0016, Consequences).
+export const FIRST_MODERN_PROTOCOL_VERSION = "2026-07-28" as const;
 
 export const ERROR_CODES = {
   METHOD_NOT_ALLOWED: 405,

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/conformanceHarness.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/conformanceHarness.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+const PACKAGE_ROOT = join(import.meta.dir, "../../../..");
+const CONFORMANCE_DIR = join(PACKAGE_ROOT, "scripts/conformance");
+
+/**
+ * Manual recursive walk rather than `readdirSync(dir, { recursive: true })`:
+ * the installed @types/node (16.x, pinned by package.json) has no overload
+ * for that option, so using it would fail `tsc --noEmit` even though Bun's
+ * runtime supports it.
+ */
+function collectBasenames(dir: string): string[] {
+  const names: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      names.push(...collectBasenames(join(dir, entry.name)));
+    } else {
+      names.push(entry.name);
+    }
+  }
+  return names;
+}
+
+function readPackageJson(): { scripts?: Record<string, string> } {
+  return JSON.parse(
+    readFileSync(join(PACKAGE_ROOT, "package.json"), "utf8"),
+  ) as { scripts?: Record<string, string> };
+}
+
+/**
+ * The harness, its runner and its baseline live under scripts/conformance/,
+ * not under src/ and not in a machine-local scratch directory. Both halves
+ * matter for different reasons:
+ *
+ * - Present under scripts/: the community-plugin review scanner lints
+ *   src/** only and forbids eslint-disable on obsidianmd/* rules there
+ *   (CLAUDE.md, ADR-0013). A refactor that moved harness.ts under src/ to
+ *   shorten an import would sail through the rest of this suite and still
+ *   break plugin review.
+ * - Runnable from the repo: package.json's test:conformance script is what
+ *   turns "the file is checked in" into "CI can actually invoke it".
+ *
+ * expected-failures.yml is checked separately below because its content,
+ * not just its location, carries intent (it is maintained by hand and
+ * never regenerated from a failing run).
+ */
+describe("conformance harness lives in the repo, not a scratch directory (R-15)", () => {
+  test("harness.ts, run.sh and expected-failures.yml exist under scripts/conformance/", () => {
+    expect(existsSync(join(CONFORMANCE_DIR, "harness.ts"))).toBe(true);
+    expect(existsSync(join(CONFORMANCE_DIR, "run.sh"))).toBe(true);
+    expect(existsSync(join(CONFORMANCE_DIR, "expected-failures.yml"))).toBe(
+      true,
+    );
+  });
+
+  test("none of the three conformance filenames exist anywhere under src/", () => {
+    const basenames = collectBasenames(join(PACKAGE_ROOT, "src"));
+    expect(basenames).not.toContain("harness.ts");
+    expect(basenames).not.toContain("run.sh");
+    expect(basenames).not.toContain("expected-failures.yml");
+  });
+
+  test("package.json's test:conformance script runs scripts/conformance/run.sh", () => {
+    const pkg = readPackageJson();
+    expect(pkg.scripts?.["test:conformance"]).toBe(
+      "bash scripts/conformance/run.sh",
+    );
+  });
+
+  test("package.json's test:mcpb script (the #412 regression guard) is untouched", () => {
+    const pkg = readPackageJson();
+    expect(pkg.scripts?.["test:mcpb"]).toBe("bun scripts/mcpb-smoke.ts");
+  });
+
+  test("expected-failures.yml parses to exactly four hand-maintained server-stateless: entries", () => {
+    const text = readFileSync(
+      join(CONFORMANCE_DIR, "expected-failures.yml"),
+      "utf8",
+    );
+    const parsed = Bun.YAML.parse(text) as Record<string, unknown>;
+    const entries = Object.values(parsed).flatMap((value) =>
+      Array.isArray(value) ? value : [],
+    );
+
+    // Four, not the nine the plan budgeted (measurement came in lower, see
+    // ADR-0016 §8-9). The count matters precisely because this file is
+    // edited by hand and never regenerated from a failing run: a silent
+    // regeneration would show up here as a count that moved without a
+    // reason. A check that starts passing is supposed to lose its entry,
+    // so if this count legitimately changes, update the number below along
+    // with the removal rather than treating this assertion as a reason not
+    // to remove one.
+    expect(entries).toHaveLength(4);
+
+    for (const entry of entries) {
+      expect(typeof entry).toBe("string");
+      expect(entry as string).toMatch(/^server-stateless:.+/);
+    }
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/eraCounters.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/eraCounters.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { mockPlugin } from "$/test-setup";
+import type McpToolsPlugin from "$/main";
+import { flush, record } from "./eraCounters";
+
+/**
+ * `record`/`flush` batch per-era request counts in memory and persist them
+ * through `SettingsStore.updateSlice`, the same batching discipline
+ * `ToolLoadingManager.flushPendingCalls` already uses for tool-call
+ * counters and for the same reason: a settings write per request would be
+ * a disk write per request (ADR-0016 §7). `mcpServer.ts` calls
+ * `record(era)` with no plugin reference on each branch of
+ * `handleRequest`, so the in-memory batch itself is a single counter, not
+ * one keyed by plugin — only `flush(plugin)` takes one.
+ *
+ * Exercised here against the same in-memory `data.json` double
+ * `setup.test.ts` uses, plus a save counter so "no write when nothing
+ * changed" can be asserted on write COUNT, the same way
+ * `tokenStore.test.ts` asserts `ensureTokenStore`'s idempotency.
+ *
+ * Because the in-memory batch is a module-level singleton, every test
+ * below records only what IT needs and flushes it away before finishing.
+ * That keeps the batch at zero regardless of which test bun runs next —
+ * none of the assertions here depend on file execution order.
+ */
+function makePlugin(initialData: Record<string, unknown> = {}) {
+  let data: Record<string, unknown> = { ...initialData };
+  let saves = 0;
+  const plugin = mockPlugin({
+    loadData: async () => data,
+    saveData: async (next: unknown) => {
+      saves += 1;
+      data = next as Record<string, unknown>;
+    },
+  } as Partial<McpToolsPlugin>);
+  return { plugin, getData: () => data, saveCount: () => saves };
+}
+
+describe("eraCounters — batched per-era request counts (R-16)", () => {
+  test('record("legacy") x3 + record("modern") x2, then flush(plugin) writes the aggregated batch in one write', async () => {
+    const { plugin, getData, saveCount } = makePlugin();
+
+    record("legacy");
+    record("legacy");
+    record("legacy");
+    record("modern");
+    record("modern");
+    await flush(plugin);
+
+    const mcpTransport = getData().mcpTransport as {
+      eraCounters?: { legacy: number; modern: number };
+    };
+    expect(mcpTransport.eraCounters).toEqual({ legacy: 3, modern: 2 });
+    expect(saveCount()).toBe(1);
+  });
+
+  test("a second flush with nothing newly recorded performs no additional write", async () => {
+    const { plugin, saveCount } = makePlugin();
+
+    record("legacy");
+    await flush(plugin);
+    expect(saveCount()).toBe(1);
+
+    await flush(plugin);
+    expect(saveCount()).toBe(1);
+  });
+
+  test("existing eraCounters values accumulate rather than reset", async () => {
+    const { plugin, getData } = makePlugin({
+      mcpTransport: { eraCounters: { legacy: 5, modern: 1 } },
+    });
+
+    record("modern");
+    record("modern");
+    await flush(plugin);
+
+    const mcpTransport = getData().mcpTransport as {
+      eraCounters: { legacy: number; modern: number };
+    };
+    expect(mcpTransport.eraCounters).toEqual({ legacy: 5, modern: 3 });
+  });
+
+  test("an absent eraCounters key defaults to zero, and sibling mcpTransport fields survive untouched", async () => {
+    const existingTokens = [
+      {
+        id: "default",
+        label: "Default",
+        token: "a".repeat(32),
+        createdAt: 1,
+      },
+    ];
+    const { plugin, getData } = makePlugin({
+      mcpTransport: {
+        port: 27123,
+        livePort: 27123,
+        serverName: "mcp-connector",
+        bearerToken: existingTokens[0]!.token,
+        tokens: existingTokens,
+      },
+      // A sibling top-level slice, unrelated to mcpTransport: proves the
+      // write goes through updateSlice's `{ ...raw, [key]: next }` merge
+      // rather than a hand-rolled write that could drop it. This is the
+      // clobber CLAUDE.md's "Settings are sliced" invariant exists to
+      // prevent — data.json is shared by every feature.
+      toolLoading: { profile: "core", promoted: [], counters: {} },
+    });
+
+    record("legacy");
+    await flush(plugin);
+
+    const data = getData();
+    const mcpTransport = data.mcpTransport as Record<string, unknown>;
+    expect(mcpTransport.eraCounters).toEqual({ legacy: 1, modern: 0 });
+    expect(mcpTransport.port).toBe(27123);
+    expect(mcpTransport.livePort).toBe(27123);
+    expect(mcpTransport.serverName).toBe("mcp-connector");
+    expect(mcpTransport.tokens).toEqual(existingTokens);
+    expect(data.toolLoading).toEqual({
+      profile: "core",
+      promoted: [],
+      counters: {},
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/eraCounters.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/eraCounters.ts
@@ -1,0 +1,111 @@
+import { SettingsStore } from "$/shared/settingsStore";
+import type { PluginDataLike } from "$/shared/types";
+import type { Era } from "./eraRouter";
+
+/**
+ * How many requests each protocol era has served, cumulative over the life
+ * of the vault. Diagnostic only: nothing reads it to make a runtime
+ * decision. It exists so the `legacy: 'reject'` trigger recorded in
+ * ADR-0016 §8 — the legacy count staying at zero across two minor releases
+ * or 60 days, whichever is longer — can be observed rather than guessed at.
+ */
+export type EraCounters = { legacy: number; modern: number };
+
+const SLICE = "mcpTransport";
+
+/**
+ * Trailing debounce for persisting the batch. `record` fires on EVERY
+ * classified request, and a settings write per request is a disk write per
+ * request, under the process-wide mutex, in front of the transport — for a
+ * number nothing reads at runtime (ADR-0016 §7, alternative G). Matching
+ * `ToolLoadingManager`'s window: the timer is armed by the first record and
+ * not re-armed by later ones, so it caps writes at one per window rather
+ * than deferring them indefinitely under sustained traffic.
+ */
+const FLUSH_DELAY_MS = 2_000;
+
+/**
+ * The unflushed batch, module-level and NOT keyed by plugin: a vault runs
+ * one transport, `record` is called from the request path where no plugin
+ * reference is in hand, and the counter is a property of the server rather
+ * than of any particular caller. `flush(plugin)` is the only function that
+ * needs one.
+ */
+let pending: EraCounters = { legacy: 0, modern: 0 };
+let timer: number | null = null;
+
+/** Normalize a stored `eraCounters` value; anything absent or malformed reads as zero. */
+export function readEraCounters(value: unknown): EraCounters {
+  const raw = (value ?? {}) as Record<string, unknown>;
+  return {
+    legacy: typeof raw.legacy === "number" ? raw.legacy : 0,
+    modern: typeof raw.modern === "number" ? raw.modern : 0,
+  };
+}
+
+/** Count one request against the era that served it. In memory only. */
+export function record(era: Era): void {
+  pending[era] += 1;
+}
+
+/**
+ * Arm the debounced flush, so a vault that stays open for weeks persists
+ * its counts without waiting for a teardown. Already-armed is a no-op —
+ * re-arming on every request would let a busy server postpone the write
+ * forever.
+ */
+export function scheduleFlush(
+  plugin: PluginDataLike,
+  delayMs: number = FLUSH_DELAY_MS,
+): void {
+  if (timer !== null) return;
+  // window.setTimeout (not the bare global): Obsidian popout-window
+  // compatibility, and the plugin runs in the renderer where window is
+  // always present.
+  timer = window.setTimeout(() => {
+    timer = null;
+    // Fire-and-forget: a failed flush puts the batch back (see below) and
+    // the next request re-arms the timer.
+    void flush(plugin).catch(() => {});
+  }, delayMs);
+}
+
+/**
+ * Persist the batch in ONE settings write, accumulating onto whatever is
+ * already stored. Callers: the debounce timer above, and
+ * `McpService.flushPendingCalls` (hence service teardown, so an unload does
+ * not drop a window of counts). Safe to call with nothing pending — it then
+ * performs no read and no write at all.
+ *
+ * The write goes through `SettingsStore.updateSlice` because `data.json` is
+ * shared by every feature: an unserialized read-modify-write here would
+ * clobber another slice, or drop `livePort` written concurrently by setup.
+ */
+export async function flush(plugin: PluginDataLike): Promise<void> {
+  if (timer !== null) {
+    window.clearTimeout(timer);
+    timer = null;
+  }
+  if (pending.legacy === 0 && pending.modern === 0) return;
+  const batch = pending;
+  pending = { legacy: 0, modern: 0 };
+  try {
+    await new SettingsStore(plugin).updateSlice(SLICE, (current) => {
+      const slice = (current as Record<string, unknown> | undefined) ?? {};
+      const stored = readEraCounters(slice.eraCounters);
+      return {
+        ...slice,
+        eraCounters: {
+          legacy: stored.legacy + batch.legacy,
+          modern: stored.modern + batch.modern,
+        },
+      };
+    });
+  } catch (error) {
+    // Put the batch back so a transient write failure does not drop the
+    // counts; merge with anything recorded meanwhile.
+    pending.legacy += batch.legacy;
+    pending.modern += batch.modern;
+    throw error;
+  }
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/eraRouter.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/eraRouter.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, test, afterEach, beforeEach, spyOn } from "bun:test";
+import { mockApp, mockPlugin, resetMockVault } from "$/test-setup";
+import {
+  createMcpService,
+  destroyMcpService,
+  type McpService,
+} from "./mcpServer";
+import { staticTokenProvider } from "./tokenStore";
+import * as parseRequestBody from "./parseRequestBody";
+
+/**
+ * Era classification for OMC-008 (`docs/architecture/ADR-0016-...md`).
+ *
+ * This file drives the real `startHttpServer` + `createMcpService` surface
+ * (the same idiom `mcpServer.test.ts` uses) rather than importing
+ * `eraRouter.ts` directly, so a failure here is an assertion mismatch about
+ * observable behaviour rather than a statement about internal structure.
+ *
+ * Most of the assertions below are REGRESSION PINS: they describe behaviour
+ * that was already true before the classifier existed and MUST stay true now
+ * that `mcpServer.ts` calls `classifyEra` / `applyDeferredVersionRung` on
+ * every request. Each test says which kind it is.
+ *
+ * These docstrings were written during the TDD red phase and described a
+ * half-built system; they are kept current deliberately. A comment that
+ * narrates a phase the code has left is worse than no comment, because it
+ * sends the next reader looking for a code path that no longer exists.
+ */
+
+const TOKEN = "t".repeat(32);
+
+beforeEach(() => resetMockVault());
+
+const active: McpService[] = [];
+afterEach(async () => {
+  for (const s of active.splice(0)) await destroyMcpService(s);
+});
+
+describe("eraRouter (Task 2) — the legacy path stays byte-identical (R-01)", () => {
+  test("a claim-less initialize POST is answered with exactly today's bytes — full-body pin, must survive the classifier being wired in", async () => {
+    const { startHttpServer } = await import("./httpServer");
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin: mockPlugin(),
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(TOKEN),
+      requestHandler: svc.handleRequest,
+    });
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "0.0.0" },
+          },
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Full-body equality, not a subset check: a request carrying no
+      // `params._meta` envelope claim must classify legacy and answer
+      // with exactly these bytes, both before eraRouter exists and after
+      // it is wired into mcpServer.ts.
+      expect(body).toEqual({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: {
+            tools: { listChanged: true },
+            prompts: { listChanged: true },
+          },
+          serverInfo: { name: "mcp-connector", version: "0.4.0-alpha.1" },
+        },
+      });
+    } finally {
+      await new Promise<void>((r) => server.server.close(() => r()));
+    }
+  });
+});
+
+describe("eraRouter — a modern-envelope request is classified separately from a claim-less one", () => {
+  test("params._meta carrying the 2026 envelope is served by the modern handler; a claim-less request is served by the legacy transport", async () => {
+    // The discriminator is the `serverInfo` stamp, not a log line. Only the
+    // 2026 encode seam writes `_meta['io.modelcontextprotocol/serverInfo']`
+    // onto a result, so its presence proves which era served the request —
+    // the same signal modernEra.test.ts uses.
+    //
+    // An earlier version of this test spied on `logger.warn` instead, back
+    // when a modern-classified request fell through to the legacy transport
+    // after warning. That fall-through is gone: the strict handler is wired
+    // now. The spy kept passing anyway, because a modern request missing its
+    // `Mcp-Method` header makes the SDK's own `onerror` warn — same signal,
+    // different cause. A test that passes for a reason other than the one it
+    // names can keep passing while the thing it names breaks.
+    //
+    // Deliberately no MCP-Protocol-Version header here: the point under
+    // test is the classifier alone, decoupled from the header rung
+    // (covered separately in middleware.test.ts). `Mcp-Method` is not the
+    // header rung — SEP-2243 makes it mandatory on every 2026-era request,
+    // so the modern leg carries it to be well-formed at all.
+    const { startHttpServer } = await import("./httpServer");
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin: mockPlugin(),
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(TOKEN),
+      requestHandler: svc.handleRequest,
+    });
+
+    try {
+      const legacyRes = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+          params: {},
+        }),
+      });
+      expect(legacyRes.status).toBe(200);
+      const legacyBody = await legacyRes.json();
+      expect(
+        legacyBody.result?._meta?.["io.modelcontextprotocol/serverInfo"],
+      ).toBeUndefined();
+
+      const modernRes = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-method": "tools/list",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/list",
+          params: {
+            _meta: {
+              "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+              "io.modelcontextprotocol/clientCapabilities": {},
+            },
+          },
+        }),
+      });
+      expect(modernRes.status).toBe(200);
+      const modernBody = await modernRes.json();
+      expect(
+        modernBody.result?._meta?.["io.modelcontextprotocol/serverInfo"],
+      ).toEqual({ name: "mcp-connector", version: "0.4.0-alpha.1" });
+    } finally {
+      await new Promise<void>((r) => server.server.close(() => r()));
+    }
+  });
+});
+
+describe("eraRouter — an unparseable body is classified legacy without constructing a Request", () => {
+  test("malformed JSON still answers the SDK's own -32700 Parse error, no crash surfaces", async () => {
+    // Regression pin: reproduces the SDK's existing parse-error behaviour
+    // (no MCP-Protocol-Version header, so this reaches mcpServer.ts's
+    // handleRequest rather than httpServer.ts's OMC-018 -32020 shortcut).
+    // classifyEra's documented job (plan Task 2 sub-step 2) is to
+    // short-circuit to "legacy" on an unparseable body WITHOUT calling
+    // toWebRequest/isLegacyRequest — this pins the answer that guarantee
+    // must keep producing.
+    const { startHttpServer } = await import("./httpServer");
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin: mockPlugin(),
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(TOKEN),
+      requestHandler: svc.handleRequest,
+    });
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: "{not valid json",
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toEqual({
+        jsonrpc: "2.0",
+        error: { code: -32700, message: "Parse error: Invalid JSON" },
+        id: null,
+      });
+    } finally {
+      await new Promise<void>((r) => server.server.close(() => r()));
+    }
+  });
+
+  test("a chunked over-cap body still answers 413 and destroys the socket (existing behaviour, mcpServer.test.ts:92)", async () => {
+    // Duplicated here deliberately (plan Task 2 sub-step 1 names this
+    // exact existing test): the 413 short-circuit in mcpServer.ts must
+    // fire BEFORE classifyEra ever sees the body, and this file is where a
+    // future change to that ordering would be caught.
+    const { startHttpServer } = await import("./httpServer");
+    const { request } = await import("node:http");
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin: mockPlugin(),
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(TOKEN),
+      requestHandler: svc.handleRequest,
+    });
+
+    try {
+      const status = await new Promise<number>((resolve, reject) => {
+        const req = request(
+          {
+            host: "127.0.0.1",
+            port: server.port,
+            path: "/mcp",
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${TOKEN}`,
+              "content-type": "application/json",
+              accept: "application/json, text/event-stream",
+              "transfer-encoding": "chunked",
+            },
+          },
+          (res) => {
+            res.resume();
+            resolve(res.statusCode ?? 0);
+          },
+        );
+        let settled = false;
+        req.on("response", () => {
+          settled = true;
+        });
+        req.on("error", (err) => {
+          if (!settled) reject(err);
+        });
+        const chunk = Buffer.alloc(64 * 1024, 0x61);
+        for (let sent = 0; sent <= 1_048_576; sent += chunk.length) {
+          req.write(chunk);
+        }
+        req.end();
+      });
+      expect(status).toBe(413);
+    } finally {
+      await new Promise<void>((r) => server.server.close(() => r()));
+    }
+  });
+});
+
+describe("eraRouter — the deferred version rung still fires on the legacy branch (R-01, OMC-018 regression guard)", () => {
+  test("still answers 400 with the -32020 unsupported-version code (body owned by the SDK ladder)", async () => {
+    // A claim-less initialize with a modern MCP-Protocol-Version header does
+    // NOT classify legacy. classifyRequestBody routes it to the
+    // "initialize-with-modern-header" cross-check, a rejection, so this
+    // never reaches applyDeferredVersionRung and the body it answers with is
+    // not buildProtocolVersionErrorBody's. What the design still guarantees
+    // is the pair the `unsupported-version-400` conformance check cares
+    // about: HTTP 400 and error code -32020. The message text, `data`
+    // payload and echoed id belong to the SDK's own ladder, not to this
+    // code, so they are deliberately left unasserted here. Task 4 wires the
+    // strict modern handler and is where `data.supported`, `data.requested`
+    // and `data.mismatch` get their own assertions.
+    const { startHttpServer } = await import("./httpServer");
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin: mockPlugin(),
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(TOKEN),
+      requestHandler: svc.handleRequest,
+    });
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": "2027-05-01",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 5,
+          method: "initialize",
+          params: {},
+        }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.jsonrpc).toBe("2.0");
+      expect(body.error.code).toBe(-32020);
+    } finally {
+      await new Promise<void>((r) => server.server.close(() => r()));
+    }
+  });
+});
+
+describe("eraRouter — the request body is read exactly once per request (R-08)", () => {
+  test("readBodyWithCap is called exactly once for a normal request", async () => {
+    // Regression guard for the SDK fact ADR-0016 §1 records: isLegacyRequest
+    // requires the already-read parsedBody to be passed through explicitly,
+    // because its internal clone throws on a stream already drained. This
+    // pins today's single-read behaviour so a future classifyEra wiring
+    // that forgets to pass parsedBody (and re-reads the stream) is caught
+    // here instead of surfacing as a hang or a parse error in production.
+    const spy = spyOn(parseRequestBody, "readBodyWithCap");
+    const { startHttpServer } = await import("./httpServer");
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin: mockPlugin(),
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(TOKEN),
+      requestHandler: svc.handleRequest,
+    });
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+          params: {},
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+      await new Promise<void>((r) => server.server.close(() => r()));
+    }
+  });
+});

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/eraRouter.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/eraRouter.ts
@@ -1,0 +1,92 @@
+import { toWebRequest } from "@modelcontextprotocol/node";
+import { isLegacyRequest } from "@modelcontextprotocol/server";
+import type { IncomingMessage } from "node:http";
+import { ERROR_CODES, SUPPORTED_PROTOCOL_VERSIONS } from "../constants";
+import {
+  buildProtocolVersionErrorBody,
+  getHeader,
+  isModernProtocolVersion,
+  type JsonRpcErrorBody,
+  type RequestHeaders,
+} from "./middleware";
+
+/**
+ * Which protocol era serves a request: the `initialize`-handshake era every
+ * currently configured client speaks, or the 2026-07-28 revision reached by
+ * probing `server/discover` (ADR-0016).
+ */
+export type Era = "legacy" | "modern";
+
+/**
+ * Classify a request into its protocol era, from the body the caller has
+ * already read.
+ *
+ * `isLegacyRequest` is the SDK entry's own classification step exported as a
+ * predicate — it runs the code `createMcpHandler` runs to make the same
+ * decision, so this hand-wired router cannot disagree with the handler it
+ * routes to.
+ *
+ * Both arguments are passed to it on purpose. Given only a `Request`, the
+ * predicate reads the body from an internal clone; cloning a `Request` whose
+ * body has already been read throws a `TypeError`, and `toWebRequest(req,
+ * parsedBody)` produces exactly such a request (it serializes the parsed
+ * value instead of touching the Node stream). Passing `parsedBody` as well
+ * makes the predicate classify from the value directly, cloning nothing. The
+ * SDK documents this as needed, not merely faster, for a body already read —
+ * which is this transport's case, since `readBodyWithCap` drained the stream
+ * before anything here runs (R-08).
+ *
+ * The `parsedBody === undefined` short-circuit returns before any `Request`
+ * is constructed. `undefined` means the body was empty or failed
+ * `JSON.parse`, and `toWebRequest(req, undefined)` would then try to read the
+ * stream that is already drained, yielding an empty body and a spurious parse
+ * error. The SDK classifies an unparseable body as legacy anyway, so the
+ * short-circuit is both safe and identical to the entry's own answer.
+ */
+export async function classifyEra(
+  req: IncomingMessage,
+  parsedBody: unknown,
+): Promise<Era> {
+  if (parsedBody === undefined) return "legacy";
+  const probe = await toWebRequest(req, parsedBody);
+  return (await isLegacyRequest(probe, parsedBody)) ? "legacy" : "modern";
+}
+
+/** A deferred protocol-version header answered after classification. */
+export type DeferredVersionRejection = {
+  status: (typeof ERROR_CODES)["PROTOCOL_VERSION_UNSUPPORTED"];
+  body: JsonRpcErrorBody;
+};
+
+/**
+ * The deferred half of the protocol-version rung (ADR-0016 §3), applied to a
+ * request that classified legacy.
+ *
+ * `checkProtocolVersion` lets a 2026-era header through the middleware chain
+ * rather than rejecting it at 400, because only classification can tell
+ * whether the SDK's validation ladder owns the answer. A request whose header
+ * names a 2026-era revision this server does not serve, and which then
+ * classifies legacy, has no such owner — nothing downstream would answer it —
+ * so it is rejected here instead, with the same body the middleware would
+ * have produced before the rung was split. That keeps the conformance suite's
+ * `unsupported-version-400` answer intact.
+ *
+ * Returns `null` for everything else: an absent header, a revision this
+ * server serves, and a pre-2026 revision it does not (`runMiddleware` already
+ * rejected that one, before auth, and this function is never reached).
+ */
+export function applyDeferredVersionRung(
+  headers: RequestHeaders,
+  parsedBody: unknown,
+): DeferredVersionRejection | null {
+  const version = getHeader(headers, "mcp-protocol-version");
+  if (version === undefined) return null;
+  if ((SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(version)) {
+    return null;
+  }
+  if (!isModernProtocolVersion(version)) return null;
+  return {
+    status: ERROR_CODES.PROTOCOL_VERSION_UNSUPPORTED,
+    body: buildProtocolVersionErrorBody(parsedBody),
+  };
+}

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/httpServer.test.ts
@@ -194,7 +194,15 @@ describe("MCP-Protocol-Version 400 carries a JSON-RPC body (SEP-2575 server-stat
       headers: {
         authorization: `Bearer ${token}`,
         "content-type": "application/json",
-        "mcp-protocol-version": "2026-07-28",
+        // Must stay a PRE-2026 unsupported value (OMC-008 Task 1). This
+        // body's -32602 comes from buildProtocolVersionErrorBody, which
+        // httpServer.ts only calls after checkProtocolVersion has already
+        // rejected the request with 400. A 2026-era value (e.g.
+        // "2026-07-28" or "2027-05-01") is deferred by the version rung
+        // instead of rejected, so it would reach requestHandler here and
+        // this test's throwing stub would 500 instead of asserting
+        // -32602. Do not "modernise" this back to a 2026-era date.
+        "mcp-protocol-version": "2023-01-01",
       },
       body: JSON.stringify({
         jsonrpc: "2.0",

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test, afterEach, beforeEach } from "bun:test";
+import {
+  InMemoryTransport,
+  type McpServer,
+} from "@modelcontextprotocol/server";
 import { mockApp, mockPlugin, resetMockVault } from "$/test-setup";
 import {
   createMcpService,
@@ -817,6 +821,114 @@ describe("Task 5 — per-token scope threading (ADR-0014 §3)", () => {
     } finally {
       await new Promise<void>((r) => server.server.close(() => r()));
     }
+  });
+});
+
+describe("OMC-008 Task 3 — buildMcpServer is the single per-request factory, called directly (R-09)", () => {
+  // TDD RED phase (plan Task 3 sub-step 1, `docs/superpowers/plans/2026-08-08-omc-008-adopt-mcp-spec-2026-07-28.md`).
+  // `buildMcpServer` does not exist yet: `createMcpService` still builds its
+  // `McpServer` inline inside `handleRequest`, unreachable from a test. This
+  // block pins the surface the extraction (plan Task 3 sub-step 2) must
+  // expose: a `buildMcpServer(tokenId)` field on the returned `McpService`,
+  // synchronous, returning an `McpServer` wired exactly like today's inline
+  // one. Both the compiler (no such property on `McpService`) and the
+  // runtime (`svc.buildMcpServer is not a function`) reject this file until
+  // that field exists — the missing export IS the RED.
+  const TOKEN_A = {
+    id: "tok-a",
+    label: "A",
+    token: "a".repeat(32),
+    createdAt: 1,
+  };
+  const TOKEN_B = {
+    id: "tok-b",
+    label: "B",
+    token: "b".repeat(32),
+    createdAt: 2,
+  };
+
+  /** Two tokens, `all` vs `core`, matching the fixture ADR-0014's own tests
+   * use (`Task 5 — per-token scope threading` above) — reused here rather
+   * than imported so this file stays a self-contained anchor for R-09's
+   * direct-call guarantee. */
+  function makeTwoTokenPlugin() {
+    let store: Record<string, unknown> = {
+      mcpTransport: {
+        bearerToken: TOKEN_A.token,
+        tokens: [TOKEN_A, TOKEN_B],
+      },
+      toolLoading: {
+        profile: "all",
+        promoted: [],
+        counters: {},
+        profiles: {
+          [TOKEN_A.id]: { profile: "all", promoted: [], allowed: null },
+          [TOKEN_B.id]: { profile: "core", promoted: [], allowed: null },
+        },
+      },
+    };
+    return mockPlugin({
+      loadData: async () => ({ ...store }),
+      saveData: async (d: unknown) => {
+        store = { ...(d as Record<string, unknown>) };
+      },
+    });
+  }
+
+  /**
+   * Drives `tools/list` straight against an `McpServer` instance with no
+   * HTTP server and no `fetch` — `InMemoryTransport.createLinkedPair()` is
+   * the SDK's own exported test seam for exactly this ("one should be
+   * passed to a Client and one to a Server", `@modelcontextprotocol/server`
+   * `dist/src-CX2iR2pK.mjs`). One end is handed to the server under test;
+   * the other is driven by hand, since this project depends on `server` and
+   * `node` only — no `@modelcontextprotocol/client` package is installed.
+   */
+  async function listToolsDirect(server: McpServer): Promise<string[]> {
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const response = new Promise<{
+      result?: { tools?: Array<{ name: string }> };
+    }>((resolve) => {
+      clientTransport.onmessage = (message) =>
+        resolve(message as { result?: { tools?: Array<{ name: string }> } });
+    });
+    await server.connect(serverTransport);
+    await clientTransport.start();
+    await clientTransport.send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    });
+    const body = await response;
+    return (body.result?.tools ?? []).map((t) => t.name);
+  }
+
+  test("buildMcpServer(tokenA) and buildMcpServer(tokenB) produce tools/list sets matching each token's own policy", async () => {
+    const plugin = makeTwoTokenPlugin();
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin,
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+
+    const serverA = svc.buildMcpServer(TOKEN_A.id);
+    const serverB = svc.buildMcpServer(TOKEN_B.id);
+
+    const namesA = await listToolsDirect(serverA);
+    const namesB = await listToolsDirect(serverB);
+
+    // Both tokens see the meta-tools, but the core token's set is the
+    // narrower one (same CORE_SET / promotion semantics the HTTP-level
+    // "Task 5" tests above already pin) — the point under test here is that
+    // this holds when `buildMcpServer` is called directly, no HTTP involved.
+    expect(namesB.length).toBeLessThan(namesA.length);
+    expect(namesB).toContain("get_active_file");
+    expect(namesB).not.toContain("find_broken_links");
+    expect(namesA).toContain("find_broken_links");
   });
 });
 

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -1,6 +1,11 @@
-import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
 import {
+  NodeStreamableHTTPServerTransport,
+  toNodeHandler,
+} from "@modelcontextprotocol/node";
+import {
+  createMcpHandler,
   McpServer,
+  type AuthInfo,
   type CallToolResult,
   type ListToolsResult,
 } from "@modelcontextprotocol/server";
@@ -20,6 +25,12 @@ import { resolveToolScope } from "$/features/adaptive-tool-loading/resolveToolSc
 import { SessionPromotions } from "$/features/adaptive-tool-loading/sessionPromotions";
 import { composeToolRegistry } from "$/composeToolRegistry";
 import { ERROR_CODES, MAX_REQUEST_BODY_BYTES } from "../constants";
+import {
+  flush as flushEraCounters,
+  record as recordEra,
+  scheduleFlush as scheduleEraFlush,
+} from "./eraCounters";
+import { applyDeferredVersionRung, classifyEra } from "./eraRouter";
 import {
   bodyTargetsSseNotificationTool,
   readBodyWithCap,
@@ -63,8 +74,28 @@ export type McpService = {
     /** Id of the bearer token this request authenticated with. */
     tokenId: string,
   ) => Promise<void>;
-  /** Persist any in-memory tool-call counters (see ToolLoadingManager). */
+  /**
+   * Build the per-request McpServer serving `tokenId`. The single
+   * construction site for both protocol eras: the legacy branch calls it
+   * directly, the modern branch reaches it through the SDK's
+   * McpServerFactory (ADR-0016 §4). Per-token tool surfaces (ADR-0014) and
+   * the tools/list stability invariant (ADR-0015) therefore cannot drift
+   * between eras — there is no second implementation to drift.
+   */
+  buildMcpServer: (tokenId: string) => McpServer;
+  /**
+   * Persist both in-memory counter batches: tool calls (see
+   * ToolLoadingManager) and per-era requests (see eraCounters). One entry
+   * point rather than two so every existing call site — the tests and
+   * `destroyMcpService` — keeps draining everything this service batches.
+   */
   flushPendingCalls: () => Promise<void>;
+  /**
+   * Tear down the modern-era handler: aborts in-flight modern exchanges and
+   * closes their per-request instances. The legacy branch needs no
+   * equivalent — it closes its own server and transport per request.
+   */
+  closeModernHandler: () => Promise<void>;
 };
 
 /**
@@ -108,15 +139,19 @@ export async function createMcpService(
     return resolveToolScope(tokenId, policy, allNames, session.get(tokenId));
   };
 
-  const handleRequest = async (
-    req: IncomingMessage,
-    res: ServerResponse,
-    tokenId: string,
-  ): Promise<void> => {
+  /**
+   * The per-request McpServer, built once per serving unit and shared by
+   * both eras. It closes nothing: the legacy branch tears its instance down
+   * in its own `finally`, and on the modern branch the SDK's serving entry
+   * owns the lifecycle.
+   */
+  const buildMcpServer = (tokenId: string): McpServer => {
     // Resolving a scope costs a settings read, and only tools/* needs
     // one: `initialize`, `prompts/*` and malformed requests must pay
     // nothing. Memoizing the PROMISE (not the value) also collapses the
-    // tools/list + tools/call pair of a batched POST into one read.
+    // tools/list + tools/call pair of a batched POST into one read. The
+    // memo lives as long as the instance, which is one request on either
+    // era, so its lifetime is unchanged by the extraction.
     let scopePromise: Promise<ToolScope> | undefined;
     const getScope = (): Promise<ToolScope> =>
       (scopePromise ??= resolveScope(tokenId));
@@ -190,6 +225,40 @@ export async function createMcpService(
       promptRegistry.dispatch(req.params),
     );
 
+    return server;
+  };
+
+  // The 2026-07-28 leg. Built once per service and wrapped once: the entry
+  // allocates an event bus, so one per request would be waste (ADR-0016 §2).
+  //
+  // `legacy: "reject"` is deliberate and is NOT the same decision as strict
+  // mode on the endpoint. `classifyEra` has already separated the traffic, so
+  // a legacy-classified request arriving here is a routing bug: rejecting it
+  // makes that bug loud instead of silently double-serving 2025 requests
+  // through a second, differently-configured stateless transport. The
+  // endpoint itself stays permissive because the legacy branch sits in front
+  // of this handler.
+  const modernHandler = createMcpHandler(
+    (ctx) => buildMcpServer(ctx.authInfo?.clientId ?? ""),
+    {
+      legacy: "reject",
+      responseMode: "auto",
+      onerror: (error) =>
+        logger.warn("[mcp] modern-era request rejected", {
+          error: error.message,
+        }),
+    },
+  );
+  const modern = toNodeHandler(modernHandler, {
+    onerror: (error) =>
+      logger.error("[mcp] modern-era handler failed", { error: error.message }),
+  });
+
+  const handleRequest = async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    tokenId: string,
+  ): Promise<void> => {
     // Inspect the body before choosing the response mode. The GET SSE
     // stream is blocked (POST-only transport), so a server-initiated
     // notification has nowhere to go — EXCEPT the response stream of the
@@ -222,6 +291,70 @@ export async function createMcpService(
       parsedBody = undefined;
     }
 
+    // Route by protocol era, from that single read (ADR-0016 §1). Routing
+    // lives here rather than in httpServer.ts because this is where the body
+    // is already read: classifying earlier would mean widening RequestHandler
+    // to carry a parsed body, for no behavioural gain.
+    const era = await classifyEra(req, parsedBody);
+
+    // Counted at the point of classification: every request that reaches
+    // here counts for the era it classified as, however it is subsequently
+    // answered — the deferred version rung's 400 below included, since that
+    // request classified legacy. A request short-circuited BEFORE this line
+    // (the 413 over-cap path above, and anything runMiddleware rejected)
+    // counts for neither era.
+    //
+    // The counter answers one question and only one: is anyone still
+    // reaching this server on the legacy era. ADR-0016 §8 makes the
+    // `legacy: 'reject'` trigger depend on that answer, so a request whose
+    // era was never determined has no era to attribute, and inventing one
+    // would corrupt exactly the signal that decision rests on. Counting a
+    // rejected-but-classified request is correct for the same reason: the
+    // client reached us on that era, and that is what the trigger measures.
+    recordEra(era);
+    scheduleEraFlush(config.plugin);
+
+    if (era === "modern") {
+      // The token id reaches the factory as pass-through AuthInfo, read back
+      // as `ctx.authInfo?.clientId`. The bearer SECRET deliberately does not
+      // travel with it: downstream of auth the identity is the token id and
+      // never the string (ADR-0014 §2, ADR-0016 §4), so a future handler that
+      // logged its own context cannot leak a credential. `token` is a
+      // pass-through field the SDK never inspects, left empty for that
+      // reason.
+      (req as IncomingMessage & { auth?: AuthInfo }).auth = {
+        token: "",
+        clientId: tokenId,
+        scopes: [],
+      };
+      // Pass the pre-parsed body: `readBodyWithCap` drained the stream, and
+      // the entry classifies from the value rather than re-reading it.
+      await modern(req, res, parsedBody);
+      return;
+    }
+
+    // Everything below is the legacy branch, and this line is what keeps it
+    // honest. After the `return` above, TypeScript narrows `era` to whatever
+    // is left of the union — today exactly "legacy", so this compiles. Add a
+    // third era and it narrows to `"legacy" | "third"`, this assignment stops
+    // compiling, and whoever added it is forced to decide which transport
+    // serves it. Without this line a new era would silently fall through and
+    // be served by the 2025 transport. The SDK added one era in two releases,
+    // so a third is a when, not an if.
+    const eraIsLegacy: "legacy" = era;
+    void eraIsLegacy;
+
+    // The other half of the split protocol-version rung: a 2026-era header
+    // the middleware deferred, on a request that turned out to be legacy,
+    // has no downstream owner and is answered here (ADR-0016 §3).
+    const deferred = applyDeferredVersionRung(req.headers, parsedBody);
+    if (deferred !== null) {
+      res.writeHead(deferred.status, { "content-type": "application/json" });
+      res.end(JSON.stringify(deferred.body));
+      return;
+    }
+
+    const server = buildMcpServer(tokenId);
     // Stateless mode (no sessionIdGenerator). Per-request transport — see
     // file header for the SDK constraint. JSON response by default; SSE
     // only for SSE_NOTIFICATION_TOOLS so their notification can be delivered.
@@ -256,23 +389,49 @@ export async function createMcpService(
     registry,
     promptRegistry,
     handleRequest,
-    flushPendingCalls: () =>
-      toolLoadingManager.flushPendingCalls(config.plugin),
+    buildMcpServer,
+    flushPendingCalls: async () => {
+      // Both batches drain, independently. Chaining them with bare awaits
+      // meant a rejected first flush skipped the second entirely, which is
+      // the opposite of what this field's own contract promises above: one
+      // entry point so every call site drains EVERYTHING this service
+      // batches. Neither write is more important than the other, and the
+      // transient failure they share a cause with — a contended
+      // `SettingsStore.updateSlice` — is exactly when both need attempting.
+      const results = await Promise.allSettled([
+        toolLoadingManager.flushPendingCalls(config.plugin),
+        flushEraCounters(config.plugin),
+      ]);
+      // Rethrow the first rejection so the caller still learns a flush
+      // failed. `destroyMcpService` logs it; the batches restore themselves
+      // for the next attempt either way.
+      const failed = results.find((r) => r.status === "rejected");
+      if (failed?.status === "rejected") throw failed.reason;
+    },
+    closeModernHandler: () => modernHandler.close(),
   };
 }
 
 /**
- * Service-level teardown. With per-request server+transport creation
- * there is nothing to close at the request level — every request
- * already cleans up after itself in the `finally` block. The one piece
- * of service state is the in-memory tool-call counter batch, flushed
- * here so an unload does not drop it.
+ * Service-level teardown. The legacy branch needs nothing here — every
+ * request already cleans up after itself in its `finally` block. Two pieces
+ * of service state do: the in-memory counter batches (tool calls and per-era
+ * requests), flushed first so an unload does not drop them, and the
+ * modern-era handler, whose in-flight exchanges and their per-request
+ * instances are the SDK's to abort.
  */
 export async function destroyMcpService(svc: McpService): Promise<void> {
   try {
     await svc.flushPendingCalls();
   } catch (error) {
-    logger.warn("[mcp] flushing tool-call counters on teardown failed", {
+    logger.warn("[mcp] flushing pending counters on teardown failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  try {
+    await svc.closeModernHandler();
+  } catch (error) {
+    logger.warn("[mcp] closing the modern-era handler on teardown failed", {
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/middleware.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/middleware.test.ts
@@ -305,6 +305,102 @@ describe("runMiddleware", () => {
   });
 });
 
+describe("runMiddleware — protocol-version era split (OMC-008 Task 1, R-06, R-07)", () => {
+  // checkProtocolVersion splits by era: pre-2026 unsupported values keep
+  // rejecting with 400 exactly as today; 2026-era values (lexicographic
+  // ">= 2026-07-28") are DEFERRED — the SDK's own ladder answers them once
+  // classification exists (Task 2) — so the middleware itself must let them
+  // through as `{ ok: true }` rather than 400ing.
+  const token = "test-token-12345678901234567890abcd";
+  const tokens = [tok(token, "solo")];
+
+  test("2026-07-28 is a genuinely supported version: passes the rung and yields the matched token (R-07)", () => {
+    const result = runMiddleware(
+      {
+        method: "POST",
+        url: "/mcp",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "mcp-protocol-version": "2026-07-28",
+        },
+      },
+      tokens,
+    );
+    expect(result).toEqual({ ok: true, tokenId: "solo" });
+  });
+
+  test("a 2026-era revision this server does not list (2027-05-01) is DEFERRED, not rejected at 400 (R-06)", () => {
+    const result = runMiddleware(
+      {
+        method: "POST",
+        url: "/mcp",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "mcp-protocol-version": "2027-05-01",
+        },
+      },
+      tokens,
+    );
+    // Deferred means the middleware itself never rejects it — the request
+    // proceeds to auth and, with a valid bearer, succeeds. The SDK's own
+    // ladder (wired in later tasks) owns the unsupported-version answer for
+    // a value in this shape; this rung must not preempt it with 400.
+    expect(result).toEqual({ ok: true, tokenId: "solo" });
+  });
+
+  test("pre-2026 unsupported values keep rejecting with 400: 1.0.0", () => {
+    const result = runMiddleware(
+      {
+        method: "POST",
+        url: "/mcp",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "mcp-protocol-version": "1.0.0",
+        },
+      },
+      tokens,
+    );
+    expect(result).toEqual({ ok: false, status: 400 });
+  });
+
+  test("pre-2026 unsupported values keep rejecting with 400: 2023-01-01", () => {
+    const result = runMiddleware(
+      {
+        method: "POST",
+        url: "/mcp",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "mcp-protocol-version": "2023-01-01",
+        },
+      },
+      tokens,
+    );
+    expect(result).toEqual({ ok: false, status: 400 });
+  });
+
+  test("check-order sibling of the end-to-end order test above: a 2026-era bad version no longer wins at 400, so a bad bearer alongside it now falls through to 401", () => {
+    // Mirrors "check order is unchanged end to end: 404 → 405 → 403 → 400 →
+    // 401" (which deliberately stays untouched and keeps pinning 1.0.0, a
+    // PRE-2026 value, at 400). This sibling probes the other half of the
+    // split: method/path valid, no Origin header (allowed), a 2026-era bad
+    // version (now deferred, not 400), and a bad bearer — the version rung
+    // must not be the one that wins any more, so the request falls through
+    // to the auth check and gets 401.
+    const badVersionDeferredBadAuth = {
+      method: "POST",
+      url: "/mcp",
+      headers: {
+        "mcp-protocol-version": "2027-05-01",
+        authorization: "Bearer wrong",
+      },
+    };
+    expect(runMiddleware(badVersionDeferredBadAuth, tokens)).toEqual({
+      ok: false,
+      status: 401,
+    });
+  });
+});
+
 describe("runMiddleware — N-token bearer matching (issue #348, ADR-0014 §2)", () => {
   const tokens: TokenRecord[] = [
     tok("token-at-position-0-aaaaaaaaaaaaaaaaaa", "id-0"),

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/middleware.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/middleware.ts
@@ -1,5 +1,6 @@
 import {
   ERROR_CODES,
+  FIRST_MODERN_PROTOCOL_VERSION,
   JSONRPC_ERROR_CODES,
   MCP_PATH_PREFIX,
   SUPPORTED_PROTOCOL_VERSIONS,
@@ -75,7 +76,17 @@ type CheckResult = { ok: true } | { ok: false; status: 400 | 401 | 403 };
 
 type AuthResult = { ok: true; tokenId: string } | { ok: false; status: 401 };
 
-function getHeader(headers: RequestHeaders, name: string): string | undefined {
+/**
+ * Read a single header value, lowercasing the name and taking the first
+ * occurrence of a multi-valued header. Exported because the deferred half of
+ * the protocol-version rung lives in eraRouter.ts and must read the
+ * `MCP-Protocol-Version` header exactly the way this rung does — a second
+ * copy of the normalization is a place for the two halves to disagree.
+ */
+export function getHeader(
+  headers: RequestHeaders,
+  name: string,
+): string | undefined {
   const v = headers[name.toLowerCase()];
   return Array.isArray(v) ? v[0] : v;
 }
@@ -119,12 +130,51 @@ function checkOrigin(headers: RequestHeaders): CheckResult {
     : { ok: false, status: ERROR_CODES.ORIGIN_FORBIDDEN };
 }
 
-function checkProtocolVersion(headers: RequestHeaders): CheckResult {
+/**
+ * Whether a protocol revision belongs to the modern (2026-07-28+) era.
+ *
+ * Project-owned copy of the SDK's own `isModernProtocolVersion`
+ * (`@modelcontextprotocol/server`, `dist/src-CX2iR2pK.mjs:553`), which is
+ * package-internal and exported from no public entry point. Revision
+ * identifiers are ISO dates, so the SDK orders eras with a lexicographic
+ * `>=` against FIRST_MODERN_PROTOCOL_VERSION and so does this copy. If the
+ * SDK ever changes the era boundary away from that comparison, this copy
+ * goes stale silently (ADR-0016, Consequences).
+ *
+ * Exported for the era router, which needs the same era test this rung uses.
+ */
+export function isModernProtocolVersion(version: string): boolean {
+  return version >= FIRST_MODERN_PROTOCOL_VERSION;
+}
+
+/**
+ * The legacy half of the protocol-version rung (ADR-0016 §3).
+ *
+ * The rung splits by era, and only this half runs inside `runMiddleware`:
+ *
+ * - Header absent → pass. Absent is legal per spec: the server assumes a
+ *   default version. Do not require the header — that would break clients
+ *   that never send it.
+ * - A revision this server serves → pass.
+ * - A PRE-2026 revision it does not serve → 400, from here, in this position
+ *   in the chain (before auth), byte-identically to before OMC-008.
+ * - A 2026-era revision it does not serve → pass, DEFERRED. Only
+ *   classification can tell whether the SDK's validation ladder owns the
+ *   answer, and that answer carries `{ supported, requested }` where this
+ *   server's `buildProtocolVersionErrorBody` carries neither. Rejecting here
+ *   would preempt it.
+ *
+ * The other half is `applyDeferredVersionRung` in eraRouter.ts: it answers a
+ * deferred header that then classifies legacy, so no unsupported-version 400
+ * is lost. Exported alongside `isModernProtocolVersion` so both halves of
+ * the split rung are reachable from the era router's side.
+ */
+export function checkProtocolVersion(headers: RequestHeaders): CheckResult {
   const version = getHeader(headers, "mcp-protocol-version");
-  // Absent is legal per spec: the server assumes a default version. Do not
-  // require the header — that would break clients that never send it.
   if (version === undefined) return { ok: true };
-  return (SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(version)
+  if ((SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(version))
+    return { ok: true };
+  return isModernProtocolVersion(version)
     ? { ok: true }
     : { ok: false, status: ERROR_CODES.PROTOCOL_VERSION_UNSUPPORTED };
 }
@@ -215,8 +265,9 @@ export function buildProtocolVersionErrorBody(
  * Check order — load-bearing for security and observability:
  *   1. Method/path (404 path unknown → 405 method not allowed)
  *   2. Origin (403) — anti-DNS-rebinding, independent of auth
- *   3. MCP-Protocol-Version (400) — absent is legal (assume default);
- *      an unsupported value is rejected
+ *   3. MCP-Protocol-Version (400) — absent is legal (assume default); an
+ *      unsupported PRE-2026 value is rejected here, an unsupported 2026-era
+ *      one is deferred to the era router (see checkProtocolVersion)
  *   4. Bearer token (401) — constant-time compare via compareTokens
  *
  * Returning 405 before 401 intentionally tells unauthenticated

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/modernEra.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/modernEra.test.ts
@@ -1,0 +1,677 @@
+import { describe, expect, test, afterEach, beforeEach } from "bun:test";
+import { mockApp, mockPlugin, resetMockVault } from "$/test-setup";
+import {
+  createMcpService,
+  destroyMcpService,
+  type McpService,
+} from "./mcpServer";
+import { staticTokenProvider } from "./tokenStore";
+import type { RunningServer } from "./httpServer";
+
+/**
+ * TDD RED phase for OMC-008 Task 4 (`docs/architecture/ADR-0016-...md`,
+ * `docs/superpowers/plans/2026-08-08-omc-008-adopt-mcp-spec-2026-07-28.md`).
+ *
+ * `mcpServer.ts`'s modern branch today only `logger.warn`s and falls through
+ * to the legacy transport (Task 2's own acceptance criterion) — the strict
+ * modern handler (`createMcpHandler(factory, { legacy: 'reject' })` wrapped by
+ * `toNodeHandler`) is not wired yet. Every assertion below states the WIRED
+ * behaviour Task 4 must produce, verified against the installed SDK
+ * (`node_modules/@modelcontextprotocol/server@2.0.0`), not summarised from
+ * the plan.
+ *
+ * Measured (not assumed) RED reason for every test below that carries an
+ * `MCP-Protocol-Version: 2026-07-28` (or `2027-05-01`) header: the fallback's
+ * `NodeStreamableHTTPServerTransport` runs its OWN header-vs-supported-list
+ * check against the hand-built `McpServer`'s `_supportedProtocolVersions`
+ * (the SDK's default legacy list, topping at `2025-11-25` —
+ * `installModernOnlyHandlers` is never called on this instance because it is
+ * only invoked inside `createMcpHandler`'s `serveModern`, not on the
+ * fallback). That check fires before dispatch and answers
+ * `{"error":{"code":-32000,"message":"Bad Request: Unsupported protocol
+ * version: ..."}}` at HTTP 400 for EVERY request in this file that names a
+ * 2026-era header — this is the exact `-32000` the task briefing already
+ * named in `eraRouter.test.ts`'s own untouched RED ("still answers 400 with
+ * the -32020 unsupported-version code"), reached here from request bodies
+ * that carry a full `_meta` envelope instead of a claim-less one. It is not
+ * the `-32602`/`-32022` ladder this file asserts, and not the `server/discover`
+ * Method Not Found a bare read of the plan might suggest either — both are
+ * still true statements about what the WIRED handler must answer, and both
+ * are still unmet today, just via this one shared proximate cause rather
+ * than two different ones. Once Task 4 routes a modern-classified request to
+ * the real `createMcpHandler` handler instead of this fallback, none of
+ * these requests reach `NodeStreamableHTTPServerTransport` at all — the
+ * SDK's own body-classification ladder (`server/dist/src-CX2iR2pK.mjs:5101`)
+ * owns the answer instead, which is what every assertion below states.
+ *
+ * Only ONE thing in this file is a true regression pin, already true with no
+ * change: an `initialize` POST carries no `MCP-Protocol-Version` header here,
+ * so it never reaches the check above and answers exactly as it does today
+ * (R-01). Every other test, including both R-09 tests, is genuinely red
+ * today for the shared reason above — the tools/list-set equivalence test is
+ * NOT a coincidental pin here, because a modern-envelope `tools/list` in
+ * this file always carries the header too. The R-09 describe block also
+ * separately asserts the one thing only the real 2026-era encode seam
+ * produces, once Task 4 does land and the header check above no longer
+ * applies: `_meta['io.modelcontextprotocol/serverInfo']` stamped onto the
+ * result (`rev2026Codec.encodeResult` calls `stampServerInfoMeta`;
+ * `rev2025Codec.encodeResult` never does, `server/dist/src-CX2iR2pK.mjs:4115`
+ * vs `:2390`) — that is the assertion that would catch a future regression
+ * where the equivalence holds again by coincidence (e.g. a modern route that
+ * silently re-delegates to the legacy encode path) rather than through the
+ * real per-token `ToolScope` resolution shared by both eras (ADR-0016 §4).
+ */
+
+const TOKEN = "t".repeat(32);
+const MODERN_HEADER = { "mcp-protocol-version": "2026-07-28" } as const;
+
+/**
+ * SEP-2243 makes `Mcp-Method` mandatory on every modern-era request; the
+ * installed SDK's `validateStandardRequestHeaders` (run by `serveModern`
+ * ahead of dispatch) rejects with -32020 when it is absent, naming the
+ * value it read from the header as "(missing)" regardless of what the body
+ * says. `Mcp-Name` is only required for `tools/call`, `prompts/get` and
+ * `resources/read` (`MCP_NAME_HEADER_SOURCE`); none of those methods appear
+ * in this file, so no request here needs it.
+ *
+ * The R-04 cases send a deliberately malformed or absent `_meta` envelope
+ * and must keep failing for that reason alone, so they still build their
+ * headers from the bare `MODERN_HEADER` above rather than this helper.
+ */
+function modernHeaders(method: string): Record<string, string> {
+  return { ...MODERN_HEADER, "mcp-method": method };
+}
+const VALID_ENVELOPE = {
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientCapabilities": {},
+};
+
+beforeEach(() => resetMockVault());
+
+const active: McpService[] = [];
+const runningServers: RunningServer[] = [];
+afterEach(async () => {
+  for (const s of active.splice(0)) await destroyMcpService(s);
+  for (const s of runningServers.splice(0)) {
+    await new Promise<void>((r) => s.server.close(() => r()));
+  }
+});
+
+/** Boot a service + HTTP server behind a single static token, the same
+ * idiom `mcpServer.test.ts` and `eraRouter.test.ts` use. */
+async function startService(): Promise<RunningServer> {
+  const { startHttpServer } = await import("./httpServer");
+  const svc = await createMcpService({
+    app: mockApp(),
+    plugin: mockPlugin(),
+    pluginVersion: "0.4.0-alpha.1",
+    serverName: "mcp-connector",
+  });
+  active.push(svc);
+  const server = await startHttpServer({
+    resolveTokens: staticTokenProvider(TOKEN),
+    requestHandler: svc.handleRequest,
+  });
+  runningServers.push(server);
+  return server;
+}
+
+async function postMcp(
+  port: number,
+  token: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Split an SSE response body into its `data:` JSON payloads, in arrival
+ * order. Every server-sent frame this process can produce — the modern
+ * `PerRequestHTTPServerTransport` (`@modelcontextprotocol/server`'s
+ * `index.mjs`, `writeMessageFrame`) and the legacy
+ * `NodeStreamableHTTPServerTransport` it wraps — writes the same
+ * `event: message\ndata: <json>\n\n` shape, so one parser covers both
+ * eras without pulling in an SSE client for a stream this server writes
+ * itself. Reads the whole body rather than incrementally, which is fine
+ * here: every exchange below closes its stream after the terminal result,
+ * so there is nothing left open to await.
+ */
+async function readSseFrames(res: Response): Promise<unknown[]> {
+  const text = await res.text();
+  return text
+    .split("\n\n")
+    .map((frame) => frame.trim())
+    .filter((frame) => frame.length > 0)
+    .map((frame) => {
+      const dataLine = frame
+        .split("\n")
+        .find((line) => line.startsWith("data:"));
+      if (dataLine === undefined) {
+        throw new Error(`SSE frame carried no data line: ${frame}`);
+      }
+      return JSON.parse(dataLine.slice("data:".length).trim());
+    });
+}
+
+describe("modern path — server/discover (R-02, R-03)", () => {
+  test("a valid envelope reaches server/discover: supportedVersions, capabilities including tools and prompts, and this server's identity under _meta", async () => {
+    const server = await startService();
+    const res = await postMcp(
+      server.port,
+      TOKEN,
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "server/discover",
+        params: { _meta: VALID_ENVELOPE },
+      },
+      modernHeaders("server/discover"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result?.supportedVersions).toEqual(["2026-07-28"]);
+    // `mcpServer.ts:163` declares `prompts: {}`, but `McpServer`'s
+    // constructor upgrades any declared `prompts` capability to
+    // `{ listChanged: true }` before advertising it (it calls
+    // `setPromptRequestHandlers()`, which calls `registerCapabilities`
+    // with that default) — the discovered set reflects the upgrade, not
+    // the bare declaration. This isn't new to the 2026 era: the legacy
+    // `initialize` reply already reports `prompts: { listChanged: true }`
+    // for the same reason (see `eraRouter.test.ts`'s pinned assertion).
+    // The server does not currently emit
+    // `notifications/prompts/list_changed`, so this advertised capability
+    // isn't honoured yet; that's a pre-existing gap tracked as a
+    // follow-up, not something this test fixes. This assertion pins what
+    // the server actually answers, not what it ought to.
+    expect(body.result?.capabilities).toEqual({
+      tools: { listChanged: true },
+      prompts: { listChanged: true },
+    });
+    expect(body.result?._meta?.["io.modelcontextprotocol/serverInfo"]).toEqual({
+      name: "mcp-connector",
+      version: "0.4.0-alpha.1",
+    });
+  });
+
+  test("every capability server/discover advertises is honoured: tools/list and prompts/list both answer over the modern path", async () => {
+    const server = await startService();
+
+    const toolsRes = await postMcp(
+      server.port,
+      TOKEN,
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: { _meta: VALID_ENVELOPE },
+      },
+      modernHeaders("tools/list"),
+    );
+    expect(toolsRes.status).toBe(200);
+    const toolsBody = await toolsRes.json();
+    expect(toolsBody.error).toBeUndefined();
+    expect(Array.isArray(toolsBody.result?.tools)).toBe(true);
+
+    const promptsRes = await postMcp(
+      server.port,
+      TOKEN,
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "prompts/list",
+        params: { _meta: VALID_ENVELOPE },
+      },
+      modernHeaders("prompts/list"),
+    );
+    expect(promptsRes.status).toBe(200);
+    const promptsBody = await promptsRes.json();
+    expect(promptsBody.error).toBeUndefined();
+    expect(Array.isArray(promptsBody.result?.prompts)).toBe(true);
+  });
+});
+
+describe("modern path — a missing or incomplete _meta envelope is rejected (R-04)", () => {
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ["_meta absent entirely", {}],
+    [
+      "_meta present but missing protocolVersion",
+      {
+        _meta: {
+          "io.modelcontextprotocol/clientCapabilities": {},
+        },
+      },
+    ],
+    [
+      "_meta present but missing clientCapabilities",
+      {
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        },
+      },
+    ],
+  ];
+
+  for (const [label, params] of cases) {
+    test(`${label} ⇒ -32602 and HTTP 400`, async () => {
+      const server = await startService();
+      const res = await postMcp(
+        server.port,
+        TOKEN,
+        { jsonrpc: "2.0", id: 1, method: "tools/list", params },
+        MODERN_HEADER,
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.jsonrpc).toBe("2.0");
+      expect(body.error?.code).toBe(-32602);
+    });
+  }
+});
+
+describe("modern path — _meta without clientInfo is served normally; clientInfo is never required (R-05)", () => {
+  test("a valid envelope missing clientInfo still answers tools/list", async () => {
+    const server = await startService();
+    const res = await postMcp(
+      server.port,
+      TOKEN,
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: { _meta: VALID_ENVELOPE },
+      },
+      modernHeaders("tools/list"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error).toBeUndefined();
+    expect(Array.isArray(body.result?.tools)).toBe(true);
+  });
+});
+
+describe("modern path — an unsupported 2026-era revision answers the SDK's own error (R-06, modern-branch verification)", () => {
+  test("MCP-Protocol-Version: 2027-05-01 with a valid, matching envelope ⇒ unsupported-version error naming this server's supported versions", async () => {
+    const server = await startService();
+    const res = await postMcp(
+      server.port,
+      TOKEN,
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2027-05-01",
+            "io.modelcontextprotocol/clientCapabilities": {},
+          },
+        },
+      },
+      { "mcp-protocol-version": "2027-05-01", "mcp-method": "tools/list" },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error?.data?.supported ?? []).toContain("2026-07-28");
+    expect(body.error?.data?.requested).toBe("2027-05-01");
+  });
+});
+
+describe("the legacy handshake is untouched by the modern path (R-01)", () => {
+  test("an initialize POST still reaches the legacy path and answers 2025-11-25", async () => {
+    const server = await startService();
+    const res = await postMcp(server.port, TOKEN, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "0.0.0" },
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result?.protocolVersion).toBe("2025-11-25");
+  });
+});
+
+describe("modern path — per-token tool surfaces match the legacy path (R-09)", () => {
+  const TOKEN_ALL = {
+    id: "tok-all",
+    label: "All",
+    token: "a".repeat(32),
+    createdAt: 1,
+  };
+  const TOKEN_CORE = {
+    id: "tok-core",
+    label: "Core",
+    token: "c".repeat(32),
+    createdAt: 2,
+  };
+
+  function makeScopedPlugin() {
+    let store: Record<string, unknown> = {
+      mcpTransport: {
+        bearerToken: TOKEN_ALL.token,
+        tokens: [TOKEN_ALL, TOKEN_CORE],
+      },
+      toolLoading: {
+        profile: "all",
+        promoted: [],
+        counters: {},
+        profiles: {
+          [TOKEN_ALL.id]: { profile: "all", promoted: [], allowed: null },
+          [TOKEN_CORE.id]: { profile: "core", promoted: [], allowed: null },
+        },
+      },
+    };
+    return mockPlugin({
+      loadData: async () => ({ ...store }),
+      saveData: async (d: unknown) => {
+        store = { ...(d as Record<string, unknown>) };
+      },
+    });
+  }
+
+  async function bootScopedServer(): Promise<RunningServer> {
+    const { startHttpServer } = await import("./httpServer");
+    const plugin = makeScopedPlugin();
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin,
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+    const server = await startHttpServer({
+      resolveTokens: async () => [TOKEN_ALL, TOKEN_CORE],
+      requestHandler: svc.handleRequest,
+    });
+    runningServers.push(server);
+    return server;
+  }
+
+  test("token A's tools/list set is identical across both eras, and token core's is narrower", async () => {
+    const server = await bootScopedServer();
+
+    const namesOf = async (
+      token: string,
+      params: Record<string, unknown>,
+      headers: Record<string, string> = {},
+    ): Promise<string[]> => {
+      const res = await postMcp(
+        server.port,
+        token,
+        { jsonrpc: "2.0", id: 1, method: "tools/list", params },
+        headers,
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      return ((body?.result?.tools ?? []) as Array<{ name: string }>).map(
+        (t) => t.name,
+      );
+    };
+
+    const legacyA = await namesOf(TOKEN_ALL.token, {});
+    const modernA = await namesOf(
+      TOKEN_ALL.token,
+      { _meta: VALID_ENVELOPE },
+      modernHeaders("tools/list"),
+    );
+    const modernCore = await namesOf(
+      TOKEN_CORE.token,
+      { _meta: VALID_ENVELOPE },
+      modernHeaders("tools/list"),
+    );
+
+    expect([...modernA].sort()).toEqual([...legacyA].sort());
+    expect(modernCore).not.toEqual(modernA);
+    expect(modernCore).toContain("get_active_file");
+    expect(modernCore).not.toContain("find_broken_links");
+  });
+
+  test("the modern-path tools/list result carries this server's identity in _meta, proving it went through the real 2026 encode seam and not the legacy fallback", async () => {
+    const server = await bootScopedServer();
+    const res = await postMcp(
+      server.port,
+      TOKEN_ALL.token,
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: { _meta: VALID_ENVELOPE },
+      },
+      modernHeaders("tools/list"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result?._meta?.["io.modelcontextprotocol/serverInfo"]).toEqual({
+      name: "mcp-connector",
+      version: "0.4.0-alpha.1",
+    });
+  });
+});
+
+describe("activate_tool's notifications/tools/list_changed rides the calling request's own stream on both eras (R-10)", () => {
+  // A token scoped to the "core" profile, the same shape as R-09's
+  // TOKEN_CORE, so `find_broken_links` starts inactive for it and
+  // activating it is a real state change — not the "already active"
+  // early return, which never calls sendNotification.
+  const CORE_TOKEN = {
+    id: "tok-core-r10",
+    label: "Core",
+    token: "d".repeat(32),
+    createdAt: 3,
+  };
+
+  function makeCoreScopedPlugin() {
+    let store: Record<string, unknown> = {
+      mcpTransport: {
+        bearerToken: CORE_TOKEN.token,
+        tokens: [CORE_TOKEN],
+      },
+      toolLoading: {
+        profile: "all",
+        promoted: [],
+        counters: {},
+        profiles: {
+          [CORE_TOKEN.id]: { profile: "core", promoted: [], allowed: null },
+        },
+      },
+    };
+    return mockPlugin({
+      loadData: async () => ({ ...store }),
+      saveData: async (d: unknown) => {
+        store = { ...(d as Record<string, unknown>) };
+      },
+    });
+  }
+
+  async function bootCoreServer(): Promise<RunningServer> {
+    const { startHttpServer } = await import("./httpServer");
+    const plugin = makeCoreScopedPlugin();
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin,
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+    const server = await startHttpServer({
+      resolveTokens: async () => [CORE_TOKEN],
+      requestHandler: svc.handleRequest,
+    });
+    runningServers.push(server);
+    return server;
+  }
+
+  test("modern path: the response upgrades to text/event-stream and the notification frame precedes the terminal result", async () => {
+    const server = await bootCoreServer();
+    const res = await postMcp(
+      server.port,
+      CORE_TOKEN.token,
+      {
+        jsonrpc: "2.0",
+        id: 7,
+        method: "tools/call",
+        params: {
+          name: "activate_tool",
+          arguments: { name: "find_broken_links" },
+          _meta: VALID_ENVELOPE,
+        },
+      },
+      { ...modernHeaders("tools/call"), "mcp-name": "activate_tool" },
+    );
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const frames = (await readSseFrames(res)) as Array<{
+      method?: string;
+      id?: number;
+      result?: { _meta?: Record<string, unknown> };
+    }>;
+    const notificationIndex = frames.findIndex(
+      (f) => f.method === "notifications/tools/list_changed",
+    );
+    const resultIndex = frames.findIndex(
+      (f) => f.id === 7 && f.result !== undefined,
+    );
+    expect(notificationIndex).toBeGreaterThanOrEqual(0);
+    expect(resultIndex).toBeGreaterThan(notificationIndex);
+    // Rules out the reading where this "upgraded to SSE" is actually the
+    // LEGACY transport's own SSE path (bodyTargetsSseNotificationTool
+    // also flags activate_tool) misclassified as modern: only the 2026
+    // encode seam stamps serverInfo onto a result's _meta (R-09's own
+    // discriminator, reused here for tools/call).
+    expect(
+      frames[resultIndex]?.result?._meta?.[
+        "io.modelcontextprotocol/serverInfo"
+      ],
+    ).toEqual({ name: "mcp-connector", version: "0.4.0-alpha.1" });
+  });
+
+  test("legacy path (regression pin): the same activation still answers over SSE with the notification ahead of the result", async () => {
+    const server = await bootCoreServer();
+    const res = await postMcp(server.port, CORE_TOKEN.token, {
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/call",
+      params: {
+        name: "activate_tool",
+        arguments: { name: "find_broken_links" },
+      },
+    });
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const frames = (await readSseFrames(res)) as Array<{
+      method?: string;
+      id?: number;
+      result?: { _meta?: Record<string, unknown> };
+    }>;
+    const notificationIndex = frames.findIndex(
+      (f) => f.method === "notifications/tools/list_changed",
+    );
+    const resultIndex = frames.findIndex(
+      (f) => f.id === 8 && f.result !== undefined,
+    );
+    expect(notificationIndex).toBeGreaterThanOrEqual(0);
+    expect(resultIndex).toBeGreaterThan(notificationIndex);
+    // The mirror image of the modern test's discriminator above: the
+    // handshake-era codec never stamps serverInfo onto a result, so its
+    // absence here confirms this pin is genuinely exercising the legacy
+    // encode path rather than coincidentally matching the modern one.
+    expect(
+      frames[resultIndex]?.result?._meta?.[
+        "io.modelcontextprotocol/serverInfo"
+      ],
+    ).toBeUndefined();
+  });
+});
+
+describe("search_vault_smart's notifications/progress rides the modern path's own stream while the index builds (R-11)", () => {
+  // Mirrors searchVaultSmart.test.ts's own `buildingPlugin()` fixture
+  // (#344): `nativeIndexBuildInProgress: true` is the sole gate the
+  // handler checks before it computes a progress percentage and pushes
+  // it, independent of provider.isReady().
+  function buildingSemanticPlugin() {
+    return mockPlugin({
+      semanticSearchState: {
+        provider: { isReady: () => true, search: async () => [] },
+        settings: { provider: "native", indexingMode: "live" },
+        startIndexerIfNeeded: () => {},
+        nativeIndexBuildInProgress: true,
+        nativeIndexBuildStartedAt: Date.now() - 1_000,
+      },
+    } as never);
+  }
+
+  async function bootBuildingServer(): Promise<RunningServer> {
+    const { startHttpServer } = await import("./httpServer");
+    const plugin = buildingSemanticPlugin();
+    const svc = await createMcpService({
+      app: mockApp(),
+      plugin,
+      pluginVersion: "0.4.0-alpha.1",
+      serverName: "mcp-connector",
+    });
+    active.push(svc);
+    const server = await startHttpServer({
+      resolveTokens: staticTokenProvider(TOKEN),
+      requestHandler: svc.handleRequest,
+    });
+    runningServers.push(server);
+    return server;
+  }
+
+  test("at least one notifications/progress frame carrying the caller's progressToken arrives before the terminal (error) result", async () => {
+    const server = await bootBuildingServer();
+    const res = await postMcp(
+      server.port,
+      TOKEN,
+      {
+        jsonrpc: "2.0",
+        id: 9,
+        method: "tools/call",
+        params: {
+          name: "search_vault_smart",
+          arguments: { query: "test" },
+          _meta: { ...VALID_ENVELOPE, progressToken: "tok-r11" },
+        },
+      },
+      { ...modernHeaders("tools/call"), "mcp-name": "search_vault_smart" },
+    );
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const frames = (await readSseFrames(res)) as Array<{
+      method?: string;
+      id?: number;
+      result?: { _meta?: Record<string, unknown> };
+      params?: { progressToken?: string };
+    }>;
+    const progressFrames = frames.filter(
+      (f) => f.method === "notifications/progress",
+    );
+    const resultIndex = frames.findIndex(
+      (f) => f.id === 9 && f.result !== undefined,
+    );
+    expect(progressFrames.length).toBeGreaterThanOrEqual(1);
+    expect(progressFrames[0]?.params?.progressToken).toBe("tok-r11");
+    const firstProgressIndex = frames.indexOf(progressFrames[0]!);
+    expect(resultIndex).toBeGreaterThan(firstProgressIndex);
+    // Same discriminator as R-10: only the modern encode seam stamps
+    // serverInfo onto a result, so its presence here proves this ran
+    // through the real 2026 codec rather than the legacy SSE path
+    // (search_vault_smart is also in SSE_NOTIFICATION_TOOLS, so a
+    // routing bug here would silently "pass" over legacy transport too).
+    expect(
+      frames[resultIndex]?.result?._meta?.[
+        "io.modelcontextprotocol/serverInfo"
+      ],
+    ).toEqual({ name: "mcp-connector", version: "0.4.0-alpha.1" });
+  });
+});


### PR DESCRIPTION
## Pull Request Description

Serves MCP `2026-07-28` (SEP-2575 stateless lifecycle) as an **additive second era** on the same
`POST /mcp` endpoint, alongside the existing `2025-*` `initialize` handshake. No configured client
has to change anything: a request that carries no `_meta` protocol claim is routed to the legacy
transport byte-identically to before.

Decision record: `docs/architecture/ADR-0016-omc-008-adopt-mcp-spec-2026-07-28.md`.
Spec: `docs/specs/omc-008-adopt-mcp-spec-2026-07-28.spec.md`.

**How it works**

- The middleware chain runs once and `readBodyWithCap` reads the body once; `classifyEra`
  (`mcp-transport/services/eraRouter.ts`) routes from that single read. An `_meta` envelope claim
  ⇒ the strict modern handler (`createMcpHandler(factory, { legacy: 'reject' })`); no claim ⇒ the
  legacy stateless transport. A body that fails `JSON.parse` short-circuits to legacy without a
  `Request` being constructed — the stream is already drained.
- `2026-07-28` is **not** reachable through `initialize`. It is reached by probing `server/discover`,
  which the SDK's serving entry installs; a client that finds no such handler falls back to the
  handshake on its own. `LATEST_PROTOCOL_VERSION` (`2025-11-25` in the SDK) is the handshake offer
  and by construction can never name the modern revision.
- The protocol-version rung splits by era, across two sites. `checkProtocolVersion` still rejects a
  **pre-2026** unsupported revision at 400, in the chain, before auth. A **2026-era** revision is
  deferred past the chain and answered by `applyDeferredVersionRung` only if the request then
  classifies legacy — otherwise the SDK's ladder owns the answer, and its answer carries `supported`
  and `requested`.
- `buildMcpServer(tokenId)` stays the single construction site for both eras, so per-token tool
  surfaces (ADR-0014) cannot drift between them. The modern branch reaches it through the SDK's
  `McpServerFactory`, which receives the token id as pass-through `AuthInfo.clientId` and never the
  bearer secret.
- Per-era request counters (`services/eraCounters.ts`, batched + debounced into `mcpTransport`)
  back a read-only row in the transport settings pane, so "which era is this vault actually being
  spoken to in" is answerable instead of guessed. Counting happens at the point of classification,
  for whatever era classified, however the request is later answered; anything short-circuited
  before classification (413 over-cap, `runMiddleware` rejections) counts as neither.

**A prediction in the ADR was falsified, and the ADR now records that rather than hiding it.**
§8 predicted the five removed-method conformance checks would stay red "by choice" until
`legacy: 'reject'` is adopted at the endpoint. Measured, **all five pass**: the suite only ever
probes the modern era, where the SDK's 2026 wire registry answers `404`/`-32601` for `initialize`,
`ping`, `logging/setLevel`, `resources/subscribe` and `resources/unsubscribe`, while claim-less
clients keep being served by the legacy transport. Strict mode on the endpoint now buys nothing on
the suite — it is a product decision only, still with its original trigger (legacy-era counter at
zero for two minor releases or 60 days, whichever is longer).

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Internal/tooling change

## Testing
**How has this been tested?**
- [x] Local Obsidian vault testing
- [x] MCP server functionality verified
- [ ] Claude Desktop integration tested
- [ ] Cross-platform testing (if applicable)

Unit suite **1761 pass / 0 fail**. `check` clean, `format:check` clean, `check:svelte` 1387 files /
0 errors, `test:mcpb` 4/4 with the shipped shim byte-identical to `scripts/connectorShim.js`.

Conformance `server-stateless` went **7/27 → 26/28**, exit 0, against a four-entry hand-maintained
baseline (`scripts/conformance/expected-failures.yml`): two `test_missing_capability` checks,
unreachable while the SDK's `REQUIRED_CLIENT_CAPABILITIES_BY_METHOD` is `{}`, and two
list-changed-on-subscription checks whose missing piece is fan-out onto an already-open stream —
that is OMC-007, which this work unblocks and defers. The baseline is never regenerated from a
failing run.

End-to-end in a real vault, both eras in one session: modern `tools/list` → 200 with 16 tools and
the `serverInfo` `_meta` stamp; `server/discover` → `supportedVersions: ["2026-07-28"]`; legacy
`initialize` → `2025-06-18`; counters read back `legacy 22 · modern 2`, persisted through
`updateSlice`.

**Not yet done, deliberately:** the already-distributed `.mcpb` and the configured Claude Desktop
client have not been re-smoke-tested against this build. Nothing here changes the shim or the
credential contract, but that check belongs before release rather than in CI.

## Architecture Compliance
- [x] Follows feature-based architecture patterns (see `/docs/project-architecture.md`)
- [ ] Uses ArkType for runtime validation where applicable
- [x] Implements proper error handling
- [ ] Includes setup function for new features
- [x] Follows coding standards in `.clinerules`

ArkType and a `setup` function are both not applicable here: this is transport plumbing inside an
existing feature slice, with no new feature root and no new user-supplied payload shape of its own —
body validation is the SDK's, and `readEraCounters` narrows a persisted value defensively so a
half-written slice degrades instead of throwing.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

New tests: `eraRouter.test.ts`, `modernEra.test.ts`, `eraCounters.test.ts`,
`conformanceHarness.test.ts`. Requirement-ID coverage 17/17; the anti-test-weakening scan reports
CLEAN, with the standing caveat that an assertion edited **in place** is invisible to that
detector, so CLEAN is a signal and not a proof.

## Security Considerations
- [x] No hardcoded secrets or API keys
- [x] Input validation implemented where needed
- [x] No new security vulnerabilities introduced
- [x] Follows minimum permission principles

The modern branch never sees the bearer secret: the SDK's factory receives only the token id, as
pass-through `AuthInfo.clientId`. Auth ordering is unchanged — the deferred version rung exists
precisely so that moving the whole rung below classification could not turn a 400 into a 401 for an
unauthenticated bad-version request.

## Additional Context

- CI note: `.github/workflows/conformance.yml` is the repo's first scheduled workflow, so it
  **will not run until it is on the default branch** — the first nightly is after merge. It is
  `schedule` + `workflow_dispatch` only, never `push`/`pull_request`: the suite has to be cloned and
  built from source at a pinned ref, which is Actions spend. `bun run test:conformance` before
  merging a transport change is a discipline, not an enforcement.
- Follow-ups filed in `TODO.md`: **OMC-024** (P2, per-token era counters, so the settings row can
  say which client speaks which protocol instead of one global pair) and **OMC-023** (P3,
  unhonoured `prompts.listChanged`).
- The "Blocked / Decisions Needed" entry in `TODO.md` was rewritten: its central premise — that
  adopting the revision breaks every configured client and so cannot be half-done — is exactly what
  this PR falsifies.

## For Maintainers
**Review checklist:**
- [ ] Code quality and architecture compliance
- [ ] Security review completed
- [ ] Tests adequate and passing
- [ ] Documentation updated as needed
- [ ] Ready for release
