### PR TITLE
fix(release): cut a release in two phases, neither able to push main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,14 @@ jobs:
       - name: Build (bundle smoke)
         run: bun run build
 
+      # The two steps below cd into a package, so a test file at the REPO root
+      # runs in neither of them. scripts/version.test.ts is the first one, and
+      # this is the same trap the Python bridge suite sat in. The path filter
+      # also re-matches the two suites under packages/*/scripts/, which costs
+      # about a second and is not worth engineering around.
+      - name: Tests — root scripts
+        run: bun test scripts/
+
       - name: Tests — shared
         run: cd packages/shared && bun test
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- project-tasks: prefix=OMC lastId=33 -->
 # PROJECT TASKS
 
-Updated: 2026-08-17 · Open: 6 (P1: 0) · In progress: 0 · Gate A: 4/4 · Gate B: 3/3 · Gate C: 4/4 · Gate D: 5/5
+Updated: 2026-08-17 · Open: 5 (P1: 0) · In progress: 0 · Gate A: 4/4 · Gate B: 3/3 · Gate C: 4/4 · Gate D: 5/5
 
 ## Roadmap — 2.0
 
@@ -244,7 +244,9 @@ blank.
       `community-plugins.json` as `mcp-tools-istefox`.
       **`bun run version major` did NOT complete it, and cannot on this repo any more.** It made
       the version commit and the tag, then its `git push origin main` was refused by the ruleset.
-      Cut by hand around it; the procedure and the reason are `OMC-032`.
+      Cut by hand around it; the procedure and the reason are `OMC-032`, **which closed the same day
+      by rewriting the script into two phases — so this is the last release cut by hand, and the next
+      one is the first test of the replacement**.
       **The published `.mcpb` is the pre-ADR-0013 npx/mcp-remote bundle, not the pure-Node shim
       this project ships from the plugin.** Found by inspecting the asset after publishing, on a
       3,577 B size that did not fit a 38 KB shim. Shipping since 2026-07-15, so not a 2.0.0
@@ -267,19 +269,6 @@ blank.
 
 ## Next — measured gaps, actionable now
 
-- [ ] `OMC-032` **P2** `bun run version` cannot cut a release on this repo any more, and 2.0.0
-      was cut by hand around it. The script (`scripts/version.ts:54-58`) commits the three version
-      files, tags, then `git push -u origin main` — which the ruleset now refuses: *"Changes must
-      be made through a pull request"* plus a required `check-and-test`. Every earlier release tag
-      points at a version commit pushed straight to `main` (`1.0.1` → `e2ebb20`, single parent,
-      subject `1.0.1`), so the procedure worked when those were cut and the rules tightened after.
-      The failure is safe and leaves a recoverable state: the local commit and tag exist, nothing
-      reaches the remote, the tree stays clean. **The recovery used for 2.0.0, which is the shape
-      any fix should keep**: branch the version commit, PR it, merge with a **merge commit** so its
-      SHA survives, fast-forward `main`, then push the tag alone — a tag push is not subject to
-      branch protection, and it is what `release.yml` triggers on. A squash would orphan the tag,
-      which is why the method was not a preference on PR #457. Fix is either to teach the script
-      that path or to stop having it push, leaving the tag push as the one manual step <!-- src:session opened:2026-08-17 -->
 - [ ] `OMC-030` **P2** A vault verification can silently run against the wrong build, and one
       did. The Labs vault carries a hand-copied `main.js`, not a `scripts/link.ts` symlink, so a
       fresh `bun run build` in the repo changes nothing there until someone copies it across.
@@ -389,6 +378,53 @@ ship — `_meta` present but not an object — is ordinary shape validation the 
 
 ## Done
 
