### PR TITLE
fix(bridge): force the stdio streams to UTF-8 before reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to **MCP Connector** (formerly `obsidian-mcp-tools`) are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [2.0.1] — 2026-08-17
+
+### Fixed
+
+- **The Windows Python bridge no longer corrupts accented and non-Latin characters.** If you use `scripts/obsidian_mcp_bridge.py` — the documented Windows path — every file name, folder name and piece of content containing a character outside plain ASCII was mangled in both directions. A note at `Personer/Person - Søren Møller-Nielsen.md` was looked up as `Personer/Person - SÃ¸ren MÃ¸ller-Nielsen.md` and reported as not found, and an alias written through the bridge landed in the note corrupted the same way. Sending an already-corrupted string corrupted it again. The cause was one step at the very edge of the process: Claude Desktop writes UTF-8 down the pipe, but Python opens `sys.stdin` and `sys.stdout` using the encoding your Windows locale prefers, which is usually not UTF-8, so the bytes were decoded as the wrong character set before anything else looked at them. That is also why it affected everything at once rather than one tool. The bridge now forces both streams to UTF-8 before it reads its first line. Nothing to configure, and nothing changes on macOS or Linux, where the default was already UTF-8. If you had set `PYTHONUTF8=1` or `PYTHONIOENCODING=utf-8` in your client config to work around this, you can leave it or remove it; the bridge no longer depends on it. Root-caused by @smollern against a Danish vault, including the fix, in discussion #406.
+
 ## [2.0.0] — 2026-08-17
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
-<!-- project-tasks: prefix=OMC lastId=32 -->
+<!-- project-tasks: prefix=OMC lastId=33 -->
 # PROJECT TASKS
 
-Updated: 2026-08-17 · Open: 7 (P1: 0) · In progress: 0 · Gate A: 4/4 · Gate B: 3/3 · Gate C: 4/4 · Gate D: 3/5
+Updated: 2026-08-17 · Open: 8 (P1: 1) · In progress: 0 · Gate A: 4/4 · Gate B: 3/3 · Gate C: 4/4 · Gate D: 4/5
 
 ## Roadmap — 2.0
 
@@ -250,7 +250,7 @@ blank.
       3,577 B size that did not fit a 38 KB shim. Shipping since 2026-07-15, so not a 2.0.0
       regression; recorded as `OMC-031` rather than fixed here, and it is the one thing in this
       release nothing in the gate speaks for
