### PR TITLE
feat(release): refuse a cut whose CHANGELOG is not ready

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
-<!-- project-tasks: prefix=OMC lastId=35 -->
+<!-- project-tasks: prefix=OMC lastId=36 -->
 # PROJECT TASKS
 
-Updated: 2026-08-17 · Shipped: **2.1.0** · Open: 5 (P1: 0) · In review: 0 · In progress: 0 · Next release: none scheduled · Open items with no GitHub issue: 2 (both by design)
+Updated: 2026-08-17 · Shipped: **2.1.0** · Open: 4 (P1: 0) · In review: 0 · In progress: 0 · Next release: none scheduled · Open items with no GitHub issue: 2 (both by design)
 
 ## Roadmap — after 2.0
 
@@ -65,10 +65,9 @@ None of these reaches a user; they cost real hours when they bite, and two alrea
   failed all four assertions against an Aug 11 `main.js` and read as a defect in new code.
 - `OMC-029` — measured figures written into comments are guarded by nothing. Deliberately has **no**
   mechanical fix and no issue: the defence is procedural and belongs in the habit.
-- `#476` — `version.ts` cuts a release without touching `CHANGELOG.md`. Found during the `2.1.0` cut
-  and issue-only for now, since nobody has committed to fixing it. The proposed answer is a refusal
-  at phase one when `[Unreleased]` is non-empty, rather than generating the heading: the prose under
-  it is written by a human anyway, and this repo's bias is to refuse rather than guess.
+- `OMC-036` / `#476` — **closed 2026-08-17**, same day it was filed. `version.ts` now refuses a cut
+  whose `CHANGELOG.md` is not ready, and tolerates that one file being uncommitted so the notes and
+  the bump land in the same commit.
 
 ### Track 3 — design. Cleared 2026-08-17, same day it was written down
 
@@ -108,7 +107,7 @@ section exists so the next drift is visible rather than rediscovered.
 | `OMC-029` | — | ledger-only **on purpose**: no actionable close condition, the defence is procedural |
 | `OMC-035` | `#445` | **both closed 2026-08-17** — `ADR-0019` decided it, `ffca69f` shipped it, the issue closed with what diverged from its own proposal |
 | — | `#465` | **survey done and consumed by `ADR-0019`** — closed 2026-08-17 |
-| — | `#476` | issue-only **for now**: found during the `2.1.0` cut, nobody has committed to fixing it, so no ledger id yet by this table's own rule |
+| `OMC-036` | `#476` | **both closed 2026-08-17** — the guard ships with the dirty-`CHANGELOG.md` allowance the issue's proposal turned out to need |
 | — | `#427` | **closed 2026-08-17** — it had been open a week after 2.0.0 shipped and `R-18` verified it |
 
 **Which surface gets what.** An issue is for anything a contributor could hit, pick up, or reasonably
@@ -496,6 +495,28 @@ ship — `_meta` present but not an object — is ordinary shape validation the 
 
 ## Done
 
+- [x] `OMC-036` #476 `version.ts` cuts a release without touching `CHANGELOG.md`. Found during the
+      `2.1.0` cut, hours after that cut nearly shipped its own notes under `[Unreleased]` with every
+      check green — nothing in the gate or in `release.yml` reads that file.
+      **The issue's own proposal was not enough, and implementing it is what showed why.** A pure
+      refusal collides with phase one's clean-tree preflight: the heading would have to land on
+      `main` first, through a PR that exists only to move it. So the guard ships with the one
+      allowance that makes it usable — `CHANGELOG.md` is the single path phase one tolerates as
+      uncommitted, and it rides the release commit. Phase two passes no allowance and stays strict,
+      because it reads the committed tree to decide what to tag.
+      Two exported pure functions, tested the way `verifyCommittedVersion` is: `checkChangelogReady`
+      reports **every** problem rather than the first (missing `[Unreleased]`, notes left under it,
+      no heading for the version being cut, a dated heading with nothing under it), and
+      `blockingStatusPaths` decides which uncommitted paths block. Version labels are matched
+      exactly, so `2.1.1` is not satisfied by a `## [2.1.10]` heading — the trap an unescaped-dot
+      regex would have walked into.
+      **No date validation and no generated prose**, on purpose: the notes are written by a human
+      every time and this repo refuses rather than guesses.
+      Verified against the real `CHANGELOG.md` rather than only fixtures: cutting `2.1.1` today is
+      refused for the missing heading, cutting `2.1.0` passes, notes left under `[Unreleased]` are
+      refused with **both** problems named. Mutation-checked both ways — a `checkChangelogReady` that
+      never refuses turns 6 tests red, an inert `blockingStatusPaths` turns 3 red. Suite `scripts/`
+      134 → 148.
 - [x] `OMC-035` #445 Write preconditions across separate MCP calls. **Decided in `ADR-0019` and
       implemented the same day**, after the shape had been recorded as unscheduled — the schedule
       changed, not the design. `patch_vault_file` and `patch_active_file` accept an optional

