### PR TITLE
docs(readme): rewrite the protocol section for the 2.0 era adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Your Obsidian vault, exposed to AI clients over the [Model Context Protocol](https://modelcontextprotocol.io). The MCP server runs **inside Obsidian**, on loopback, with no binary to download and no cloud round-trip. Claude Desktop, Claude Code, Cursor, Cline, Continue, Windsurf and VS Code all connect to the same endpoint.
 
-[What's new](#whats-new-in-10x) · [Quick start](#quick-start) · [Tools](#what-it-can-do) · [Adaptive tool loading](#adaptive-tool-loading) · [Per-client tokens](#per-client-tokens) · [Prompts](#prompts) · [Protocol](#protocol-status) · [Clients](#connecting-a-client) · [Troubleshooting](#troubleshooting) · [Security](#security) · [For developers](#for-developers)
+[What's new](#whats-new-in-20x) · [Quick start](#quick-start) · [Tools](#what-it-can-do) · [Rendered search results](#rendered-search-results-mcp-apps) · [Adaptive tool loading](#adaptive-tool-loading) · [Per-client tokens](#per-client-tokens) · [Prompts](#prompts) · [Protocol](#protocol-status) · [Clients](#connecting-a-client) · [Troubleshooting](#troubleshooting) · [Security](#security) · [For developers](#for-developers)
 
 ---
 
@@ -31,7 +31,25 @@ Four things follow from that shape:
 - **Semantic search is on-device.** Transformers.js runs the embedding model locally. No API key, no Smart Connections requirement.
 - **Every request carries its own credentials.** The transport keeps no session state, which is what makes per-client tool surfaces possible.
 
-## What's new in 1.0.x
+## What's new in 2.0.x
+
+2.0 is the release where this connector stopped waiting for the next MCP revision and started
+serving it. The protocol work is the substance, and the visible half is that search results now
+arrive as a list you can read instead of a wall of JSON.
+
+| Change | Why it matters |
+|---|---|
+| **MCP revision `2026-07-28` is served, alongside the old one** (2.0.0) | Two protocol eras on one endpoint, one port, one token, classified per request. A client that speaks the new revision finds it by probing `server/discover`; a client that does not never sees it. Nothing you have configured needs to change. See [Protocol status](#protocol-status). |
+| **Search results render as a ranked list** (2.0.0) | `search_vault_smart` and `search_vault_simple` publish an [MCP Apps](#rendered-search-results-mcp-apps) view: one row per hit with the path, the excerpt, and for the semantic search a similarity score and the heading. The text result is byte-identical to before, so clients without the extension see exactly what they saw. |
+| **Prompt-list changes are announced for real** (2.0.0) | On the new revision, adding, deleting or renaming a note under `Prompts/` tells listening clients to re-read the list. On the old revision the connector now says it cannot, which is the truthful answer. This retraction is what makes the number 2.0. |
+| **Per-token request counters** (2.0.0) | The transport settings show how many requests each token served and on which revision, so a client that stopped working is a row whose count stopped moving. |
+| **A tool promoted by one client is announced to the others** (2.0.0) | Promotion counters are vault-wide, so one client crossing the threshold widens every adaptive client's list. On the new revision the others are now told instead of serving a stale list. [#419](https://github.com/istefox/obsidian-mcp-connector/issues/419) |
+| **Windows bridge: no more mangled accents** (2.0.1) | `scripts/obsidian_mcp_bridge.py` forces its stdio streams to UTF-8, so `æ ø å ü` and non-Latin scripts survive in both directions. Root-caused, with the fix, by [@smollern](https://github.com/istefox/obsidian-mcp-connector/discussions/406). |
+| **Boolean arguments accept real booleans** (2.0.0) | Six fields across five tools rejected a genuine JSON `true`, including `delete_vault_directory.recursive`. [#444](https://github.com/istefox/obsidian-mcp-connector/issues/444) |
+| **`search_vault_smart` works under `auto` again** (2.0.0) | With Smart Connections installed it returned an empty result for every query, silently. [#430](https://github.com/istefox/obsidian-mcp-connector/issues/430) |
+
+<details>
+<summary>What 1.0.x brought (still current)</summary>
 
 | Change | Why it matters |
 |---|---|
@@ -43,6 +61,8 @@ Four things follow from that shape:
 | **Built-in-Node fix** (1.0.1) | The Claude Desktop extension now works with **Use Built-in Node.js for MCP** left on. See [#412](https://github.com/istefox/obsidian-mcp-connector/issues/412). |
 | **Whole-request deadline in the shim** (1.0.1) | A failing request answers inside 45 s with the reason instead of being cancelled at 60 s with nothing logged. |
 | **MCP SDK v2, error codes out of the reserved range** (0.28.2, 1.0.1) | See [Protocol status](#protocol-status). |
+
+</details>
 
 Full history: [`CHANGELOG.md`](CHANGELOG.md).
 
@@ -72,9 +92,37 @@ Ask the agent to call `get_server_info` to confirm the round trip. Requirements:
 | **Other** | `fetch`, `get_server_info` | `fetch` returns Markdown via Turndown, paginated. |
 | **Meta** | `tool_catalog`, `activate_tool`, `activate_tools` | Always reachable, see below. |
 
-Every result carries `structuredContent` next to the text payload, and every tool declares MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so a client can skip confirmation on reads and gate it on writes. List and scan tools take a `limit` (default 200, clamped to 1000) and report `truncated` with the real `total`.
+Every tool declares MCP annotations, such as `readOnlyHint`, `destructiveHint`, `idempotentHint` and `openWorldHint`, so a client can skip confirmation on reads and gate it on writes. List and scan tools take a `limit` (default 200, clamped to 1000) and report `truncated` with the real `total`.
+
+**On `outputSchema`, deliberately absent.** Almost no tool here declares one, and that is a decision rather than an omission. Once a tool declares an output schema, SDK clients reject every response from it that lacks `structuredContent`. Several of these tools return genuinely different shapes depending on what they find, so declaring a schema for them broke `get_vault_file` for five releases (0.27.2 through 0.27.6) before the rule was written down. A tool whose result shape is polymorphic gets no schema.
 
 **Semantic search providers.** Native MiniLM-L6-v2 (~25 MB, default), Gemma 300M (768d, best for non-Latin vaults), Multilingual-E5-Base (768d), or Smart Connections if you already use it. Providers swap live while the previous one keeps serving. The index is sharded into 16 segments by path, so editing one note rewrites one segment. While a build is running, `search_vault_smart` returns a structured `index_building` error with `filesIndexed`, `filesTotal` and an estimated `retryAfterSeconds`.
+
+## Rendered search results (MCP Apps)
+
+Both search tools publish a small HTML view alongside their text result, using the
+[MCP Apps](https://modelcontextprotocol.io) `ui://` resource extension. In a client that supports
+it, a search comes back as a ranked list you can read: one row per hit, carrying the note's path,
+the matching excerpt, and, for the semantic search, a similarity score and the heading the passage
+sits under. A zero-match query renders an explicit empty state naming the vault it searched.
+
+Four things about how this is built, because they are the parts that usually go wrong:
+
+- **The text result did not change, byte for byte.** A client that knows nothing about MCP Apps sees
+  exactly what it saw before, with no stray output and nothing to configure. The row data rides in
+  the result's own `_meta`, on the success branch only; when a tool errors, that key is absent and
+  the view falls back to the text.
+- **The `resources` capability serves the view and nothing else.** No vault content is reachable
+  through `resources/*`. Listing notes there would need a permission model designed from scratch,
+  since the per-token allowlist and the kill switch are tool-level concepts, so it is deliberately
+  out of scope. Decisions in
+  [ADR-0018](docs/architecture/ADR-0018-omc-016-mcp-apps-ui-resource.md).
+- **Clicking a row asks the client to open the note in Obsidian, and the client decides.** Claude
+  Desktop currently declines to follow an `obsidian://` link out of a tool result. When that
+  happens the row reveals the note's vault-relative path instead, so the information is never lost.
+  This is host policy and not something this plugin can change from its side.
+- **The line number is shown, never used as a jump target.** `obsidian://open` has no line
+  parameter, and under Smart Connections the semantic provider resolves no line at all.
 
 ## Adaptive tool loading
 
@@ -180,20 +228,44 @@ Off by default. When enabled, the agent can run Obsidian commands from the comma
 
 ## Protocol status
 
-**What the connector speaks today:** MCP revision `2025-11-25` and earlier, which is what every shipping client negotiates. Nothing you have configured needs to change.
+**The connector serves two MCP revisions from one endpoint.** `2026-07-28`, the revision that moves
+MCP to a stateless request/response core, and the `2025-11-25`-and-earlier line that every shipping
+client still negotiates. Same port, same URL, same bearer token. Each request is classified on its
+own, from one read of its body, so adopting the new revision took nothing away from the old one and
+no configured client, generated bundle or bridge config needed touching. Decisions in
+[ADR-0016](docs/architecture/ADR-0016-omc-008-adopt-mcp-spec-2026-07-28.md).
 
-**Where it already matches `2026-07-28`,** the revision Anthropic published on 28 July 2026, which moves MCP to a stateless request/response core:
+One thing to know if you are implementing against this: **the new revision is not reachable through
+`initialize`.** A client finds it by probing `server/discover`, and falls back to the handshake on
+its own if that method is absent. The SDK's `LATEST_PROTOCOL_VERSION` is the handshake offer and by
+construction can never name the 2026 revision, so it tells you nothing about whether a server serves
+it.
 
 | `2026-07-28` direction | Status here |
 |---|---|
-| No protocol-level sessions, no `Mcp-Session-Id` | Never had them. Every request carries its own credentials. |
-| `GET`/`DELETE` on the MCP endpoint answer `405` | `GET /mcp` returns 405 by design. There is no server-initiated stream. |
-| No SSE resumability, no `Last-Event-ID` | Not implemented, not needed. `notifications/tools/list_changed` rides the caller's own POST response with that call's `relatedRequestId`. |
+| Stateless core, no protocol-level sessions, no `Mcp-Session-Id` | Never had them. Every request carries its own credentials, which is what makes per-token tool surfaces possible in the first place. |
+| `GET`/`DELETE` on the MCP endpoint answer `405` | By design. There is no server-initiated stream on the legacy era at all. |
+| `subscriptions/listen` replaces the GET stream | Served. A client that opens one is acknowledged, gets a subscription id, and receives the notification types it opted into. |
+| `notifications/tools/list_changed` | Delivered two ways: on the caller's own POST response, and fanned out to every open listen stream that asked for it, so a promotion triggered by one client reaches the others. |
+| `notifications/prompts/list_changed` | Honoured on the new revision, declared unavailable on the old one, where a POST-only transport structurally cannot deliver it. See [ADR-0017](docs/architecture/ADR-0017-omc-023-prompts-list-changed-by-era.md). |
+| `resources/*` capability | Declared, and it serves `ui://` application resources only. No vault content is reachable through it, deliberately: the per-token allowlist and the kill switch are tool-level concepts and none of them reaches a resource surface. |
+| Removed methods answer `404` / `-32601` on the new era | Confirmed by the conformance suite for `initialize`, `ping`, `logging/setLevel`, `resources/subscribe` and `resources/unsubscribe`. A claim-less client carries no envelope, classifies legacy, and keeps being served. |
 | `-32000`–`-32019` is a legacy range new code should avoid | The `.mcpb` shim and the Windows bridge report local failures as `-33000`, below the reserved range entirely. |
 | Per-request authorization may scope the tool set | Exactly what [per-client tokens](#per-client-tokens) do. |
 | Tool-set stability clause | Analysed and satisfied, see [ADR-0015](docs/architecture/ADR-0015-tools-list-invariant-and-adaptive-loading.md). |
 
-**What is still open:** the SDK migration landed in 0.28.2 (`@modelcontextprotocol/server` and `@modelcontextprotocol/node` 2.0.0 replaced the 1.x monolith), and negotiating the `2026-07-28` revision on the wire is a separate opt-in tracked in [#407](https://github.com/istefox/obsidian-mcp-connector/issues/407). Servers may serve both revisions from one endpoint, so this will not be a flag day. `subscriptions/listen`, the piece that would let a promotion reach a client that was not the caller, is tracked in [#419](https://github.com/istefox/obsidian-mcp-connector/issues/419).
+**Measured, not asserted.** The `server-stateless` suite from the official conformance harness runs
+against a headless build of this connector and reports **26 of 28**. It went from 7 of 27 over the
+course of this work. The two that stay red need a fixture tool shipped in every user's vault purely
+so a test can mutate the tool list, and this project will not ship one; they are named in a
+four-entry baseline that is maintained by hand and never regenerated from a failing run, so a check
+that starts failing gets investigated rather than absorbed. The job runs nightly rather than per PR,
+because it clones and builds the suite from source at a pinned ref.
+
+**What is still open.** Retiring the legacy era is a decision with a measured trigger rather than a
+plan: the legacy request counter has to sit at zero for two minor releases or 60 days. It is nowhere
+near. Until then both eras are served, and the counters in the transport settings are how you watch
+that number.
 
 ## Connecting a client
 
@@ -237,6 +309,8 @@ Paste into `claude_desktop_config.json` (Settings → Developer → Edit Config)
 <summary>Windows: use the POST-only bridge</summary>
 
 `mcp-remote` hangs for 60 s on connect on Windows ([geelen/mcp-remote#296](https://github.com/geelen/mcp-remote/issues/296)), against unrelated MCP servers too. Use the bundled `scripts/obsidian_mcp_bridge.py`, standard library only:
+
+**Update the bridge if you are on a copy older than 2.0.1.** Before that release it read and wrote its stdio streams using whatever encoding your Windows locale preferred, usually not UTF-8, so any file name, folder name or note content containing a character outside plain ASCII was corrupted in both directions: a note at `Personer/Person - Søren Møller-Nielsen.md` was looked up as `Personer/Person - SÃ¸ren MÃ¸ller-Nielsen.md` and reported missing. The bridge now forces both streams to UTF-8 before reading anything. If you set `PYTHONUTF8=1` or `PYTHONIOENCODING=utf-8` in your client config to work around it, you can keep or drop it; the bridge no longer depends on either.
 
 ```json
 {

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- project-tasks: prefix=OMC lastId=33 -->
 # PROJECT TASKS
 
-Updated: 2026-08-17 · Open: 8 (P1: 1) · In progress: 0 · Gate A: 4/4 · Gate B: 3/3 · Gate C: 4/4 · Gate D: 4/5
+Updated: 2026-08-17 · Open: 7 (P1: 0) · In progress: 0 · Gate A: 4/4 · Gate B: 3/3 · Gate C: 4/4 · Gate D: 5/5
 
 ## Roadmap — 2.0
 
@@ -253,40 +253,19 @@ blank.
 - [x] `D4` **Passed on the 2.0.0 release, 2026-08-17.** The Obsidian scanner runs **on the release, never before**. Known constraints that
       have already failed a release: no `eslint-disable` on `obsidianmd/*` rules, and
       non-plugin code stays out of `src/` because the scanner lints `src/**` only
-- [ ] `D5` Post-release: tell @smollern (#406), @ottopichlhoefer (#430) and @Madulone (#352)
-      that their work is in a release, not just on `main`
+- [x] `D5` Post-release: tell @smollern (#406), @ottopichlhoefer (#430) and @Madulone (#352)
+      that their work is in a release, not just on `main`. **All three posted 2026-08-17**, after
+      2.0.1 rather than after 2.0.0, so that @smollern's reply could say all three of his findings
+      shipped instead of two of three. @Madulone's says plainly that the cross-call half is in
+      neither release and that #445 is unscheduled, rather than implying a date.
+      **Discussion comments cannot be written through REST.**
+      `POST repos/{owner}/{repo}/discussions/{n}/comments` answers 404 even where the matching GET
+      works; it takes the GraphQL `addDiscussionComment` mutation with the discussion's node id.
+      An issue comment is `gh issue comment` as usual — #430 is an issue, #406 and #352 are
+      discussions
 
 ## Next — measured gaps, actionable now
 
-- [ ] `OMC-033` **P1** The Windows bridge still corrupts every non-ASCII path and body, and the
-      fix has been known and confirmed since 2026-07-26. @smollern root-caused it in discussion
-      #406 against a Danish vault: `scripts/obsidian_mcp_bridge.py` reads `sys.stdin` and writes
-      through `sys.stdout.write` (`main()` at :316-326, `write_message` at :216), both **text**
-      streams, so on Windows they use the locale codepage rather than UTF-8. Claude Desktop sends
-      UTF-8 down the pipe, so `ø` (`0xC3 0xB8`) is decoded as two cp1252 characters and arrives as
-      `Ã¸`; a path lookup then fails as "File not found", and a written alias lands corrupted in
-      the file. Re-sending a corrupted string doubles the corruption, which is what identified it
-      as a single reinterpretation at the stdio boundary. **He applied
-      `sys.stdin/sys.stdout.reconfigure(encoding="utf-8")` and confirmed it round-trips æ, ø, å, ü
-      and Japanese vault-wide. That change was never made here**: grepped 2026-08-17, the repo
-      contains no `reconfigure`, no `PYTHONUTF8` and no `PYTHONIOENCODING` anywhere. The two
-      `decode("utf-8")` calls at :189 and :200 are on the HTTP response body and do not touch the
-      stdio boundary. So 2.0.0 shipped with it, and #406's other two points did not: bug 2 needed
-      no code change (`set_note_property` was the right tool) and bug 3 is the six-field boolean
-      fix released in 2.0.0. **Do not tell @smollern his report is in a release until this is** —
-      two of three is not three. **Fixed on `main` 2026-08-17; this entry closes when 2.0.1
-      ships.** `force_utf8_stdio()` reconfigures `sys.stdin` and `sys.stdout` to UTF-8 and is
-      called as the first statement of `main()`, before a byte is read; `sys.stderr` is
-      deliberately left alone, so the diagnostic channel does not depend on the thing being
-      diagnosed. A stream with no `reconfigure`, or one that refuses, is skipped with a log line
-      rather than aborting the bridge — off Windows the default is already UTF-8. Four tests added
-      (`ForceUtf8StdioTests`), 28 → 32, and they assert the **call**, not the platform: a test that
-      merely round-tripped `ø` would pass with the fix deleted on every machine CI runs on.
-      Mutation-checked both ways — deleting the call from `main()` turns 1 red, reconfiguring to
-      `cp1252` instead turns 2 red. **Weakness to keep in view**: the bridge suite is stdlib
-      `unittest`, run by `python3 -m unittest discover -s scripts`, and is deliberately outside
-      `bun test` (issue #355) — so nothing in CI runs it, and this guard is a discipline rather
-      than an enforcement. Worth a CI step of its own <!-- src:session opened:2026-08-17 updated:2026-08-17 -->
 - [ ] `OMC-031` **P2** The `.mcpb` attached to every GitHub release is the pre-ADR-0013 bundle,
       and has been since 2026-07-15. Two build paths produce a `.mcpb` and only one was migrated.
       `generateMcpb()` (`features/mcp-client-config/services/mcpbGenerator.ts`), the plugin's
@@ -429,6 +408,35 @@ ship — `_meta` present but not an object — is ordinary shape validation the 
 
 ## Done
 
+- [x] `OMC-033` The Windows bridge corrupted every non-ASCII path and body, and the
+      fix has been known and confirmed since 2026-07-26. @smollern root-caused it in discussion
+      #406 against a Danish vault: `scripts/obsidian_mcp_bridge.py` reads `sys.stdin` and writes
+      through `sys.stdout.write` (`main()` at :316-326, `write_message` at :216), both **text**
+      streams, so on Windows they use the locale codepage rather than UTF-8. Claude Desktop sends
+      UTF-8 down the pipe, so `ø` (`0xC3 0xB8`) is decoded as two cp1252 characters and arrives as
+      `Ã¸`; a path lookup then fails as "File not found", and a written alias lands corrupted in
+      the file. Re-sending a corrupted string doubles the corruption, which is what identified it
+      as a single reinterpretation at the stdio boundary. **He applied
+      `sys.stdin/sys.stdout.reconfigure(encoding="utf-8")` and confirmed it round-trips æ, ø, å, ü
+      and Japanese vault-wide. That change was never made here**: grepped 2026-08-17, the repo
+      contains no `reconfigure`, no `PYTHONUTF8` and no `PYTHONIOENCODING` anywhere. The two
+      `decode("utf-8")` calls at :189 and :200 are on the HTTP response body and do not touch the
+      stdio boundary. So 2.0.0 shipped with it, and #406's other two points did not: bug 2 needed
+      no code change (`set_note_property` was the right tool) and bug 3 is the six-field boolean
+      fix released in 2.0.0. **Do not tell @smollern his report is in a release until this is** —
+      two of three is not three. **Fixed on `main` 2026-08-17; this entry closes when 2.0.1
+      ships.** `force_utf8_stdio()` reconfigures `sys.stdin` and `sys.stdout` to UTF-8 and is
+      called as the first statement of `main()`, before a byte is read; `sys.stderr` is
+      deliberately left alone, so the diagnostic channel does not depend on the thing being
+      diagnosed. A stream with no `reconfigure`, or one that refuses, is skipped with a log line
+      rather than aborting the bridge — off Windows the default is already UTF-8. Four tests added
+      (`ForceUtf8StdioTests`), 28 → 32, and they assert the **call**, not the platform: a test that
+      merely round-tripped `ø` would pass with the fix deleted on every machine CI runs on.
+      Mutation-checked both ways — deleting the call from `main()` turns 1 red, reconfiguring to
+      `cp1252` instead turns 2 red. **Weakness to keep in view**: the bridge suite is stdlib
+      `unittest`, run by `python3 -m unittest discover -s scripts`, and is deliberately outside
+      `bun test` (issue #355) — so nothing in CI runs it, and this guard is a discipline rather
+      than an enforcement. Worth a CI step of its own <!-- src:session opened:2026-08-17 updated:2026-08-17 --> **Released in 2.0.1 (tag `2.0.1` → `60d6e6c`), 2026-08-17**, and @smollern told the same day (2026-08-17)
 - [x] `OMC-024` Per-token era counters. **Implemented, and verified in a vault on both of the checks that were holding it open.** `eraCountersByToken` now sits alongside `eraCounters` in the `mcpTransport` slice, keyed by token id, and each token row in the transport settings says which era it is served on. Additive rather than the migration this entry originally asked for, and the original framing was wrong: the counts already on disk predate the split and belong to no token, so attributing them would invent data and dropping them would damage ADR-0016 §8's trigger, which reads the vault-wide legacy total. `sum(byToken) <= eraCounters` holds by construction. A revoked token's bucket is pruned in the counter's own recipe; an absent or malformed `tokens` key prunes nothing, so a boot that writes before `ensureTokenStore` seeds the list cannot wipe the map. **Both remaining checks are now done, so this closes.** Two tokens on different eras with disagreeing rows against a global that exceeds their sum: `A1`, 2026-08-15. A pre-existing vault with no `eraCountersByToken` key: `A2`, 2026-08-16 — the key removed with the plugin stopped, the token row rendering with no era label at all, the global `Requests served` still reading from `eraCounters`, and the server answering normally; backup restored (2026-08-16)
 - [x] `OMC-016` #427 MCP Apps: a `ui://` resource surface for the two search tools, decided in `docs/architecture/ADR-0018-omc-016-mcp-apps-ui-resource.md`, SPEC archived at `docs/specs/omc-016-mcp-apps-ui-resource.spec.md`. `C1` the `resources` capability with every field explicit and `extensions: { "io.modelcontextprotocol/ui": … }` declared once at `buildMcpServer(tokenId)` for both eras; `C2` the `@modelcontextprotocol/ext-apps` handshake bundled from the view-side entry, `main.js` 2,649,591 → 3,011,578 B (+13.66%, trigger +20%); `C3` both search tools' rows riding the result's own `_meta`, `content` byte-identical to before. Merged as PR #454 (`e3dcd8c`), squashed, CI green, 1849 tests, conformance 26/28 baseline unmoved. **Closed 2026-08-16 by `R-18`**, which put the view in front of a human for the first time: it renders, and **Claude Desktop forwards the tool result's `_meta` to it**, so ADR-0018 Alternative D (`structuredContent`) never has to be built. Two things the run settled that no test could: the host refuses the `obsidian://` scheme, so the click degrades to revealing the vault-relative path — designed fallback, host policy, and it leaves the URL encoding untested by any means; and the theme follows a host switch with no reload. Full per-check measurements in `R-18` under Gate C (2026-08-16)
 - [x] `OMC-023` The server advertised a prompts capability it did not honour, on both protocol eras. ADR-0017 settled it three ways rather than two: modern declares `prompts: { listChanged: true }` and honours it, legacy declares `false`, because a POST-only transport with `GET /mcp` at 405 structurally cannot deliver a notification with no request in flight. Shipped 2026-08-15 (PR #450 decision, #452 code); `eraRouter.test.ts`'s full-body `initialize` pin reads `false`, and that assertion IS the record of what a major release moved. **Closed 2026-08-16 by `B3`**, the only thing it was still open on: a hand-built `subscriptions/listen` client against the Labs vault saw `notifications/prompts/list_changed` arrive on a prompt create and on a delete, carrying the ack's own subscription id; saw nothing for a body edit that changed no field a client can see, which is the case the list comparison exists for and the only place a per-event implementation would have failed; and saw a `toolsListChanged` bystander stay silent throughout, with its filter genuinely honored. The legacy half stayed structural rather than observational — `GET /mcp` is 405 and a live legacy `initialize` returns `prompts.listChanged: false`, so there is no stream for a notification to ride. Conformance stayed 26/28. Full measurements in `B3` under Gate B (2026-08-16)


### PR DESCRIPTION
The README's Protocol status section had gone stale in a way that misrepresented the project: it said the connector speaks `2025-11-25` and that negotiating `2026-07-28` was "a separate opt-in tracked in #407", and that `subscriptions/listen` was tracked in #419. All of that shipped in 2.0.0.

**Rewritten around what the connector actually does.** Two revisions served from one endpoint, one port, one token, classified per request. The entry point stated plainly, because it is the thing an implementer gets wrong: the new revision is not reachable through `initialize`, a client probes `server/discover`, and the SDK's `LATEST_PROTOCOL_VERSION` can never name it. The capability table now covers `subscriptions/listen`, the two delivery paths for `tools/list_changed`, `prompts/list_changed` per era, and the `resources` surface with its deliberate limit that no vault content is reachable through it. Conformance is stated as measured (26 of 28, from 7 of 27) with the reason the last two stay red and the note that the baseline is maintained by hand.

**New section for the MCP Apps search view**, and it does not promise what `R-18` disproved: clicking a row asks the client to open the note, Claude Desktop currently declines the `obsidian://` scheme, and the row reveals the vault-relative path instead. Stated as host policy rather than as a feature that works.

**One false claim corrected.** The README said "Every result carries `structuredContent` next to the text payload". Measured on the wire: 0 of the tools on a live surface declare `outputSchema`, and 2 of 52 tool files return `structuredContent`. The absence is a decision, since declaring a schema makes SDK clients reject every response lacking `structuredContent`, which is what broke `get_vault_file` across 0.27.2 to 0.27.6. That is now explained instead of contradicted.

**Windows bridge note added** where someone who worked around the UTF-8 corruption will find it, including that `PYTHONUTF8=1` is no longer needed.

Also closes `D5` in TODO.md (all three contributor replies posted) and moves `OMC-033` to Done now that 2.0.1 shipped. Gate D is 5/5.

Checked: all 14 nav anchors resolve against real headings; tool counts (52 total, 49 vault, 3 meta) and the annotation coverage re-measured against the running connector rather than copied forward. The one `SECRET` the pre-commit scanner reports on `README.md:321` is the `paste-your-token-here` placeholder in the example config, present before this change at line 247.

Documentation only.