### PR TITLE
docs(todo): record the #465 prior-art survey and the #416 trigger re-check

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,9 +47,17 @@ Neither reaches a user; both cost real hours when they bite, and one already did
   and constraint 1's opt-in makes the protection optional, which is not protection. **Both
   corrections are now on the issue** (2026-08-17), with the file:line evidence and addressed to
   @Madulone, since #445 declares itself the spec for whoever prototypes it.
-- `#465` — the brief's declared gap: no ecosystem survey of how other MCP servers handle
-  read-then-write staleness. Informs #445's ADR, blocks nothing. Established while filing it: the
-  MCP SDK v2.0.0 defines no write-precondition mechanism at all.
+- `#465` — **survey done 2026-08-17, findings on the issue.** Prior art exists: `hashfile-mcp`
+  (`file_hash` parameter, token in a text footer, whole-file plus per-line, refuses) and
+  `stale-write-guard-fs` (a **tracked read** holding the view server-side, a typed `stale_view` deny
+  carrying `recover: reacquire`, **mandatory not opt-in**, and it explicitly catches edits made
+  outside the tool surface). Two of the brainstorm's first-principles conclusions now have
+  independent support: opt-in is the wrong default, and a server-held view is an ordinary pattern
+  rather than an exotic one. **Nobody merges** — both refuse — so the pre-mortem's fear about
+  merging prose is neither confirmed nor refuted by anyone's shipped experience. **Nobody uses
+  `_meta`** for the token either, so #445's ADR has to say why it diverges. The spec side is now
+  checked from both ends: no SEP and no issue in `modelcontextprotocol/modelcontextprotocol` about
+  write preconditions, matching the SDK finding.
 
 ### Not on any track
 
@@ -134,7 +142,7 @@ _none_
 
 ## Parked — external trigger, nothing to do until it fires
 
-- [ ] `OMC-010` **P3** #416 MCP Tasks: watch item only, no client in the support matrix declares `io.modelcontextprotocol/tasks` yet. The MCP Apps half moved to OMC-016. Re-check the matrix when the tiering page's client matrix moves <!-- src:session opened:2026-08-05 updated:2026-08-07 -->
+- [ ] `OMC-010` **P3** #416 MCP Tasks: watch item only. **Trigger re-checked 2026-08-17 and it has NOT fired, in a sharper way than this entry assumed.** `modelcontextprotocol.io/extensions/client-matrix` tracks three official extensions — MCP Apps, OAuth Client Credentials, Enterprise-Managed Authorization — and **Tasks is not among them**: no column, no row, and the Tasks overview page points back at that same matrix. So it is not "no client declares it yet", it is "nobody's support is recorded anywhere". Implementing now would mean building against a spec no listed client is known to speak, with no way to verify one end-to-end call. Watch condition sharpened from "when the tiering page's client matrix moves" to **a Tasks column appearing there with at least one client checked**. The MCP Apps half moved to OMC-016 and shipped in 2.0.0 — and that matrix now lists **eleven** clients supporting `io.modelcontextprotocol/ui` (Claude web, Claude Desktop, VS Code Copilot, M365 Copilot, Goose, Postman, MCPJam, ChatGPT, Cursor, Archestra.AI, PostHog Code), against the **one** `R-18` verified. Both of `R-18`'s host findings are host-specific: `_meta` forwarding and the refusal of `obsidian://`. On a client that follows the scheme the click would open the note and the URL encoding — recorded as untested by any means — would finally be exercised <!-- src:session opened:2026-08-05 updated:2026-08-17 -->
 
 ## Blocked / Decisions Needed
 


### PR DESCRIPTION
Two external-state checks that could be done without a decision from anyone, both of which had an answer. **No code changed.**

## #465 — the prior-art gap, surveyed

Prior art exists, and the full findings are [on the issue](https://github.com/istefox/obsidian-mcp-connector/issues/465).

- **[`hashfile-mcp`](https://github.com/mrorigo/hashfile-mcp)** — a `file_hash` parameter on the write, the token returned in a **text footer** after the content, hashed at two levels (whole-file plus per-line), refuses on mismatch.
- **[`stale-write-guard-fs`](https://agent-coherence.dev/mcp/)** — a **tracked read** that holds the agent's view server-side, a typed **`stale_view` deny carrying `recover: reacquire`**, **mandatory rather than opt-in**, and it explicitly catches edits made outside the tool surface — a human, a formatter — which is the case #445 predicts will dominate.

**Two of the brainstorm's first-principles conclusions now have independent support**, rather than only an argument: that opt-in is the wrong default, and that a server-held view is an ordinary pattern rather than the exotic one this project's stateless transport made it feel like.

**Two negatives worth as much as the positives.** Nobody merges — both refuse — so the pre-mortem's leading risk, a silent bad merge on Markdown, is neither confirmed nor refuted by anyone's shipped experience. And nobody carries the token in `_meta`, so #445's ADR has to argue for that seam rather than assume it is idiomatic.

The spec side is now checked from both ends: no SEP and no issue in `modelcontextprotocol/modelcontextprotocol` about write preconditions at the tool level, which matches the SDK finding recorded when #465 was filed. The ETag hits there are all HTTP-transport work (SEP-1597, SEP-1442, SEP-1612).

## #416 / OMC-010 — the trigger has not fired, more sharply than assumed

The [extension support matrix](https://modelcontextprotocol.io/extensions/client-matrix) tracks three official extensions — MCP Apps, OAuth Client Credentials, Enterprise-Managed Authorization. **Tasks is not among them: no column, no row**, and the Tasks overview page points back at that same matrix.

So the state is not "no client declares Tasks yet" but "nobody's support is recorded anywhere". Watch condition sharpened accordingly, from *"when the tiering page's client matrix moves"* to **a Tasks column appearing there with at least one client checked**.

## A finding nobody asked for, and the reason this PR is worth reading

That same matrix lists **eleven** clients supporting `io.modelcontextprotocol/ui`: Claude (web), Claude Desktop, VS Code GitHub Copilot, Microsoft 365 Copilot, Goose, Postman, MCPJam, ChatGPT, Cursor, Archestra.AI, PostHog Code.

`R-18` verified the `ui://` view against **one** of them. Both of its host findings are host-specific and should not be read as properties of this server:

- the host **forwards the tool result's `_meta`** — which is what retired ADR-0018's Alternative D
- the host **refuses the `obsidian://` scheme**, so a row click degrades to revealing the vault-relative path

On a client that does follow the scheme, the click would open the note, and the URL encoding of the path — which `R-18` recorded as untested by any means — would finally be exercised.

## Limits, stated

Two third-party projects are not a convention. Their documentation was read, not their source, so the field names are as documented rather than as verified in code. Nothing here was measured against a vault.