### PR TITLE
fix(scripts): make link.ts refuse a copied plugin directory

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -141,7 +141,26 @@ to be titled "actionable now", which was false for both.
       the probe at all, while at 21:44 the identical action worked. Either the probe was not
       created where it was believed to be, or the instance was left in a bad state by swapping
       `main.js` under a running Obsidian. Until that is understood, confirm `prompts/list` sees
-      the probe before concluding anything about notifications <!-- src:session opened:2026-08-16 -->
+      the probe before concluding anything about notifications
+      **UPDATE 2026-08-17 — the silent half is fixed, and its mechanism was in this repo, not in
+      the vault.** `scripts/link.ts` decided with `existsSync(targetPath)`, which is true for any
+      existing path including a plain directory, so running `bun run link` against a vault whose
+      plugin directory is a copy printed **"Symlink already exists."** and did nothing. The tool
+      whose only job is to guarantee the link claimed success in precisely the case where the link
+      was absent — not silence, an active false claim, and the reason this stayed invisible.
+      It now inspects with `lstat` and refuses: a copied directory is named as a copy, with
+      `data.json` and `embeddings/` cited as the reason it will not act and `mv` given as the
+      recovery step; a symlink pointing at a **different** checkout is refused too, which was
+      equally silent before and equally stale-making. It never deletes. A refusal exits non-zero,
+      which `main().catch(console.error)` previously made impossible.
+      Verified by running the real script against four scratch vaults (absent / copy / correct
+      link / foreign link → create, refuse, ok, refuse; exit 0/1/0/1), never against the Labs
+      vault. Mutation-checked both ways. `readlink` may return a **relative** path and is resolved
+      against the link's own directory, not the cwd — resolving against the cwd would refuse a
+      perfectly good link.
+      **Still open, deliberately:** the Labs vault is still a copy, and moving that directory is a
+      human step this script now asks for rather than performing. The `prompts/list` mystery above
+      is untouched and may have no close condition <!-- src:session opened:2026-08-16 updated:2026-08-17 -->
 - [ ] `OMC-027` **P3** MCP Apps empty state names the vault, not the query. The implementation
       plan's task 6 step 2 specified that the empty state should name "the query"; the result
       payload carries only `vaultName`, never the query string — both projections are called as

--- a/packages/obsidian-plugin/scripts/link.test.ts
+++ b/packages/obsidian-plugin/scripts/link.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Unit tests for the decision half of scripts/link.ts.
+ *
+ * The filesystem half (`inspectLinkTarget`) is exercised by the real script
+ * against scratch directories rather than mocked here: mocking `lstat` would
+ * test the mock, and `lstat` versus `stat` is the whole point of that function.
+ *
+ * Importing this module at all depends on link.ts's `import.meta.main` guard.
+ * Without it, this import would run the script — and with no argv, exit the
+ * test process.
+ */
+import { describe, expect, test } from "bun:test";
+import { decideLinkAction, type LinkTargetState } from "./link";
+
+const REPO = "/Users/dev/Obsidian_MCP";
+const TARGET = "/vault/.obsidian/plugins/mcp-tools-istefox";
+
+const decide = (state: LinkTargetState) =>
+  decideLinkAction(state, REPO, TARGET);
+
+describe("decideLinkAction", () => {
+  test("creates the link when nothing is there", () => {
+    expect(decide({ kind: "absent" }).action).toBe("create");
+  });
+
+  test("accepts a symlink that points at this repo", () => {
+    const d = decide({ kind: "symlink", target: REPO });
+    expect(d.action).toBe("ok");
+    expect(d.message).toContain(REPO);
+  });
+
+  test("REFUSES a real directory — the #468 case", () => {
+    // The one that reported "Symlink already exists." and did nothing, because
+    // existsSync is true for a directory. A copied plugin directory means a
+    // build in this repo never reaches the vault.
+    const d = decide({ kind: "directory" });
+    expect(d.action).toBe("refuse");
+    expect(d.message).toMatch(/COPY/);
+  });
+
+  test("the directory refusal names the data it will not touch", () => {
+    // The refusal has to explain why it stops rather than deleting: the
+    // directory holds live settings and a vector store.
+    const { message } = decide({ kind: "directory" });
+    expect(message).toContain("data.json");
+    expect(message).toContain("embeddings/");
+  });
+
+  test("the directory refusal names the recovery step", () => {
+    expect(decide({ kind: "directory" }).message).toMatch(/mv .*copy-backup/);
+  });
+
+  test("REFUSES a symlink pointing at another checkout", () => {
+    // Also silent before this change, and just as stale-making as a copy.
+    const d = decide({ kind: "symlink", target: "/Users/dev/other-checkout" });
+    expect(d.action).toBe("refuse");
+    expect(d.message).toContain("/Users/dev/other-checkout");
+    expect(d.message).toContain(REPO);
+  });
+
+  test("a near-miss path is not treated as this repo", () => {
+    // Substring thinking would accept a sibling checkout whose path merely
+    // starts with ours.
+    expect(decide({ kind: "symlink", target: `${REPO}-2` }).action).toBe(
+      "refuse",
+    );
+  });
+
+  test("REFUSES a file", () => {
+    expect(decide({ kind: "file" }).action).toBe("refuse");
+  });
+
+  test("every refusal names the path it is refusing", () => {
+    const states: LinkTargetState[] = [
+      { kind: "directory" },
+      { kind: "file" },
+      { kind: "symlink", target: "/elsewhere" },
+    ];
+    for (const state of states) {
+      expect(decide(state).message).toContain(TARGET);
+    }
+  });
+});