+- [x] `OMC-032` `bun run version` could not cut a release and now can, in two commands with a human
+      gate between them. It used to end in `git push -u origin main`, which `main` refuses: a ruleset
+      requires a pull request and classic branch protection requires `check-and-test` and (since
+      today) `bridge-tests`. Every tag before 2.0.0 points at a version commit pushed straight to
+      `main` (`1.0.1` → `e2ebb20`, single parent, subject `1.0.1`), so the old shape worked when
+      those were cut and the rules tightened afterwards; 2.0.0 and 2.0.1 were both cut by hand
+      around the failure. **`bun run version <part>`** now preflights, bumps the three files, makes
+      `chore/release-<version>`, commits with the version as the subject, pushes the branch and opens
+      the PR through `gh` — falling back to printing the compare URL if `gh` is absent, since the
+      branch is already pushed by then and that is the part a human cannot redo in a second.
+      **`bun run version:tag`** tags `main` and pushes the tag, which is what `release.yml` triggers
+      on. Neither command can push `main`.
+      **The tag moved to phase two, and that is the substantive change rather than a reordering.**
+      Tagging before the push meant the tag pointed at a pre-merge commit, which is the entire reason
+      the manual recovery had to insist on a **merge commit** and why a squash would have orphaned
+      the tag. Tagging after the commit is on `main` means it points at whatever `main` actually has,
+      so **either merge method is now correct** and that constraint is gone. This deliberately
+      supersedes the procedure this entry used to record.
+      **A flaw in the new design, caught before it shipped:** phase two first read the version from
+      the working copy and compared it against `HEAD`, which on a clean tree — which the preflight
+      already insists on — is the same file, so the comparison could never fail. It now reads the
+      version from the **committed** `package.json` and checks that all three files agree with it at
+      the exact commit about to be tagged, which is the shape a partial merge or a hand-edit breaks.
+      Preflights: clean tree, on `main`, and new here, `main` identical to `origin/main` — a stale
+      local `main` would have shipped the wrong tree and nothing said so before. `FORCE=true` still
+      overrides the first two.
+      **`DRY_RUN=1` prints every mutating command and runs every read-only preflight for real**, and
+      it is the only end-to-end evidence available short of a real cut. Four guards demonstrated
+      against live state rather than asserted: a dirty tree refused; a non-`main` branch refused
+      naming the branch; the full prepare path printed its seven commands and wrote nothing
+      (`git status` empty afterwards); the tag phase refused with *"Tag 2.0.1 already exists
+      locally"*; and on a `HEAD` where only `package.json` had been bumped it refused naming both
+      disagreements at once, `manifest.json` and the missing `versions.json` key.
+      Serialisation is untouched on purpose (two spaces for `package.json`/`manifest.json`, a tab for
+      `versions.json`): the 2.0.1 bump had to replicate it by hand, so drift would surface as an
+      unrelated diff in a release commit. `bump()` and `verifyCommittedVersion()` are pure and tested
+      in `scripts/version.test.ts` (14 tests), mutation-checked — a `minor` that does not zero the
+      patch turns 1 red, dropping the `package.json` comparison turns 2 red. **The module needs its
+      `import.meta.main` guard to be importable at all**: without it, the test file's own import
+      would cut a release. A CI step (`bun test scripts/`) was added because CI runs `bun test`
+      inside each package and never at the root, so the new file would otherwise have run nowhere —
+      the same trap the Python bridge suite was in this morning.
+      **Two residual gaps, named rather than papered over.** Root `scripts/` is outside both
+      packages' `tsconfig.json`, so `bun run check` does not type-check `version.ts`; it was checked
+      by hand with `tsc --strict` (clean) and nothing keeps it that way. And **the real cut is
+      untested** — every dry run is a dry run, and the next release is the first true exercise of
+      this path <!-- src:session opened:2026-08-17 closed:2026-08-17 -->
 - [x] `OMC-031` The `.mcpb` attached to every GitHub release was not the bundle this project
       ships, and is no longer attached at all. **The framing this entry opened with was wrong and
       is corrected here**: it said "two build paths produce a `.mcpb` and only one was migrated",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "format:check": "prettier --check \"packages/obsidian-plugin/src/**/*.ts\" \"packages/shared/src/**/*.ts\"",
     "dev": "bun --filter '*' dev",
     "version": "bun scripts/version.ts",