--- a/scripts/version.test.ts
+++ b/scripts/version.test.ts
@@ -12,7 +12,13 @@
  * guard. Without it, this import would cut a release.
  */
 import { describe, expect, test } from "bun:test";
-import { bump, releaseBranchName, verifyCommittedVersion } from "./version";
+import {
+  blockingStatusPaths,
+  bump,
+  checkChangelogReady,
+  releaseBranchName,
+  verifyCommittedVersion,
+} from "./version";
 
 describe("bump", () => {
   test("major zeroes minor and patch", () => {
@@ -111,5 +117,131 @@ describe("verifyCommittedVersion", () => {
     const f = files("2.0.2");
     f.pkg = JSON.stringify({ name: "x" });
     expect(verifyCommittedVersion(f, "2.0.2")[0]).toMatch(/says undefined/);
+  });
+});
+
+describe("checkChangelogReady", () => {
+  const ready = [
+    "# Changelog",
+    "",
+    "## [Unreleased]",
+    "",
+    "## [2.1.1] — 2026-08-17",
+    "",
+    "### Fixed",
+    "",
+    "- Something.",
+    "",
+    "## [2.1.0] — 2026-08-17",
+    "",
+    "- Older.",
+    "",
+  ].join("\n");
+
+  test("no problems when the notes have been moved", () => {
+    expect(checkChangelogReady(ready, "2.1.1")).toEqual([]);
+  });
+
+  test("catches notes left under Unreleased, quoting the first line", () => {
+    // The 2.1.0 near-miss exactly: the content was written, under the wrong
+    // heading, and every other check in the repo stayed green.
+    const stale = ready.replace(
+      "## [Unreleased]\n",
+      "## [Unreleased]\n\n### Fixed\n\n- Something.\n",
+    );
+    const problems = checkChangelogReady(stale, "2.1.1");
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/still has content under/);
+    expect(problems[0]).toMatch(/### Fixed/);
+  });
+
+  test("catches a missing heading for the version being cut", () => {
+    const problems = checkChangelogReady(ready, "2.2.0");
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/no `## \[2\.2\.0\]` heading/);
+  });
+
+  test("a dated heading with nothing under it is not a pass", () => {
+    const empty = ready.replace("\n### Fixed\n\n- Something.\n", "\n");
+    const problems = checkChangelogReady(empty, "2.1.1");
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/section is empty/);
+  });
+
+  test("a missing Unreleased heading is a problem, never silently fine", () => {
+    // The check cannot do its job against a file it cannot read, and passing
+    // there is the failure mode it exists to prevent.
+    const problems = checkChangelogReady(
+      "# Changelog\n\n## [2.1.1] — 2026-08-17\n\n- Something.\n",
+      "2.1.1",
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/no `## \[Unreleased\]` heading/);
+  });
+
+  test("reports every problem, not just the first", () => {
+    const problems = checkChangelogReady(
+      "# Changelog\n\n## [Unreleased]\n\n- Left behind.\n",
+      "2.1.1",
+    );
+    expect(problems).toHaveLength(2);
+  });
+
+  test("whitespace under Unreleased is empty, not content", () => {
+    const padded = ready.replace(
+      "## [Unreleased]\n",
+      "## [Unreleased]\n\n  \n",
+    );
+    expect(checkChangelogReady(padded, "2.1.1")).toEqual([]);
+  });
+
+  test("the version label is matched exactly, not as a prefix", () => {
+    // `2.1.1` must not be satisfied by a `## [2.1.10]` heading, which a naive
+    // substring or unescaped-dot regex would accept.
+    const other = ready.replace("## [2.1.1] —", "## [2.1.10] —");
+    expect(checkChangelogReady(other, "2.1.1")[0]).toMatch(
+      /no `## \[2\.1\.1\]` heading/,
+    );
+  });
+});
+
+describe("blockingStatusPaths", () => {
+  test("empty status blocks nothing", () => {
+    expect(blockingStatusPaths("", ["CHANGELOG.md"])).toEqual([]);
+  });
+
+  test("the allowed path does not block", () => {
+    expect(blockingStatusPaths(" M CHANGELOG.md", ["CHANGELOG.md"])).toEqual(
+      [],
+    );
+  });
+
+  test("anything else blocks, and is named", () => {
+    const blocking = blockingStatusPaths(
+      " M CHANGELOG.md\n M src/main.ts\n?? notes.txt",
+      ["CHANGELOG.md"],
+    );
+    expect(blocking).toEqual(["src/main.ts", "notes.txt"]);
+  });
+
+  test("with no allowance every dirty path blocks", () => {
+    // Phase two's call, where a dirty tree means the tag would not describe
+    // what was checked.
+    expect(blockingStatusPaths(" M CHANGELOG.md")).toEqual(["CHANGELOG.md"]);
+  });
+
+  test("a rename is judged by its destination", () => {
+    expect(
+      blockingStatusPaths("R  old.md -> CHANGELOG.md", ["CHANGELOG.md"]),
+    ).toEqual([]);
+    expect(
+      blockingStatusPaths("R  CHANGELOG.md -> notes.md", ["CHANGELOG.md"]),
+    ).toEqual(["notes.md"]);
+  });
+
+  test("a quoted path is unquoted before comparison", () => {
+    expect(blockingStatusPaths(' M "CHANGELOG.md"', ["CHANGELOG.md"])).toEqual(
+      [],
+    );
   });
 });

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -22,6 +22,11 @@
  * after means the tag points at whatever main actually has, so either merge
  * method is correct and that constraint is gone.
  *