--- a/packages/obsidian-plugin/scripts/link.ts
+++ b/packages/obsidian-plugin/scripts/link.ts
@@ -1,5 +1,11 @@
-import { symlinkSync, existsSync, mkdirSync } from "fs";
-import { join, resolve } from "node:path";
+import {
+  symlinkSync,
+  existsSync,
+  mkdirSync,
+  lstatSync,
+  readlinkSync,
+} from "fs";
+import { dirname, join, resolve } from "node:path";
 
 /**
  * This development script creates a symlink to the plugin in the Obsidian vault's plugin directory. This allows you to
@@ -10,6 +16,113 @@ import { join, resolve } from "node:path";
  * Usage: `bun scripts/link.ts <path_to_obsidian_vault>`
  * @returns {Promise<void>}
  */
+
+/** What the vault's plugin path turned out to be, as observed by `lstat`. */
+export type LinkTargetState =
+  | { kind: "absent" }
+  /** `target` is the link's destination, already resolved to an absolute path. */
+  | { kind: "symlink"; target: string }
+  | { kind: "directory" }
+  | { kind: "file" };
+
+export type LinkDecision = {
+  action: "create" | "ok" | "refuse";
+  message: string;
+};
+
+/**
+ * What to do about the vault's plugin path, given what is actually there.
+ *
+ * Pure so it can be tested without a filesystem, the same split
+ * `verifyCommittedVersion` and `checkChangelogReady` use in scripts/version.ts:
+ * the caller does the I/O, the decision is a function of the facts.
+ *
+ * This exists because the check it replaces was `existsSync(targetPath)`, which
+ * is true for ANY existing path — a plain directory included. A vault whose
+ * plugin directory is a hand-made COPY therefore got "Symlink already exists."
+ * and no link, from the one tool whose job is to guarantee the link (#468). A
+ * verification then measures whatever build was copied last: on 2026-08-16 that
+ * was five days old and read as a defect in code merged hours earlier.
+ *
+ * It never deletes. A real directory there holds `data.json` and `embeddings/`,
+ * live settings and a vector store, so replacing it is a human decision and the
+ * refusal says so instead of acting.
+ */
+export function decideLinkAction(
+  state: LinkTargetState,
+  repoRoot: string,
+  targetPath: string,
+): LinkDecision {
+  switch (state.kind) {
+    case "absent":
+      return { action: "create", message: `Creating symlink at ${targetPath}` };
+
+    case "symlink":
+      if (state.target === repoRoot) {
+        return {
+          action: "ok",
+          message: `Already linked: ${targetPath} → ${repoRoot}`,
+        };
+      }
+      // Silent before this change, and as stale-making as a copy: a link to
+      // another checkout means `bun run build` here never reaches the vault.
+      return {
+        action: "refuse",
+        message:
+          `${targetPath} is a symlink to a DIFFERENT directory:\n` +
+          `    it points at ${state.target}\n` +
+          `    this repo is  ${repoRoot}\n` +
+          `  A build here will never reach that vault. Remove the link and re-run to point it at this checkout.`,
+      };
+
+    case "directory":
+      return {
+        action: "refuse",
+        message:
+          `${targetPath} is a real directory, not a symlink — the plugin there is a COPY.\n` +
+          `  A build in this repo does not reach it, and nothing else says so: this is #468.\n` +
+          `  Not touching it, because it holds your live \`data.json\` and \`embeddings/\`.\n` +
+          `  Move it aside yourself, then re-run this script:\n` +
+          `    mv "${targetPath}" "${targetPath}.copy-backup"`,
+      };
+
+    case "file":
+      return {
+        action: "refuse",
+        message: `${targetPath} is a file, not a directory or a symlink. Move it aside and re-run.`,
+      };
+  }
+}
+
+/**
+ * `lstat`, never `stat`, and that is load-bearing: `stat` follows the link, so a
+ * valid symlink would report as a directory and a broken one as absent — the
+ * exact conflation this whole change exists to undo.
+ */
+export function inspectLinkTarget(targetPath: string): LinkTargetState {
+  let stats;
+  try {
+    stats = lstatSync(targetPath);
+  } catch {
+    // Only "not there" is a legitimate absence. `lstat` does not follow the
+    // link, so a symlink whose target was deleted still stats fine and is
+    // reported as the symlink it is, rather than as absent.
+    return { kind: "absent" };
+  }
+  if (stats.isSymbolicLink()) {
+    // `readlink` may hand back a RELATIVE path, which is relative to the link's
+    // own directory and not to the cwd this script happens to run from.
+    // Resolving it against the cwd would compare two unrelated paths and refuse
+    // a perfectly good link.
+    return {
+      kind: "symlink",
+      target: resolve(dirname(targetPath), readlinkSync(targetPath)),
+    };
+  }
+  if (stats.isDirectory()) return { kind: "directory" };
+  return { kind: "file" };
+}
+
 async function main() {
   const args = process.argv.slice(2);
   if (args.length < 1) {
@@ -22,14 +135,18 @@ async function main() {
   const vaultConfigPath = args[0];
   const projectRootDirectory = resolve(__dirname, "../../..");
   const pluginManifestPath = resolve(projectRootDirectory, "manifest.json");
-  const pluginsDirectoryPath = join(vaultConfigPath, "plugins");
+  const pluginsDirectoryPath = join(vaultConfigPath!, "plugins");
 
   const file = Bun.file(pluginManifestPath);
   const manifest = await file.json();
 
   const pluginName = manifest.id;
+  // Announces what it is about to inspect, not what it is about to do: this
+  // line used to claim "Creating symlink…" before anything had been decided,
+  // and then printed "Symlink already exists." over a directory that was not
+  // one. Two false claims in four lines is how #468 stayed invisible.
   console.log(
-    `Creating symlink to ${projectRootDirectory} for plugin ${pluginName} in ${pluginsDirectoryPath}`,
+    `Linking plugin ${pluginName} from ${projectRootDirectory} into ${pluginsDirectoryPath}`,
   );
 
   if (!existsSync(pluginsDirectoryPath)) {
@@ -37,11 +154,21 @@ async function main() {
   }
 
   const targetPath = join(pluginsDirectoryPath, pluginName);
+  const decision = decideLinkAction(
+    inspectLinkTarget(targetPath),
+    projectRootDirectory,
+    targetPath,
+  );
 
-  if (existsSync(targetPath)) {
-    console.log("Symlink already exists.");
-    return;
+  if (decision.action === "refuse") {
+    // Non-zero, so a caller can tell. The old shape logged through
+    // `.catch(console.error)` and exited 0 whatever happened.
+    console.error(`\n✗ ${decision.message}\n`);
+    process.exit(1);
   }
+
+  console.log(decision.message);
+  if (decision.action === "ok") return;
 
   symlinkSync(projectRootDirectory, targetPath, "dir");
   console.log("Symlink created successfully.");
@@ -51,4 +178,12 @@ async function main() {
   );
 }
 
-main().catch(console.error);
+// Without this guard, importing the module to test it RUNS it — and with no
+// argv that is a `process.exit(1)` in the middle of the test run. Same reason
+// scripts/version.ts carries one, where the stakes are a release.
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Refs #468. Closes its silent half; does **not** close the issue.

## The mechanism was in this repo, not in the vault

#468 reads as "the Labs vault holds a copy instead of a symlink". That is the condition. The mechanism is `link.ts:40`, which decided with `existsSync(targetPath)` — true for **any** existing path, a plain directory included. So `bun run link <vault>` against a vault whose plugin directory is a copy printed **"Symlink already exists."** and returned.

The one tool whose job is to guarantee the link reported success in exactly the case where the link was absent. That is not the silence the rest of this week's findings involved; it is an active false claim, and it is why a verification could measure a five-day-old build and read as a defect in code merged hours earlier.

It compounded: the line before it announced "Creating symlink to …" before anything had been decided. Two false claims in four lines.

## What it does now

`lstat`, never `stat` — `stat` follows the link, so a valid symlink reports as a directory and a broken one as absent, the same conflation being fixed.

- absent → create
- symlink resolving to this repo → confirm
- symlink resolving **elsewhere** → refuse, naming both paths. Silent before, and as stale-making as a copy: a build here never reaches that vault.
- a real directory → refuse, named as a copy, with `data.json` and `embeddings/` cited as the reason it will not act and `mv` given as the recovery step
- a file → refuse

**It never deletes.** Replacing that directory stays a human decision, which is what the issue asked for.

Two details worth a look in review: `readlink` may return a **relative** path, resolved here against the link's own directory rather than the cwd (resolving against the cwd would refuse a perfectly good link); and `import.meta.main` is what lets a test import the module without running it, the same guard and the same reason as `scripts/version.ts`.

## Verification

The real script against four scratch vaults under the session scratchpad, never the Labs vault: absent → create (exit 0), copy → refuse (exit 1), correct link → ok (exit 0), foreign link → refuse (exit 1).

Mutation-checked both ways: the directory branch returning `ok` turns 1 test red, an always-matching symlink comparison turns 2 red. Restored green. Stated precisely because three of the four directory tests assert on the message rather than the action, so only one catches that particular flip.

Full gate: `check` 0 errors, `bun test` 1905 (from 1896), `format:check` clean, `check:svelte` 1413 files 0 errors, `test:mcpb` OK, `python3 -m unittest` 32 OK.

## Still open

The Labs vault is still a copy. The unexplained `prompts/list` behaviour from the 15:10 run of 2026-08-16 is untouched and may have no close condition.