+    "version:tag": "bun scripts/version.ts --tag",
     "release": "bun --filter '*' release",
     "zip": "bun --filter '*' zip"
   },

--- a/scripts/version.test.ts
+++ b/scripts/version.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Unit tests for the pure parts of scripts/version.ts.
+ *
+ * The git and gh orchestration is NOT covered here and no attempt is made to
+ * fake it: mocking `$` would test the mock. `DRY_RUN=1 bun run version <part>`
+ * is what exercises that half, by printing every mutating command instead of
+ * running it. This file covers the two functions where a wrong answer is
+ * silent — a bump that lands on the wrong number, and a version check that
+ * says a tree is fine when it is not.
+ *
+ * Importing this module at all depends on version.ts's `import.meta.main`
+ * guard. Without it, this import would cut a release.
+ */
+import { describe, expect, test } from "bun:test";
+import { bump, releaseBranchName, verifyCommittedVersion } from "./version";
+
+describe("bump", () => {
+  test("major zeroes minor and patch", () => {
+    expect(bump("2.0.1", "major")).toBe("3.0.0");
+    expect(bump("1.4.9", "major")).toBe("2.0.0");
+  });
+
+  test("minor zeroes patch and keeps major", () => {
+    // The case that regressed once: `bun run version minor` produced a patch
+    // bump because the part was read from the wrong argv index.
+    expect(bump("2.0.1", "minor")).toBe("2.1.0");
+    expect(bump("0.27.13", "minor")).toBe("0.28.0");
+  });
+
+  test("patch increments only the patch", () => {
+    expect(bump("2.0.0", "patch")).toBe("2.0.1");
+    expect(bump("0.27.13", "patch")).toBe("0.27.14");
+  });
+
+  test("defaults to patch", () => {
+    expect(bump("2.0.1")).toBe("2.0.2");
+  });
+
+  test("throws on an unknown part rather than guessing", () => {
+    expect(() => bump("2.0.1", "mayor")).toThrow(/Invalid semver part: mayor/);
+  });
+
+  test("throws on a version that is not three numeric parts", () => {
+    expect(() => bump("2.0", "patch")).toThrow(/three-part semver/);
+    expect(() => bump("2.0.1-rc.1", "patch")).toThrow(/three-part semver/);
+  });
+});
+
+describe("releaseBranchName", () => {
+  test("is the name publish-side steps expect", () => {
+    expect(releaseBranchName("2.0.2")).toBe("chore/release-2.0.2");
+  });
+});
+
+describe("verifyCommittedVersion", () => {
+  const files = (version: string, versionsKey = version) => ({
+    pkg: JSON.stringify({ name: "x", version }),
+    manifest: JSON.stringify({ id: "x", version, minAppVersion: "1.7.2" }),
+    versions: JSON.stringify({ "1.0.1": "1.7.2", [versionsKey]: "1.7.2" }),
+  });
+
+  test("no problems when all three agree", () => {
+    expect(verifyCommittedVersion(files("2.0.2"), "2.0.2")).toEqual([]);
+  });
+
+  test("names a stale package.json", () => {
+    const f = files("2.0.2");
+    f.pkg = JSON.stringify({ name: "x", version: "2.0.1" });
+    const problems = verifyCommittedVersion(f, "2.0.2");
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/package\.json at HEAD says "2\.0\.1"/);
+  });
+
+  test("names a stale manifest.json", () => {
+    const f = files("2.0.2");
+    f.manifest = JSON.stringify({ id: "x", version: "2.0.1" });
+    const problems = verifyCommittedVersion(f, "2.0.2");
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/manifest\.json at HEAD says "2\.0\.1"/);
+  });
+
+  test("names a versions.json missing the entry", () => {
+    const problems = verifyCommittedVersion(files("2.0.2", "2.0.1"), "2.0.2");
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(
+      /versions\.json at HEAD has no entry for 2\.0\.2/,
+    );
+  });
+
+  test("reports every disagreement, not just the first", () => {
+    const problems = verifyCommittedVersion(
+      {
+        pkg: JSON.stringify({ version: "2.0.1" }),
+        manifest: JSON.stringify({ version: "1.9.9" }),
+        versions: JSON.stringify({ "1.0.1": "1.7.2" }),
+      },
+      "2.0.2",
+    );
+    expect(problems).toHaveLength(3);
+  });
+
+  test("an unparseable file is a problem, never silently fine", () => {
+    const f = files("2.0.2");
+    f.manifest = "{ not json";
+    const problems = verifyCommittedVersion(f, "2.0.2");
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/manifest\.json at HEAD does not parse/);
+  });
+
+  test("an absent version field is a mismatch, not a pass", () => {
+    const f = files("2.0.2");
+    f.pkg = JSON.stringify({ name: "x" });
+    expect(verifyCommittedVersion(f, "2.0.2")[0]).toMatch(/says undefined/);
+  });
+});

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -1,79 +1,306 @@
+/*
+ * Cuts a release, in two commands with a human gate between them.
+ *
+ *   bun run version <major|minor|patch>   prepares: bump, branch, commit, push
+ *                                         the branch, open the PR. Publishes
+ *                                         nothing.
+ *   bun run version:tag                   publishes: tags `main` and pushes
+ *                                         the tag, which is what release.yml
+ *                                         triggers on. Point of no return.
+ *
+ * It used to be one command ending in `git push -u origin main`, and `main`
+ * refuses a direct push: a ruleset requires a pull request and classic branch
+ * protection requires `check-and-test` and `bridge-tests` to pass. Every tag
+ * before 2.0.0 points at a version commit pushed straight to main, so the old
+ * shape worked when those were cut and the rules tightened afterwards. 2.0.0
+ * and 2.0.1 were both cut by hand around the failure (OMC-032).
+ *
+ * The tag is created in phase TWO, after the commit is on main, and that is
+ * the substantive change rather than a reordering. Tagging before the push
+ * meant the tag pointed at a pre-merge commit, so the manual recovery had to
+ * insist on a merge commit and a squash would have orphaned the tag. Tagging
+ * after means the tag points at whatever main actually has, so either merge
+ * method is correct and that constraint is gone.
+ *
+ * DRY_RUN=1 prints every mutating command instead of running it, and still
+ * runs every read-only preflight. It is the only way to exercise this flow
+ * without cutting a real release.
+ */
 import { $ } from "bun";
 import { readFileSync, writeFileSync } from "fs";
 