-- [ ] `D4` The Obsidian scanner runs **on the release, never before**. Known constraints that
+- [x] `D4` **Passed on the 2.0.0 release, 2026-08-17.** The Obsidian scanner runs **on the release, never before**. Known constraints that
       have already failed a release: no `eslint-disable` on `obsidianmd/*` rules, and
       non-plugin code stays out of `src/` because the scanner lints `src/**` only
 - [ ] `D5` Post-release: tell @smollern (#406), @ottopichlhoefer (#430) and @Madulone (#352)
@@ -258,6 +258,35 @@ blank.
 
 ## Next — measured gaps, actionable now
 
+- [ ] `OMC-033` **P1** The Windows bridge still corrupts every non-ASCII path and body, and the
+      fix has been known and confirmed since 2026-07-26. @smollern root-caused it in discussion
+      #406 against a Danish vault: `scripts/obsidian_mcp_bridge.py` reads `sys.stdin` and writes
+      through `sys.stdout.write` (`main()` at :316-326, `write_message` at :216), both **text**
+      streams, so on Windows they use the locale codepage rather than UTF-8. Claude Desktop sends
+      UTF-8 down the pipe, so `ø` (`0xC3 0xB8`) is decoded as two cp1252 characters and arrives as
+      `Ã¸`; a path lookup then fails as "File not found", and a written alias lands corrupted in
+      the file. Re-sending a corrupted string doubles the corruption, which is what identified it
+      as a single reinterpretation at the stdio boundary. **He applied
+      `sys.stdin/sys.stdout.reconfigure(encoding="utf-8")` and confirmed it round-trips æ, ø, å, ü
+      and Japanese vault-wide. That change was never made here**: grepped 2026-08-17, the repo
+      contains no `reconfigure`, no `PYTHONUTF8` and no `PYTHONIOENCODING` anywhere. The two
+      `decode("utf-8")` calls at :189 and :200 are on the HTTP response body and do not touch the
+      stdio boundary. So 2.0.0 shipped with it, and #406's other two points did not: bug 2 needed
+      no code change (`set_note_property` was the right tool) and bug 3 is the six-field boolean
+      fix released in 2.0.0. **Do not tell @smollern his report is in a release until this is** —
+      two of three is not three. **Fixed on `main` 2026-08-17; this entry closes when 2.0.1
+      ships.** `force_utf8_stdio()` reconfigures `sys.stdin` and `sys.stdout` to UTF-8 and is
+      called as the first statement of `main()`, before a byte is read; `sys.stderr` is
+      deliberately left alone, so the diagnostic channel does not depend on the thing being
+      diagnosed. A stream with no `reconfigure`, or one that refuses, is skipped with a log line
+      rather than aborting the bridge — off Windows the default is already UTF-8. Four tests added
+      (`ForceUtf8StdioTests`), 28 → 32, and they assert the **call**, not the platform: a test that
+      merely round-tripped `ø` would pass with the fix deleted on every machine CI runs on.
+      Mutation-checked both ways — deleting the call from `main()` turns 1 red, reconfiguring to
+      `cp1252` instead turns 2 red. **Weakness to keep in view**: the bridge suite is stdlib
+      `unittest`, run by `python3 -m unittest discover -s scripts`, and is deliberately outside
+      `bun test` (issue #355) — so nothing in CI runs it, and this guard is a discipline rather
+      than an enforcement. Worth a CI step of its own <!-- src:session opened:2026-08-17 updated:2026-08-17 -->
 - [ ] `OMC-031` **P2** The `.mcpb` attached to every GitHub release is the pre-ADR-0013 bundle,
       and has been since 2026-07-15. Two build paths produce a `.mcpb` and only one was migrated.
       `generateMcpb()` (`features/mcp-client-config/services/mcpbGenerator.ts`), the plugin's

--- a/scripts/obsidian_mcp_bridge.py
+++ b/scripts/obsidian_mcp_bridge.py
@@ -66,6 +66,60 @@ def log(msg):
     print(f"[obsidian-bridge] {msg}", file=sys.stderr, flush=True)
 
 
+def force_utf8_stdio(streams: Optional[list] = None) -> int:
+    """Force this process's stdio text streams to UTF-8, and report how many moved.
+
+    The MCP client writes UTF-8 bytes down the stdio pipe and expects UTF-8
+    back. Python does NOT guarantee that on the receiving end: `sys.stdin` and
+    `sys.stdout` are text streams opened with the locale's preferred encoding,
+    which on Windows is typically cp1252 rather than UTF-8 unless the
+    environment forces it (`PYTHONUTF8=1`, `PYTHONIOENCODING=utf-8`). Decoding
+    UTF-8 bytes as cp1252 mangles every non-ASCII character in a way that
+    survives into the vault: `ø` is `0xC3 0xB8` in UTF-8, and read one byte at
+    a time as cp1252 those become `Ã` + `¸`, so the path
+    `Personer/Person - Søren Møller-Nielsen.md` is looked up as
+    `Personer/Person - SÃ¸ren MÃ¸ller-Nielsen.md` and answered "File not
+    found", while a frontmatter alias written through the bridge lands
+    corrupted in the note. Because the damage happens once at the stdio
+    boundary, before the bytes are ever parsed as JSON, it hits every tool
+    argument and every response body alike, and re-sending an
+    already-corrupted string corrupts it again.
+
+    Root-caused by @smollern against a Danish vault in discussion #406, with
+    this fix confirmed round-tripping æ, ø, å, ü and Japanese vault-wide.
+
+    Args:
+        streams: Streams to reconfigure. Defaults to `[sys.stdin, sys.stdout]`
+            — override only for tests. `sys.stderr` is deliberately absent:
+            it carries only this bridge's own ASCII log lines, and touching it
+            would make a diagnostic channel depend on the thing being
+            diagnosed.
+
+    Returns:
+        How many streams were actually reconfigured. Returned rather than
+        logged so a test can assert the call did something, which is the only
+        way to catch this regressing on a platform where the default encoding
+        already happens to be UTF-8.
+    """
+    if streams is None:
+        streams = [sys.stdin, sys.stdout]
+    moved = 0
+    for stream in streams:
+        # A stream replaced by a test double (StringIO) has no reconfigure,
+        # and a closed or detached stream raises when asked. Neither is a
+        # reason to refuse to start: the bridge still works wherever the
+        # platform default is already UTF-8, which is every non-Windows host.
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+            moved += 1
+        except (ValueError, OSError) as exc:
+            log(f"could not force UTF-8 on {getattr(stream, 'name', stream)}: {exc}")
+    return moved
+
+
 def parse_sse(body: str) -> list[dict]:
     """Parse an SSE response body into ordered JSON-RPC messages.
 
@@ -322,6 +376,11 @@ def main(argv: Optional[list[str]] = None, stdin=None) -> None:
         stdin: Line-iterable input source. Defaults to `sys.stdin` —
             override only for tests.
     """
+    # FIRST, before anything reads a byte: the streams have to be UTF-8 or
+    # every non-ASCII path and body is corrupted at this boundary (see
+    # force_utf8_stdio). Ordered ahead of the argv checks on purpose — those
+    # can log, and a log line is easier to read than a mangled one.
+    force_utf8_stdio()
     argv = sys.argv if argv is None else argv
     stdin = sys.stdin if stdin is None else stdin
     if len(argv) < 2:

--- a/scripts/test_obsidian_mcp_bridge.py
+++ b/scripts/test_obsidian_mcp_bridge.py
@@ -12,6 +12,7 @@ import threading
 import time
 import unittest
 import urllib.error
+from typing import Optional
 from unittest import mock
 
 import obsidian_mcp_bridge as bridge
@@ -359,6 +360,76 @@ class ConcurrencyTests(unittest.TestCase):
         ]
         _, elapsed = self._run_main(fake_urlopen, lines)
         self.assertLess(elapsed, 1.0)
+
+
+class _RecordingStream:
+    """Text stream double that records the encodings it was reconfigured to."""
+
+    def __init__(self, name: str, raises: Optional[Exception] = None):
+        self.name = name
+        self.raises = raises
+        self.encodings: list[str] = []
+
+    def reconfigure(self, encoding: Optional[str] = None, **kwargs) -> None:
+        if self.raises is not None:
+            raise self.raises
+        self.encodings.append(encoding)
+
+
+class ForceUtf8StdioTests(unittest.TestCase):
+    """Regression guard for the Windows non-ASCII corruption of discussion #406.
+
+    These assert the CALL, not the platform behaviour. On macOS and Linux the
+    default stdio encoding is already UTF-8, so a test that only checked that
+    round-tripping `ø` works would pass with the fix deleted, on every machine
+    that runs CI. What actually has to hold is that the bridge forces the
+    encoding rather than inheriting it.
+    """
+
+    def test_reconfigures_every_stream_to_utf8(self):
+        streams = [_RecordingStream("<stdin>"), _RecordingStream("<stdout>")]
+        moved = bridge.force_utf8_stdio(streams)
+        self.assertEqual(moved, 2)
+        self.assertEqual(streams[0].encodings, ["utf-8"])
+        self.assertEqual(streams[1].encodings, ["utf-8"])
+
+    def test_skips_a_stream_with_no_reconfigure(self):
+        # io.StringIO has no reconfigure, and the suite's own _run_main patches
+        # sys.stdout with one — so this is the path every other test here takes.
+        moved = bridge.force_utf8_stdio([io.StringIO()])
+        self.assertEqual(moved, 0)
+
+    def test_a_refusing_stream_does_not_stop_the_bridge(self):
+        # A detached or closed stream raises. Refusing to start would be worse
+        # than running with the platform default, which is correct off Windows.
+        hostile = _RecordingStream("<stdout>", raises=ValueError("detached"))
+        healthy = _RecordingStream("<stdin>")
+        moved = bridge.force_utf8_stdio([hostile, healthy])
+        self.assertEqual(moved, 1)
+        self.assertEqual(healthy.encodings, ["utf-8"])
+
+    def test_main_forces_utf8_before_reading_a_single_line(self):
+        # The ordering IS the invariant: the corruption happens at the stdio
+        # boundary, so a reconfigure that lands after the first read has
+        # already lost that line. Deleting the call from main(), or moving it
+        # below the read loop, fails here.
+        events: list[str] = []
+
+        class _RecordingStdin:
+            def __iter__(self):
+                events.append("read")
+                return iter([])
+
+        with mock.patch.object(
+            bridge, "force_utf8_stdio", lambda *a, **k: events.append("reconfigure")
+        ):
+            bridge.main(
+                argv=["bridge.py", "http://fake.local/mcp", "tok"],
+                stdin=_RecordingStdin(),
+            )
+
+        self.assertEqual(events[0], "reconfigure")
+        self.assertIn("read", events)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the only P1 in the ledger (`OMC-033`). Ships as 2.0.1.

**The bug.** On Windows, Python opens `sys.stdin` and `sys.stdout` with the locale's preferred encoding, typically cp1252. Claude Desktop writes UTF-8 down the pipe. So `ø` (`0xC3 0xB8`) was decoded as `Ã` + `¸`, and `Personer/Person - Søren Møller-Nielsen.md` was looked up as `Personer/Person - SÃ¸ren MÃ¸ller-Nielsen.md` and answered "File not found"; a frontmatter alias written through the bridge landed corrupted in the note. The damage happened once, at the stdio boundary, before anything parsed the bytes as JSON, which is why it hit every tool argument and every response body at once and why re-sending a corrupted string corrupted it again.

**The uncomfortable part.** @smollern root-caused this against a Danish vault in discussion #406 on 2026-07-26, proposed exactly this fix, and confirmed it round-trips æ, ø, å, ü and Japanese vault-wide. It was never applied here. 2.0.0 shipped without it. Every Windows bridge user with non-ASCII characters in their vault has been hitting it for three weeks.

**The fix.** `force_utf8_stdio()` reconfigures both streams and is called as the first statement of `main()`, before a byte is read — the ordering is the invariant, since a reconfigure that lands after the first read has already lost that line. `sys.stderr` is deliberately untouched: it carries only this bridge's own ASCII log lines, and reconfiguring it would make the diagnostic channel depend on the thing being diagnosed. A stream with no `reconfigure`, or one that refuses because it is detached or closed, is skipped with a log line rather than aborting — off Windows the platform default is already UTF-8, and refusing to start there would be worse than the status quo.

**Tests: 28 → 32.** They assert the *call*, not the platform. A test that merely round-tripped `ø` would pass with the fix deleted on every machine CI runs on, because macOS and Linux already default to UTF-8. Mutation-checked in both directions: deleting the call from `main()` turns 1 red, reconfiguring to `cp1252` instead turns 2 red.

**One weakness stated rather than hidden:** the bridge suite is stdlib `unittest`, run by `python3 -m unittest discover -s scripts`, deliberately outside `bun test` (issue #355). Nothing in CI runs it, so this guard is a discipline rather than an enforcement. A CI step of its own is worth doing and is noted in `OMC-033`.

Gate: `python3 -m unittest discover -s scripts` 32 pass, `bun run check` 0 errors, `bun test` 1849 pass / 0 fail, `format:check` clean.