### PR TITLE
feat(mcp-transport): honour prompts.listChanged on modern, retract on legacy

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- project-tasks: prefix=OMC lastId=26 -->
 # PROJECT TASKS
 
-Updated: 2026-08-15 · Open: 4 (P1: 0) · In progress: 0 · Gate A: 3/4 · Gate B: 1/2
+Updated: 2026-08-15 · Open: 4 (P1: 0) · In progress: 0 · Gate A: 3/4 · Gate B: 2/2 (B2 unverified end-to-end)
 
 ## Roadmap — 2.0
 
@@ -71,14 +71,23 @@ Gate C is by far the longest piece.
       explicit `false` survives, `:164` gates delivery on that same bit, and
       `notify.promptsChanged()` exists as the exact twin of the `toolsChanged()` OMC-007 wired
       at `mcpServer.ts:137`
-- [ ] `B2` Implement ADR-0017 and pin the resulting legacy reply with a test, so whoever reads
-      OMC-008's Invariant 1 next sees what superseded it. Shape: the prompts capability becomes
-      a parameter of `buildMcpServer` instead of the literal at `mcpServer.ts:188`, an
-      `onPromptsChanged` callback fires where the watcher invalidates `epoch`, and one line
-      mirrors `mcpServer.ts:137`. **Emit only when the discovered list actually differs from
-      the cached one** — the watcher fires on every save, including saves that change neither
-      the description nor the argument declarations, and per-tick emission would notify on
-      every keystroke-debounced write inside a prompt
+- [x] `B2` Implement ADR-0017. **Done 2026-08-15, code and unit tests. NOT yet observed
+      end-to-end.** `buildMcpServer` takes `promptsListChanged` (default `false`, the legacy
+      shape) and the two call sites are the era discriminant; `McpService.notifyPromptsChanged`
+      wraps `modernHandler.notify.promptsChanged()`; the prompts feature schedules a debounced
+      re-scan on any watcher event and publishes only when the canonicalised list differs.
+      `eraRouter.test.ts`'s full-body `initialize` pin now reads `prompts: { listChanged: false }`
+      — that assertion IS the record of what OMC-008's Invariant 1 forbade and 2.0 allowed.
+      Conformance re-run: 26/28 unchanged, baseline still four entries.
+      **Two things the mutation checks taught, both kept in comments:** counting notifications
+      does not pin the debounce, because the list comparison already collapses a burst on its own
+      (deleting the timer reset left a notification-counting assertion green) — the re-scan is the
+      cost the debounce avoids, so the test counts `getMarkdownFiles` calls instead; and
+      `resetMockVault()` clears the registered vault-event handlers, so a test that resets the
+      mock mid-run unhooks the watcher it is exercising. **Remaining**: no unit test can see the
+      notification reach a client, and no shipping client opens a `subscriptions/listen` stream —
+      a hand-built listen client against a real vault is the only way, in the shape of A1's
+      script. Do not claim B2 verified until that runs <!-- src:session opened:2026-08-15 -->
 
 ### Gate C — OMC-016 / #427, the feature that carries the number
 

--- a/packages/obsidian-plugin/scripts/conformance/expected-failures.yml
+++ b/packages/obsidian-plugin/scripts/conformance/expected-failures.yml
@@ -54,5 +54,11 @@ server:
 
   # Needs a shipped `test_trigger_tool_change` to mutate the list; the fan-out itself exists.
   - server-stateless:sep-2575-server-sends-tools-list-changed-on-subscription