-// Check for uncommitted changes
-const status = await $`git status --porcelain`.quiet();
-if (!!status.text() && !process.env.FORCE) {
-  console.error(
-    "There are uncommitted changes. Commit them before releasing or run with FORCE=true.",
-  );
-  process.exit(1);
-}
+const DRY_RUN = !!process.env.DRY_RUN;
+const FORCE = !!process.env.FORCE;
 
-// Check if on main branch
-const currentBranch = (await $`git rev-parse --abbrev-ref HEAD`.quiet())
-  .text()
-  .trim();
-if (currentBranch !== "main" && !process.env.FORCE) {
-  console.error(
-    "Not on main branch. Switch to main before releasing or run with FORCE=true.",
-  );
-  process.exit(1);
-}
+const PKG_PATH = "./package.json";
+const MANIFEST_PATH = "./manifest.json";
+const VERSIONS_PATH = "./versions.json";
 
-// Bump project version. When invoked as `bun run version <part>`,
-// Bun's argv is [bunBinary, scriptPath, <part>] — the user-supplied
-// semver part lives at index 2, not 3. The previous code used
-// argv[3], which was always undefined under the documented call
-// convention, so every invocation silently fell back to "patch"
-// regardless of what the user typed (caught while preparing the
-// 0.3.0 cut: `bun run version minor` produced 0.2.28).
-const semverPart = Bun.argv[2] || "patch";
-const json = await Bun.file("./package.json").json();
-const [major, minor, patch] = json.version.split(".").map((s) => parseInt(s));
-json.version = bump([major, minor, patch], semverPart);
-await Bun.write("./package.json", JSON.stringify(json, null, 2) + "\n");
+export type SemverPart = "major" | "minor" | "patch";
 