+ * Phase one also refuses a cut whose CHANGELOG.md is not ready (#476), and is
+ * the reason CHANGELOG.md is the one path it tolerates as uncommitted: the
+ * release notes are moved and the version bumped in the same commit, rather
+ * than in a PR of their own that exists only to relocate a heading.
+ *
  * DRY_RUN=1 prints every mutating command instead of running it, and still
  * runs every read-only preflight. It is the only way to exercise this flow
  * without cutting a real release.
@@ -35,6 +40,14 @@ const FORCE = !!process.env.FORCE;
 const PKG_PATH = "./package.json";
 const MANIFEST_PATH = "./manifest.json";
 const VERSIONS_PATH = "./versions.json";
+const CHANGELOG_PATH = "./CHANGELOG.md";
+
+/**
+ * The one path phase one tolerates as uncommitted. See
+ * {@link checkChangelogReady} for why the release notes are edited in the same
+ * breath as the cut rather than in a PR of their own.
+ */
+const CHANGELOG_STATUS_PATH = "CHANGELOG.md";
 
 export type SemverPart = "major" | "minor" | "patch";
 
@@ -104,6 +117,118 @@ export function verifyCommittedVersion(
   return problems;
 }
 
+/**
+ * The `## [label]` headings in a changelog, with the body lines under each.
+ *
+ * Structural rather than a regex built from the version string, which contains
+ * dots: the label is whatever sits between the first `[` and the first `]`, and
+ * a section runs to the next such heading or to the end of the file.
+ */
+function changelogSections(text: string): Map<string, string[]> {
+  const lines = text.split("\n");
+  const sections = new Map<string, string[]>();
+  let current: string[] | null = null;
+  for (const line of lines) {
+    if (line.startsWith("## [")) {
+      const end = line.indexOf("]");
+      const label = end === -1 ? line.slice(4) : line.slice(4, end);
+      current = [];
+      // First heading wins on a duplicate label. A file with two of them is
+      // already malformed and this function is not the place to say so.
+      if (!sections.has(label)) sections.set(label, current);
+      else current = sections.get(label)!;
+      continue;
+    }
+    if (current) current.push(line);
+  }
+  return sections;
+}
+
+/**
+ * Every reason `CHANGELOG.md` is not ready for `version` to be cut, as
+ * human-readable lines. Empty means it is ready.
+ *
+ * This exists because nothing else in the repo reads this file. `bun run
+ * check`, the whole suite, `format:check`, both CI jobs and `release.yml` all
+ * pass with the released changes still sitting under `## [Unreleased]`, so a
+ * release can publish with its own notes in the wrong section and no signal
+ * anywhere (#476). It nearly happened on the 2.1.0 cut, caught only because a
+ * dry run listed three filenames and the fourth was missing.
+ *
+ * It refuses rather than writing the heading itself. The prose under a release
+ * heading is written by a human every time, and this repo's bias is to refuse
+ * rather than to guess.
+ *
+ * The date is deliberately not validated. The convention is
+ * `## [X.Y.Z] — YYYY-MM-DD`, but policing prose formatting buys little and
+ * would refuse honest cuts; the version label is the part that carries meaning.
+ */
+export function checkChangelogReady(text: string, version: string): string[] {
+  const problems: string[] = [];
+  const sections = changelogSections(text);
+  const nonEmpty = (lines: string[]): string[] =>
+    lines.filter((l) => l.trim() !== "");
+
+  const unreleased = sections.get("Unreleased");
+  if (!unreleased) {
+    // Not a pass. A file this check cannot read is the failure mode it exists
+    // to prevent, not an exemption from it.
+    problems.push(
+      "CHANGELOG.md has no `## [Unreleased]` heading, so this check cannot tell whether the release notes were moved.",
+    );
+  } else {
+    const left = nonEmpty(unreleased);
+    if (left.length > 0) {
+      problems.push(
+        `CHANGELOG.md still has content under \`## [Unreleased]\`, starting: ${left[0]!.trim()}\n` +
+          `    Move it under a \`## [${version}] — <date>\` heading.`,
+      );
+    }
+  }
+
+  const released = sections.get(version);
+  if (!released) {
+    problems.push(
+      `CHANGELOG.md has no \`## [${version}]\` heading. The release would publish with no entry of its own.`,
+    );
+  } else if (nonEmpty(released).length === 0) {
+    problems.push(
+      `CHANGELOG.md's \`## [${version}]\` section is empty. A dated heading with nothing under it is as wrong as notes left under Unreleased.`,
+    );
+  }
+
+  return problems;
+}
+
+/**
+ * The uncommitted paths that should block a release, given the ones this phase
+ * tolerates.
+ *
+ * Exported and tested because "which uncommitted files block a release" is
+ * exactly the kind of predicate that is wrong silently: too permissive and a
+ * cut carries someone's work in progress, too strict and the changelog cannot
+ * be edited in the same breath as the bump.
+ */
+export function blockingStatusPaths(
+  porcelain: string,
+  allowed: string[] = [],
+): string[] {
+  const allow = new Set(allowed);
+  return porcelain
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "")
+    .map((line) => {
+      // `XY path`, with renames and copies spelled `XY old -> new`. The
+      // destination is the path that is actually dirty.
+      const path = line.slice(2).trim();
+      const arrow = path.indexOf(" -> ");
+      return arrow === -1 ? path : path.slice(arrow + 4);
+    })
+    .map((path) => path.replace(/^"|"$/g, ""))
+    .filter((path) => !allow.has(path));
+}
+
 function die(message: string): never {
   console.error(`\n✗ ${message}\n`);
   process.exit(1);
@@ -131,12 +256,19 @@ async function gitText(argv: string[]): Promise<string> {
  *
  * The origin/main comparison is new. A stale local main would have based a
  * release on old code, and the old script had nothing to say about it.
+ *
+ * `allowDirty` is how phase one lets `CHANGELOG.md` be edited in the same
+ * breath as the bump. Phase TWO passes nothing and stays strict: it reads the
+ * committed tree to decide what to tag, so a dirty file there would mean the
+ * tag does not describe what was checked.
  */
-async function assertReleasableMain(): Promise<void> {
+async function assertReleasableMain(allowDirty: string[] = []): Promise<void> {
   const status = await gitText(["git", "status", "--porcelain"]);
-  if (status && !FORCE) {
+  const blocking = blockingStatusPaths(status, allowDirty);
+  if (blocking.length > 0 && !FORCE) {
     die(
-      "There are uncommitted changes. Commit them before releasing, or run with FORCE=true.",
+      `There are uncommitted changes. Commit them before releasing, or run with FORCE=true.\n` +
+        blocking.map((p) => `    ${p}`).join("\n"),
     );
   }
   const branch = await gitText(["git", "rev-parse", "--abbrev-ref", "HEAD"]);
@@ -158,7 +290,7 @@ async function assertReleasableMain(): Promise<void> {
 }
 
 async function prepare(semverPart: string): Promise<void> {
-  await assertReleasableMain();
+  await assertReleasableMain([CHANGELOG_STATUS_PATH]);
 
   const pkg = await Bun.file(PKG_PATH).json();
   const version = bump(pkg.version, semverPart);
@@ -167,6 +299,28 @@ async function prepare(semverPart: string): Promise<void> {
   const existing = await gitText(["git", "tag", "-l", version]);
   if (existing) {
     die(`Tag ${version} already exists locally. Nothing to prepare.`);
+  }
+
+  // Read-only, so it runs for real under DRY_RUN like every other preflight. A
+  // dry run that skipped it would prove nothing about the real one.
+  const changelogProblems = checkChangelogReady(
+    readFileSync(CHANGELOG_PATH, "utf8"),
+    version,
+  );
+  if (changelogProblems.length > 0) {
+    if (FORCE) {
+      console.warn(
+        `\n! CHANGELOG.md is not ready and FORCE=true is set. Continuing:\n` +
+          changelogProblems.map((p) => `    ${p}`).join("\n"),
+      );
+    } else {
+      die(
+        `CHANGELOG.md is not ready for ${version}:\n` +
+          changelogProblems.map((p) => `    ${p}`).join("\n") +
+          `\n  Edit it now — it is the one file this phase lets you leave uncommitted, ` +
+          `and it rides the release commit. Or run with FORCE=true.`,
+      );
+    }
   }
 
   console.log(`\nPreparing ${pkg.version} → ${version} (${semverPart})\n`);
@@ -197,7 +351,17 @@ async function prepare(semverPart: string): Promise<void> {
   );
 
   await run(["git", "checkout", "-b", branch]);
-  await run(["git", "add", PKG_PATH, MANIFEST_PATH, VERSIONS_PATH]);
+  // CHANGELOG.md is in the list whether or not it was edited: `git add` on an
+  // unchanged path is a no-op, and leaving it out would strand the one edit
+  // this phase deliberately allowed.
+  await run([
+    "git",
+    "add",
+    PKG_PATH,
+    MANIFEST_PATH,
+    VERSIONS_PATH,
+    CHANGELOG_PATH,
+  ]);
   await run(["git", "commit", "-m", version]);
   await run(["git", "push", "-u", "origin", branch]);
 
@@ -213,7 +377,8 @@ async function prepare(semverPart: string): Promise<void> {
       "--title",
       `chore(release): ${version}`,
       "--body",
-      `Version bump only: \`package.json\`, \`manifest.json\`, \`versions.json\`.\n\n` +
+      `Version bump: \`package.json\`, \`manifest.json\`, \`versions.json\`, ` +
+        `plus \`CHANGELOG.md\` if the release notes were moved in the same step.\n\n` +
         `Merge this once CI is green, pull \`main\`, then run \`bun run version:tag\` to tag and publish. ` +
         `Either merge method is fine — the tag is created after the merge, so it points at whatever \`main\` has.`,
     ]);


### PR DESCRIPTION
Closes #476.

`version.ts` bumps three version files. Nothing anywhere touches `CHANGELOG.md`, so a release can publish with its own notes still under `## [Unreleased]` while `bun run check`, the full suite, `format:check`, both CI jobs and `release.yml` stay green. None of them reads that file. The `2.1.0` cut nearly shipped exactly that, caught only because the dry run printed three filenames and the fourth was missing.

## The issue's own proposal was not enough

It said refuse and stop there. Implementing it showed why that is not usable on its own: phase one's preflight requires a clean tree on `main` equal to `origin/main`, so a bare refusal means the heading has to land on `main` first, through a PR whose only content is a moved heading. Two PRs per release, one of them pure ceremony.

So the guard ships with one narrow allowance: **`CHANGELOG.md` is the single path phase one tolerates as uncommitted**, and it is added to the release commit. Phase two passes no allowance and stays strict, because it reads the committed tree to decide what to tag.

## What is checked

`checkChangelogReady(text, version)` returns human-readable problems, empty means ready, and reports **every** problem rather than the first — the same shape and the same tested bias as `verifyCommittedVersion`:

- no `## [Unreleased]` heading at all, which is a problem rather than an exemption: a file the check cannot read is the failure mode it exists to prevent
- content under `[Unreleased]`, quoting the first line so the message is actionable
- no `## [<version>]` heading
- a dated heading with nothing under it

Version labels are matched **exactly**, so `2.1.1` is not satisfied by a `## [2.1.10]` heading — the trap an unescaped-dot regex walks into. No date validation and no generated prose: the notes are written by a human every time, and this repo refuses rather than guesses.

`blockingStatusPaths(porcelain, allowed)` is exported and tested separately because "which uncommitted files block a release" is wrong silently in both directions.

## Verification

Exercised against the **real** `CHANGELOG.md`, not only fixtures: cutting `2.1.1` today is refused for the missing heading; cutting `2.1.0` passes; notes left under `[Unreleased]` are refused with both problems named. The clean-tree message was seen live naming two real dirty files.

Mutation-checked both directions: a `checkChangelogReady` that never refuses turns 6 tests red, an inert `blockingStatusPaths` turns 3 red. Restored green.

Full gate: `check` 0 errors, `bun test` 1896 (from 1882), `format:check` clean, `check:svelte` 1412 files 0 errors, `test:mcpb` all checks, `python3 -m unittest` 32 OK.