-  # Same, via `test_trigger_prompt_change` — and nothing here mutates prompts either (OMC-023).
+  # Same, via `test_trigger_prompt_change`. The prompts half of that
+  # parenthetical used to read "and nothing here mutates prompts either
+  # (OMC-023)" — that stopped being true in 2.0. ADR-0017 wired
+  # `notifications/prompts/list_changed`, and the modern era declares and
+  # honours `prompts.listChanged`. The check stays red for the FIRST reason
+  # alone: the suite drives its own fixture tool to mutate the list inside
+  # the check's window, and we refuse to ship one.
   - server-stateless:sep-2575-server-sends-prompts-list-changed-on-subscription

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/eraRouter.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/eraRouter.test.ts
@@ -77,6 +77,16 @@ describe("eraRouter (Task 2) — the legacy path stays byte-identical (R-01)", (
       // `params._meta` envelope claim must classify legacy and answer
       // with exactly these bytes, both before eraRouter exists and after
       // it is wired into mcpServer.ts.
+      //
+      // `prompts.listChanged` READ `true` HERE UNTIL 2.0, and this is the
+      // record of what moved it. OMC-008's Invariant 1 forbade touching
+      // these bytes, so the unhonoured claim survived that work on purpose
+      // (OMC-023). ADR-0017 is the decision that retired it: this era has
+      // no server-initiated stream, so a vault event has no way to reach a
+      // client, so advertising the capability was a promise the transport
+      // could not keep. The modern era declares `true` and honours it —
+      // see the `server/discover` assertion in modernEra.test.ts, which is
+      // deliberately the opposite value and pins the other half.
       expect(body).toEqual({
         jsonrpc: "2.0",
         id: 1,
@@ -84,7 +94,7 @@ describe("eraRouter (Task 2) — the legacy path stays byte-identical (R-01)", (
           protocolVersion: "2025-06-18",
           capabilities: {
             tools: { listChanged: true },
-            prompts: { listChanged: true },
+            prompts: { listChanged: false },
           },
           serverInfo: { name: "mcp-connector", version: "0.4.0-alpha.1" },
         },

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/mcpServer.ts
@@ -81,8 +81,26 @@ export type McpService = {
    * McpServerFactory (ADR-0016 §4). Per-token tool surfaces (ADR-0014) and
    * the tools/list stability invariant (ADR-0015) therefore cannot drift
    * between eras — there is no second implementation to drift.
+   *
+   * `promptsListChanged` is the ONE thing that legitimately differs by era
+   * (ADR-0017): only the modern era can deliver
+   * `notifications/prompts/list_changed`, so only it may advertise it.
+   * Defaults to the legacy shape, so a call site that says nothing gets the
+   * era that cannot notify rather than re-claiming the capability.
    */
-  buildMcpServer: (tokenId: string) => McpServer;
+  buildMcpServer: (tokenId: string, promptsListChanged?: boolean) => McpServer;
+  /**
+   * Publish `notifications/prompts/list_changed` onto every open
+   * `subscriptions/listen` stream that opted in (ADR-0017). The prompts
+   * feature owns WHEN — it watches the vault and compares the discovered
+   * list — and this owns HOW.
+   *
+   * Safe to call with no subscribers: the SDK's notifier publishes to open
+   * subscriptions and there is nothing to deliver to when there are none.
+   * Legacy-era clients never see one, by construction: nothing on that wire
+   * can carry a notification outside a request.
+   */
+  notifyPromptsChanged: () => void;
   /**
    * Persist both in-memory counter batches: tool calls (see
    * ToolLoadingManager) and per-era requests (see eraCounters). One entry
@@ -160,7 +178,10 @@ export async function createMcpService(
    * in its own `finally`, and on the modern branch the SDK's serving entry
    * owns the lifecycle.
    */
-  const buildMcpServer = (tokenId: string): McpServer => {
+  const buildMcpServer = (
+    tokenId: string,
+    promptsListChanged = false,
+  ): McpServer => {
     // Resolving a scope costs a settings read, and only tools/* needs
     // one: `initialize`, `prompts/*` and malformed requests must pay
     // nothing. Memoizing the PROMISE (not the value) also collapses the
@@ -185,7 +206,15 @@ export async function createMcpService(
           // listChanged: true signals support for notifications/tools/list_changed
           // (MCP spec 2025-06-18), emitted by activate_tool.
           tools: { listChanged: true },
-          prompts: {},
+          // Declared EXPLICITLY, both ways round, because the SDK does not
+          // leave a bare `{}` alone: `setPromptRequestHandlers()` rewrites
+          // it to `{ listChanged: … ?? true }` (mcp-DXXb3Vv3.mjs:1550), so
+          // the old `prompts: {}` advertised a capability nothing honoured.
+          // An explicit `false` survives that `??` and is how the legacy era
+          // stops claiming it (ADR-0017). Declaring the capability at all is
+          // what registers the prompts/* handlers, so `false` costs nothing
+          // but the claim.
+          prompts: { listChanged: promptsListChanged },
         },
       },
     );
@@ -254,7 +283,10 @@ export async function createMcpService(
   // endpoint itself stays permissive because the legacy branch sits in front
   // of this handler.
   const modernHandler = createMcpHandler(
-    (ctx) => buildMcpServer(ctx.authInfo?.clientId ?? ""),
+    // `true` is the era discriminant for prompts.listChanged (ADR-0017):
+    // this leg is the one with a `subscriptions/listen` stream to publish
+    // onto, so it is the one allowed to advertise the capability.
+    (ctx) => buildMcpServer(ctx.authInfo?.clientId ?? "", true),
     {
       legacy: "reject",
       responseMode: "auto",
@@ -373,6 +405,10 @@ export async function createMcpService(
       return;
     }
 
+    // No second argument: this leg advertises `prompts.listChanged: false`
+    // (ADR-0017). It is not a lesser implementation — the era has no
+    // server-initiated stream at all, so there is nowhere to deliver a
+    // notification a vault event produces.
     const server = buildMcpServer(tokenId);
     // Stateless mode (no sessionIdGenerator). Per-request transport — see
     // file header for the SDK constraint. JSON response by default; SSE
@@ -409,6 +445,7 @@ export async function createMcpService(
     promptRegistry,
     handleRequest,
     buildMcpServer,
+    notifyPromptsChanged: () => modernHandler.notify.promptsChanged(),
     flushPendingCalls: async () => {
       // Both batches drain, independently. Chaining them with bare awaits
       // meant a rejected first flush skipped the second entirely, which is

--- a/packages/obsidian-plugin/src/features/mcp-transport/services/modernEra.test.ts
+++ b/packages/obsidian-plugin/src/features/mcp-transport/services/modernEra.test.ts
@@ -200,19 +200,19 @@ describe("modern path — server/discover (R-02, R-03)", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.result?.supportedVersions).toEqual(["2026-07-28"]);
-    // `mcpServer.ts:163` declares `prompts: {}`, but `McpServer`'s
-    // constructor upgrades any declared `prompts` capability to
-    // `{ listChanged: true }` before advertising it (it calls
-    // `setPromptRequestHandlers()`, which calls `registerCapabilities`
-    // with that default) — the discovered set reflects the upgrade, not
-    // the bare declaration. This isn't new to the 2026 era: the legacy
-    // `initialize` reply already reports `prompts: { listChanged: true }`
-    // for the same reason (see `eraRouter.test.ts`'s pinned assertion).
-    // The server does not currently emit
-    // `notifications/prompts/list_changed`, so this advertised capability
-    // isn't honoured yet; that's a pre-existing gap tracked as a
-    // follow-up, not something this test fixes. This assertion pins what
-    // the server actually answers, not what it ought to.
+    // `prompts.listChanged` is `true` here because this era CAN deliver
+    // the notification and does: the prompts feature compares the
+    // discovered list after a vault event and calls
+    // `notifyPromptsChanged()`, which publishes onto every open
+    // `subscriptions/listen` stream (ADR-0017).
+    //
+    // The value is now deliberate rather than inherited. It used to be the
+    // SDK's doing — `setPromptRequestHandlers()` rewrites a declared
+    // `prompts` capability to `{ listChanged: … ?? true }`
+    // (mcp-DXXb3Vv3.mjs:1550), so the old bare `prompts: {}` advertised a
+    // capability nothing honoured, on both eras. `mcpServer.ts` now passes
+    // the bit explicitly, and the legacy half is pinned to the opposite
+    // value in `eraRouter.test.ts` — that pair is the whole decision.
     expect(body.result?.capabilities).toEqual({
       tools: { listChanged: true },
       prompts: { listChanged: true },

--- a/packages/obsidian-plugin/src/features/prompts/index.test.ts
+++ b/packages/obsidian-plugin/src/features/prompts/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach } from "bun:test";
+import { describe, expect, test, beforeEach, spyOn } from "bun:test";
 import {
   fireMockVaultEvent,
   mockApp,
@@ -229,5 +229,167 @@ describe("prompts feature setup", () => {
     if (result.success) {
       expect(() => teardown(result.state)).not.toThrow();
     }
+  });
+});
+
+/**
+ * ADR-0017. The modern era advertises `prompts.listChanged: true`, so the
+ * server has to actually send `notifications/prompts/list_changed` when the
+ * set changes — and, just as importantly, NOT send one when it hasn't.
+ *
+ * The watcher fires on `modify` as well as create/delete/rename, so every
+ * save inside a prompt reaches this path. A per-event implementation passes
+ * "notifies on create" and still floods a client with one notification per
+ * keystroke burst, which is why the negative cases below carry the design
+ * rather than decorating it.
+ */
+describe("prompts list-changed notification (ADR-0017)", () => {
+  const DEBOUNCE = 5;
+  // Comfortably past the debounce, and past the microtask the comparison's
+  // own `await discoverPrompts` costs.
+  const settle = () => new Promise((r) => setTimeout(r, DEBOUNCE + 40));
+
+  function promptFile(path: string, description: string): void {
+    setMockFile(path, "Body");
+    setMockMetadata(path, {
+      frontmatter: { tags: ["mcp-tools-prompt"], description },
+    });
+  }
+
+  async function setupWithSpy(app: ReturnType<typeof mockApp>) {
+    const calls: number[] = [];
+    const result = await setup(new PromptRegistryClass(), app, {
+      notifyPromptsChanged: () => calls.push(1),
+      debounceMs: DEBOUNCE,
+    });
+    if (!result.success) throw new Error(result.error);
+    return { calls, state: result.state };
+  }
+
+  test("a new prompt file notifies once", async () => {
+    promptFile("Prompts/greet.md", "one");
+    const app = mockApp();
+    const { calls, state } = await setupWithSpy(app);
+
+    promptFile("Prompts/second.md", "two");
+    fireMockVaultEvent("create", { path: "Prompts/second.md" });
+    await settle();
+
+    expect(calls).toHaveLength(1);
+    teardown(state);
+  });
+
+  test("a prompt leaving the list notifies once", async () => {
+    promptFile("Prompts/greet.md", "one");
+    promptFile("Prompts/second.md", "two");
+    const app = mockApp();
+    const { calls, state } = await setupWithSpy(app);
+
+    // The list shrinks by dropping the qualifying tag rather than by
+    // removing the file: `resetMockVault()` also clears the registered
+    // vault-event handlers, so tearing the mock down mid-test would unhook
+    // the very watcher under test. What reaches `discoverPrompts` is the
+    // same either way — one fewer entry — and the `delete` event is real.
+    setMockMetadata("Prompts/second.md", { frontmatter: { tags: [] } });
+    fireMockVaultEvent("delete", { path: "Prompts/second.md" });
+    await settle();
+
+    expect(calls).toHaveLength(1);
+    teardown(state);
+  });
+
+  test("a save that changes nothing observable does NOT notify", async () => {
+    promptFile("Prompts/greet.md", "unchanged");
+    const app = mockApp();
+    const { calls, state } = await setupWithSpy(app);
+
+    // Exactly what Obsidian does while the user types in a prompt: a
+    // modify event whose content leaves the description and the argument
+    // declarations alone. Nothing a client can observe moved, so there is
+    // no list change to announce.
+    fireMockVaultEvent("modify", { path: "Prompts/greet.md" });
+    await settle();
+
+    expect(calls).toHaveLength(0);
+    teardown(state);
+  });
+
+  test("a changed description notifies, because the list carries it", async () => {
+    promptFile("Prompts/greet.md", "old");
+    const app = mockApp();
+    const { calls, state } = await setupWithSpy(app);
+
+    promptFile("Prompts/greet.md", "new");
+    fireMockVaultEvent("modify", { path: "Prompts/greet.md" });
+    await settle();
+
+    expect(calls).toHaveLength(1);
+    teardown(state);
+  });
+
+  test("a burst of saves re-scans the vault once, not once per event", async () => {
+    promptFile("Prompts/greet.md", "old");
+    const app = mockApp();
+    const { calls, state } = await setupWithSpy(app);
+
+    // Counting NOTIFICATIONS here would prove nothing: the list comparison
+    // already collapses a burst to one notification even with no debounce
+    // at all, because the first comparison to run updates the baseline and
+    // the rest find nothing new. Verified by mutation — deleting the
+    // `stopNotifier()` that resets the timer leaves a notification-counting
+    // assertion green.
+    //
+    // The re-scan is the cost the debounce actually exists to avoid, so the
+    // scan is what gets counted. `discoverPrompts` calls `getMarkdownFiles`
+    // exactly once per scan (`promptDiscovery.ts:34`).
+    const scan = spyOn(app.vault, "getMarkdownFiles");
+    promptFile("Prompts/greet.md", "new");
+    for (let i = 0; i < 5; i++) {
+      fireMockVaultEvent("modify", { path: "Prompts/greet.md" });
+    }
+    await settle();
+
+    expect(scan).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(1);
+    scan.mockRestore();
+    teardown(state);
+  });
+
+  test("no callback (legacy-only wiring) still invalidates the memo", async () => {
+    promptFile("Prompts/greet.md", "one");
+    const app = mockApp();
+    const registry = new PromptRegistryClass();
+    // No `notifyPromptsChanged`: what the legacy era gets, and what every
+    // other suite in this file constructs.
+    const result = await setup(registry, app, { debounceMs: DEBOUNCE });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect((await registry.list()).prompts).toHaveLength(1);
+
+    promptFile("Prompts/second.md", "two");
+    fireMockVaultEvent("create", { path: "Prompts/second.md" });
+    await settle();
+
+    // Cache invalidation is not era-specific and must not have moved into
+    // the notification path: without a callback there is nothing to send,
+    // but the next list still re-discovers.
+    expect((await registry.list()).prompts).toHaveLength(2);
+    teardown(result.state);
+  });
+
+  test("teardown cancels a comparison already scheduled", async () => {
+    promptFile("Prompts/greet.md", "old");
+    const app = mockApp();
+    const { calls, state } = await setupWithSpy(app);
+
+    promptFile("Prompts/greet.md", "new");
+    fireMockVaultEvent("modify", { path: "Prompts/greet.md" });
+    // Tear down INSIDE the debounce window: the callback would otherwise
+    // publish onto a handler this teardown is closing.
+    teardown(state);
+    await settle();
+
+    expect(calls).toHaveLength(0);
   });
 });

--- a/packages/obsidian-plugin/src/features/prompts/index.ts
+++ b/packages/obsidian-plugin/src/features/prompts/index.ts
@@ -1,6 +1,7 @@
 import { TFile, type App } from "obsidian";
 import { ProtocolError, ProtocolErrorCode } from "@modelcontextprotocol/server";
 import { PromptFrontmatterSchema } from "shared";
+import { logger } from "$/shared/logger";
 import type {
   PromptListEntry,
   PromptRegistry,
@@ -10,15 +11,65 @@ import { renderPrompt } from "./services/promptRenderer";
 import { expandEmbeds } from "./services/promptTransclusion";
 import { createVaultWatcher, type VaultWatcher } from "./services/vaultWatcher";
 
-export type PromptsFeatureState = { watcher: VaultWatcher };
+export type PromptsFeatureState = {
+  watcher: VaultWatcher;
+  /**
+   * Cancel a pending list-changed comparison. Called from teardown so a save
+   * landing during unload cannot fire into a handler that is going away.
+   */
+  stopNotifier: () => void;
+};
+
+/**
+ * How long the vault must stay quiet before the prompt list is re-scanned to
+ * decide whether anything actually changed.
+ *
+ * The watcher fires on `modify` as well as create/delete/rename, so every
+ * save inside a prompt reaches this path — Obsidian writes while the user is
+ * still typing. Without this window the connector would re-scan the vault,
+ * and potentially notify, several times per sentence.
+ */
+const NOTIFY_DEBOUNCE_MS = 500;
+
+/**
+ * A stable, order-independent form of the prompt list, for deciding whether
+ * anything a client can observe has changed.
+ *
+ * `discoverPrompts` returns entries in vault iteration order and never sorts,
+ * so comparing raw arrays would report a change when two prompts merely swap
+ * places. Sorting by name first means only real content differences —
+ * a prompt appearing, disappearing, or its description or argument
+ * declarations changing — produce a notification.
+ */
+function canonical(list: PromptListEntry[]): string {
+  return JSON.stringify([...list].sort((a, b) => a.name.localeCompare(b.name)));
+}
+
+export type PromptsSetupOptions = {
+  /**
+   * Publish `notifications/prompts/list_changed` (ADR-0017). Optional: the
+   * legacy era has no way to deliver one, and the unit tests that only
+   * exercise discovery and rendering pass nothing.
+   */
+  notifyPromptsChanged?: () => void;
+  /**
+   * Override {@link NOTIFY_DEBOUNCE_MS}. Same escape hatch as the semantic
+   * indexer's `debounceMs` (`semantic-search/services/indexer.ts`): tests
+   * need the comparison to run promptly, and half a second per assertion
+   * across a suite is real time spent waiting for a timer.
+   */
+  debounceMs?: number;
+};
 
 export async function setup(
   promptRegistry: PromptRegistry,
   app: App,
+  options: PromptsSetupOptions = {},
 ): Promise<
   | { success: true; state: PromptsFeatureState }
   | { success: false; error: string }
 > {
+  const { notifyPromptsChanged, debounceMs = NOTIFY_DEBOUNCE_MS } = options;
   try {
     // Memoized discovery: prompts/list used to re-scan every markdown
     // file and cachedRead each candidate on every call. The watcher
@@ -89,14 +140,57 @@ export async function setup(
       };
     });
 
+    // Baseline for the comparison below. Taken once at setup so the first
+    // watcher event is judged against the vault as it was at load, not
+    // against nothing — otherwise the first save of the session always
+    // looks like a change.
+    let lastNotified = canonical(await discoverPrompts(app));
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const stopNotifier = (): void => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
     const watcher = createVaultWatcher(app, () => {
-      // Invalidate the memoized prompt list; the stateless transport
-      // has no persistent session to notify beyond that.
+      // Invalidate the memoized prompt list. This half must stay sync and
+      // cheap: it runs on every save inside a prompt.
       epoch += 1;
       cached = null;
+
+      // The other half, and the reason it is deferred rather than done
+      // here: deciding whether to notify means re-scanning the vault, which
+      // is exactly the cost the memo above exists to avoid paying per event.
+      // On the legacy era there is nothing to schedule at all.
+      if (!notifyPromptsChanged) return;
+      stopNotifier();
+      timer = setTimeout(() => {
+        timer = null;
+        void (async () => {
+          try {
+            const next = canonical(await discoverPrompts(app));
+            // A save that touched neither the description nor the argument
+            // declarations changes no byte a client can see, so it is not a
+            // list change and must not be announced as one.
+            if (next === lastNotified) return;
+            lastNotified = next;
+            notifyPromptsChanged();
+          } catch (error) {
+            // A failed re-scan means the next event re-runs the comparison
+            // against the same baseline. Losing a notification is a stale
+            // list until the client re-lists; throwing out of a timer is an
+            // unhandled rejection.
+            logger.warn("prompts: list-changed comparison failed", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        })();
+      }, debounceMs);
     });
 
-    return { success: true, state: { watcher } };
+    return { success: true, state: { watcher, stopNotifier } };
   } catch (error) {
     return {
       success: false,
@@ -107,4 +201,8 @@ export async function setup(
 
 export function teardown(state: PromptsFeatureState): void {
   state.watcher.stop();
+  // Stopping the watcher stops new events, but one comparison may already be
+  // scheduled from a save moments ago. Cancel it: its callback publishes onto
+  // a handler this teardown is about to close.
+  state.stopNotifier();
 }

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -75,6 +75,14 @@ export default class McpToolsPlugin extends Plugin {
       const promptsResult = await promptsSetup(
         mcpResult.state.mcp.promptRegistry,
         this.app,
+        {
+          // ADR-0017: the prompts feature decides WHEN the list changed, the
+          // transport owns HOW it is published. Wiring it here rather than
+          // inside the transport keeps the vault-watching in the feature
+          // that already watches the vault.
+          notifyPromptsChanged: () =>
+            mcpResult.state.mcp.notifyPromptsChanged(),
+        },
       );
       if (promptsResult.success) {
         this.promptsState = promptsResult.state;


### PR DESCRIPTION
Implements ADR-0017, closes OMC-023, and takes Gate B of the 2.0 roadmap to 2/2.

The server declared `prompts: {}` at `mcpServer.ts`, which the SDK rewrites to `{ listChanged: true }` inside `setPromptRequestHandlers()` (`mcp-DXXb3Vv3.mjs:1550`, `?? true`). Both eras therefore advertised a capability nothing honoured, and no client that trusted the bit ever received a notification.

## Why the eras differ

Only the modern era can deliver one. The legacy transport is stateless and POST-only, `GET /mcp` returns 405 by design, and notifications ride the calling request's own response — where, for tools, the notification *is caused by* the request it rides. A vault file event has no request in flight. So the modern era declares `true` and honours it; the legacy era declares `false`, which is what makes it stop claiming something it cannot do.

Both halves move bytes only a major release may move, which is why this sat blocked behind OMC-008's Invariant 1 until now.

## Shape

- `buildMcpServer(tokenId, promptsListChanged = false)` — the single construction site for both eras (ADR-0016 §4) takes the bit rather than growing a second construction path. The two call sites are the era discriminant. The default is the legacy shape, so a call site that says nothing gets the era that cannot notify rather than re-claiming the capability.
- `McpService.notifyPromptsChanged()` wraps `modernHandler.notify.promptsChanged()`, the exact twin of the `toolsChanged()` OMC-007 wired.
- The prompts feature owns *when*: any watcher event schedules a debounced re-scan, and it publishes only when the canonicalised list differs from the last notified one. `main.ts` passes the callback in; ordering already worked, since `mcpTransportState` is assigned before `promptsSetup` runs.

Two details that are load-bearing rather than incidental. The watcher fires on `modify`, so every save inside a prompt reaches this path — without the debounce the connector re-scans several times per sentence. And `discoverPrompts` returns vault-iteration order with no sort, so the comparison canonicalises by name first; otherwise two prompts swapping places would read as a change.

## Tests

`eraRouter.test.ts`'s full-body `initialize` pin now reads `prompts: { listChanged: false }`. That assertion **is** OMC-008's Invariant 1, so the change is the visible record of what a major release moved, and the comment beside it says so. `modernEra.test.ts` keeps `true` on `server/discover` and its comment is rewritten: the value is now deliberate rather than inherited from the SDK's `??`.

Seven new tests. Two carry the design rather than decorate it: a save that changes nothing observable must **not** notify, and a burst must re-scan once.

**The second mutation check found a defect in my own test.** Counting notifications does not pin the debounce — the list comparison already collapses a burst on its own, because the first comparison to run updates the baseline and the rest find nothing new. Deleting the timer reset left a notification-counting assertion green. The re-scan is the cost the debounce actually avoids, so the test counts `getMarkdownFiles` calls instead; the same mutation now gives `Expected 1, Received 5`. Both that and the fact that `resetMockVault()` clears registered vault-event handlers (so a test resetting the mock mid-run unhooks the watcher it is exercising) are recorded in the test comments.

## Gate

`bun run check` clean, `bun test` 1795 pass / 0 fail, `bun run format:check` clean, `bun run check:svelte` 1387 files / 0 errors, `bun run test:mcpb` 4/4.

`bun run test:conformance` re-run: **26/28, baseline still four entries, unchanged.** That was the condition — if it had moved, the change reached further than intended. The prompts list-changed check stays a baselined WARNING because the suite drives a `test_trigger_prompt_change` fixture tool this project refuses to ship (ADR-0016 Alternative F); the baseline's parenthetical claiming "nothing here mutates prompts either" is corrected in this PR, since that half stopped being true.

## Not verified

No unit test can watch the notification reach a client, and no shipping client opens a `subscriptions/listen` stream. A hand-built listen client against a real vault is the only way to see it arrive, in the shape of the script that closed A1. **The TODO entry says B2 is not verified end-to-end and should not be re-worded until that runs.**