-// Update manifest.json with new version and get minAppVersion
-const pluginManifestPath = "./manifest.json";
-const pluginManifest = await Bun.file(pluginManifestPath).json();
-const { minAppVersion } = pluginManifest;
-pluginManifest.version = json.version;
-await Bun.write(
-  pluginManifestPath,
-  JSON.stringify(pluginManifest, null, 2) + "\n",
-);
-
-// Update versions.json with target version and minAppVersion from manifest.json
-const pluginVersionsPath = "./versions.json";
-let versions = JSON.parse(readFileSync(pluginVersionsPath, "utf8"));
-versions[json.version] = minAppVersion;
-writeFileSync(pluginVersionsPath, JSON.stringify(versions, null, "\t") + "\n");
-
-// Commit, tag and push
-await $`git add package.json ${pluginManifestPath} ${pluginVersionsPath}`;
-await $`git commit -m ${json.version}`;
-await $`git tag ${json.version}`;
-await $`git push -u origin ${currentBranch}`;
-await $`git push origin ${json.version}`;
-
-function bump(semver: [number, number, number], semverPart = "patch") {
+export function bump(version: string, semverPart: string = "patch"): string {
+  const parts = version.split(".").map((s) => parseInt(s, 10));
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+    throw new Error(`Not a three-part semver: ${version}`);
+  }
+  const [major, minor, patch] = parts as [number, number, number];
   switch (semverPart) {
     case "major":
-      semver[0]++;
-      semver[1] = 0;
-      semver[2] = 0;
-      break;
+      return `${major + 1}.0.0`;
     case "minor":
-      semver[1]++;
-      semver[2] = 0;
-      break;
+      return `${major}.${minor + 1}.0`;
     case "patch":
-      semver[2]++;
-      break;
+      return `${major}.${minor}.${patch + 1}`;
     default:
       throw new Error(`Invalid semver part: ${semverPart}`);
   }
+}
 
-  return semver.join(".");
+export function releaseBranchName(version: string): string {
+  return `chore/release-${version}`;
+}
+
+/**
+ * Every way the three version files can disagree with `version`, as
+ * human-readable lines. Empty means they agree.
+ *
+ * Phase two feeds this the files as COMMITTED at HEAD, not as they sit on
+ * disk, which is the check that makes tagging the wrong commit impossible.
+ * Nothing equivalent existed before: the old script tagged whatever HEAD was
+ * without ever looking at what HEAD contained.
+ */
+export function verifyCommittedVersion(
+  files: { pkg: string; manifest: string; versions: string },
+  version: string,
+): string[] {
+  const problems: string[] = [];
+  const read = (
+    label: string,
+    text: string,
+  ): Record<string, unknown> | null => {
+    try {
+      return JSON.parse(text) as Record<string, unknown>;
+    } catch (err) {
+      problems.push(`${label} at HEAD does not parse as JSON: ${String(err)}`);
+      return null;
+    }
+  };
+  const pkg = read("package.json", files.pkg);
+  if (pkg && pkg.version !== version) {
+    problems.push(
+      `package.json at HEAD says ${JSON.stringify(pkg.version)}, expected ${version}`,
+    );
+  }
+  const manifest = read("manifest.json", files.manifest);
+  if (manifest && manifest.version !== version) {
+    problems.push(
+      `manifest.json at HEAD says ${JSON.stringify(manifest.version)}, expected ${version}`,
+    );
+  }
+  const versions = read("versions.json", files.versions);
+  if (versions && !(version in versions)) {
+    problems.push(`versions.json at HEAD has no entry for ${version}`);
+  }
+  return problems;
+}
+
+function die(message: string): never {
+  console.error(`\n✗ ${message}\n`);
+  process.exit(1);
+}
+
+/** Runs a mutating command, or prints it under DRY_RUN. */
+async function run(argv: string[]): Promise<void> {
+  if (DRY_RUN) {
+    console.log(`  would run: ${argv.join(" ")}`);
+    return;
+  }
+  const [cmd, ...args] = argv;
+  await $`${cmd} ${args}`;
+}
+
+async function gitText(argv: string[]): Promise<string> {
+  const [cmd, ...args] = argv;
+  return (await $`${cmd} ${args}`.quiet()).text().trim();
+}
+
+/**
+ * The preflight both phases share. Read-only, so it runs for real even under
+ * DRY_RUN — a dry run that skipped the checks would prove nothing about the
+ * real one.
+ *
+ * The origin/main comparison is new. A stale local main would have based a
+ * release on old code, and the old script had nothing to say about it.
+ */
+async function assertReleasableMain(): Promise<void> {
+  const status = await gitText(["git", "status", "--porcelain"]);
+  if (status && !FORCE) {
+    die(
+      "There are uncommitted changes. Commit them before releasing, or run with FORCE=true.",
+    );
+  }
+  const branch = await gitText(["git", "rev-parse", "--abbrev-ref", "HEAD"]);
+  if (branch !== "main" && !FORCE) {
+    die(
+      `On branch ${branch}, not main. Switch to main, or run with FORCE=true.`,
+    );
+  }
+  await $`git fetch origin main --tags`.quiet();
+  const local = await gitText(["git", "rev-parse", "HEAD"]);
+  const remote = await gitText(["git", "rev-parse", "origin/main"]);
+  if (local !== remote && !FORCE) {
+    die(
+      `Local main (${local.slice(0, 7)}) is not origin/main (${remote.slice(0, 7)}).\n` +
+        `  Pull or push first — releasing from a stale main ships the wrong tree.\n` +
+        `  Override with FORCE=true only if you know exactly why.`,
+    );
+  }
+}
+
+async function prepare(semverPart: string): Promise<void> {
+  await assertReleasableMain();
+
+  const pkg = await Bun.file(PKG_PATH).json();
+  const version = bump(pkg.version, semverPart);
+  const branch = releaseBranchName(version);
+
+  const existing = await gitText(["git", "tag", "-l", version]);
+  if (existing) {
+    die(`Tag ${version} already exists locally. Nothing to prepare.`);
+  }
+
+  console.log(`\nPreparing ${pkg.version} → ${version} (${semverPart})\n`);
+
+  // Serialisation is load-bearing and deliberately unchanged: two spaces plus
+  // a trailing newline for package.json and manifest.json, a tab for
+  // versions.json. The 2.0.1 bump had to be replicated by hand and any drift
+  // here would have shown up as an unrelated diff in the release commit.
+  pkg.version = version;
+  if (!DRY_RUN) {
+    await Bun.write(PKG_PATH, JSON.stringify(pkg, null, 2) + "\n");
+  }
+
+  const manifest = await Bun.file(MANIFEST_PATH).json();
+  const { minAppVersion } = manifest;
+  manifest.version = version;
+  if (!DRY_RUN) {
+    await Bun.write(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n");
+  }
+
+  const versions = JSON.parse(readFileSync(VERSIONS_PATH, "utf8"));
+  versions[version] = minAppVersion;
+  if (!DRY_RUN) {
+    writeFileSync(VERSIONS_PATH, JSON.stringify(versions, null, "\t") + "\n");
+  }
+  console.log(
+    `  ${DRY_RUN ? "would write" : "wrote"} package.json, manifest.json, versions.json (minAppVersion ${minAppVersion})`,
+  );
+
+  await run(["git", "checkout", "-b", branch]);
+  await run(["git", "add", PKG_PATH, MANIFEST_PATH, VERSIONS_PATH]);
+  await run(["git", "commit", "-m", version]);
+  await run(["git", "push", "-u", "origin", branch]);
+
+  // gh is not a hard dependency. The branch is already pushed by this point,
+  // which is the part that cannot be redone by hand in a second; opening a PR
+  // from a URL can.
+  const hasGh = await Bun.which("gh");
+  if (hasGh) {
+    await run([
+      "gh",
+      "pr",
+      "create",
+      "--title",
+      `chore(release): ${version}`,
+      "--body",
+      `Version bump only: \`package.json\`, \`manifest.json\`, \`versions.json\`.\n\n` +
+        `Merge this once CI is green, pull \`main\`, then run \`bun run version:tag\` to tag and publish. ` +
+        `Either merge method is fine — the tag is created after the merge, so it points at whatever \`main\` has.`,
+    ]);
+  } else {
+    console.log(
+      `  gh not found — open the PR by hand:\n` +
+        `    https://github.com/istefox/obsidian-mcp-connector/compare/${branch}?expand=1`,
+    );
+  }
+
+  console.log(
+    `\n${DRY_RUN ? "[dry run] " : ""}Prepared. Nothing is published yet.\n` +
+      `  1. wait for CI, then merge the PR (squash or merge commit, either is correct)\n` +
+      `  2. git checkout main && git pull --ff-only\n` +
+      `  3. bun run version:tag        ← tags ${version} and pushes it; release.yml runs on that\n`,
+  );
+}
+
+async function tagAndPublish(): Promise<void> {
+  await assertReleasableMain();
+
+  // Read from the COMMITTED package.json, not from disk. Taking it from disk
+  // and then comparing it against HEAD would be tautological on a clean tree,
+  // which the preflight above has already insisted on — the two are the same
+  // file. What this pair of steps genuinely buys is the agreement of the three
+  // files with each other at the exact commit about to be tagged, which a
+  // partial merge or a hand-edit can break.
+  const committedPkg = await gitText(["git", "show", "HEAD:package.json"]);
+  let version: string;
+  try {
+    version = JSON.parse(committedPkg).version;
+  } catch (err) {
+    die(`package.json at HEAD does not parse as JSON: ${String(err)}`);
+  }
+  if (typeof version !== "string" || version === "") {
+    die("package.json at HEAD has no version string. Nothing to tag.");
+  }
+
+  const problems = verifyCommittedVersion(
+    {
+      pkg: committedPkg,
+      manifest: await gitText(["git", "show", "HEAD:manifest.json"]),
+      versions: await gitText(["git", "show", "HEAD:versions.json"]),
+    },
+    version,
+  );
+  if (problems.length > 0) {
+    die(
+      `main's committed tree does not agree on ${version}:\n` +
+        problems.map((p) => `  - ${p}`).join("\n") +
+        `\n  A partial merge or a hand-edit leaves exactly this shape.`,
+    );
+  }
+
+  if (await gitText(["git", "tag", "-l", version])) {
+    die(`Tag ${version} already exists locally.`);
+  }
+  if (await gitText(["git", "ls-remote", "--tags", "origin", version])) {
+    die(`Tag ${version} already exists on origin. A release cannot be re-cut.`);
+  }
+
+  console.log(
+    `\nTagging ${version} at ${(await gitText(["git", "rev-parse", "HEAD"])).slice(0, 7)}\n`,
+  );
+  await run(["git", "tag", version]);
+  await run(["git", "push", "origin", version]);
+  console.log(
+    `\n${DRY_RUN ? "[dry run] " : ""}${DRY_RUN ? "Would publish" : "Published"} ${version}.` +
+      `${DRY_RUN ? "" : " That was the point of no return."}\n` +
+      `  release.yml builds, attests and publishes off the tag. Watch it:\n` +
+      `    gh run watch --exit-status\n`,
+  );
+}
+
+// `bun run version <part>` gives Bun an argv of [bunBinary, scriptPath, <part>],
+// so the user-supplied part is at index 2. It used to read argv[3], which is
+// always undefined under that call convention, so every invocation silently
+// fell back to "patch" — caught while preparing the 0.3.0 cut, where
+// `bun run version minor` produced 0.2.28.
+// `import.meta.main` is not decoration. Without it, importing this module to
+// unit-test its pure functions would CUT A RELEASE, because the dispatch below
+// is top-level.
+if (import.meta.main) {
+  const arg = Bun.argv[2];
+  if (arg === "--tag") {
+    await tagAndPublish();
+  } else {
+    await prepare(arg || "patch");
+  }
 }


### PR DESCRIPTION
Closes `OMC-032`. No release is cut by this.

## The problem

`scripts/version.ts` ended in `git push -u origin main`, and `main` refuses a direct push: a ruleset requires a pull request, and classic branch protection requires `check-and-test` and (since #463) `bridge-tests`. Every tag before 2.0.0 points at a version commit pushed straight to `main` (`1.0.1` → `e2ebb20`, single parent, subject `1.0.1`), so the old shape worked when those were cut and the rules tightened afterwards. 2.0.0 and 2.0.1 were both cut by hand around the failure.

## The shape

```
bun run version <part>   preflight, bump the three files, branch, commit,
                         push the branch, open the PR. Publishes nothing.
bun run version:tag      tag main, push the tag. release.yml runs on that.
```

Neither command can push `main`. `gh` is not a hard dependency: if it is missing, phase one prints the compare URL, because the branch is already pushed by then and that is the part a human cannot redo in a second.

## The tag moved to phase two, and that is the substantive change

Tagging *before* the push meant the tag pointed at a pre-merge commit. That is the entire reason the manual recovery had to insist on a **merge commit**, and why a squash would have orphaned the tag. Tagging *after* the commit is on `main` means it points at whatever `main` actually has, so **either merge method is now correct**. This deliberately supersedes the procedure `OMC-032` used to record.

## A flaw in the new design, caught before shipping

Phase two first read the version from the working copy and compared it against `HEAD`. On a clean tree — which the preflight already insists on — those are the same file, so the comparison could never fail. It now reads the version from the **committed** `package.json` and checks that all three files agree with it at the exact commit about to be tagged, which is the shape a partial merge or a hand-edit breaks.

## Verified against live state, not asserted

`DRY_RUN=1` prints every mutating command and runs every read-only preflight for real. Four guards were demonstrated:

| | |
|---|---|
| Dirty tree | refused |
| Non-`main` branch | refused, naming the branch |
| Full prepare path | printed its seven commands, wrote nothing (`git status` empty after) |
| Tag phase, real git state | refused: *"Tag 2.0.1 already exists locally"* |
| `HEAD` with only `package.json` bumped | refused naming **both** disagreements at once |

Plus: `check` 0 errors · 1863 tests pass · `bun test scripts/` 134 pass · `format:check` clean · `check:svelte` 0 errors · `test:mcpb` green · `python3 -m unittest` 32 OK. Both pure functions mutation-checked (a `minor` that does not zero the patch turns 1 red; dropping the `package.json` comparison turns 2 red).

## Details worth a reviewer's eye

- **`import.meta.main` is load-bearing.** Without it, the test file's own import would cut a release, because the dispatch is top-level.
- **Serialisation is untouched on purpose**: two spaces for `package.json`/`manifest.json`, a tab for `versions.json`. The 2.0.1 bump had to replicate it by hand, so drift would surface as an unrelated diff in a release commit.
- **The new CI step exists because CI runs `bun test` inside each package and never at the root**, so `scripts/version.test.ts` would otherwise have run nowhere — the same trap the Python bridge suite was in this morning. The path filter also re-matches the two suites under `packages/*/scripts/`, about a second of CI.

## Not covered

- Root `scripts/` is outside both packages' `tsconfig.json`, so `bun run check` does **not** type-check `version.ts`. Checked by hand with `tsc --strict` (clean); nothing keeps it that way.
- **The real cut is untested.** Every dry run is a dry run. The next release is the first true exercise of this path, and the ledger entry says so.