### PR TITLE
fix(prompts): re-check the list when a file finishes indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), version
 
 ## [Unreleased]
 
+### Fixed
+
+- **A prompt you have just created could stay invisible to your client for the rest of the session.** Add a note to `Prompts/`, ask the client for the list of prompts a moment later, and the new one could be missing — and stay missing, no matter how many times you asked, until you restarted Obsidian or happened to edit some other prompt note. The cause is a timing gap that lasted a fraction of a second and then became permanent. Obsidian tells the plugin that a file exists as soon as it appears, but it reads what is inside the file a little afterwards; a prompt is only a prompt once its frontmatter has been read. If your client asked for the list in that short gap, the answer it got was correct at that instant and wrong a moment later, and the plugin kept serving it, because it only knew to look again when a file was created, renamed, deleted or edited, and "finished reading a file" is none of those. The same gap could also announce that the list had changed and then hand back the old list, or lose the announcement entirely, which is why a missing prompt and a broken notification looked identical. The plugin now also listens for the moment a file becomes readable, which closes all of that. One more case goes with it, reachable without creating anything at all: a client that asks for the list while Obsidian is still opening the vault could be left with a short list, or an empty one, for as long as it stayed connected. (#483)
+
 ## [2.1.0] — 2026-08-17
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-<!-- project-tasks: prefix=OMC lastId=37 -->
+<!-- project-tasks: prefix=OMC lastId=38 -->
 # PROJECT TASKS
 
 Updated: 2026-08-17 · Shipped: **2.1.0** · Open: 4 (P1: 0) · In review: 0 · In progress: 0 · Next release: none scheduled · Open items with no GitHub issue: 2 (both by design)
@@ -62,7 +62,13 @@ failure ("no compile error") was false, and the fix as planned would not have fi
 None of these reaches a user; they cost real hours when they bite, and two already have.
 
 - `OMC-030` / `#468` — a vault verification can run against a stale build, and one did: the first `B3` run
-  failed all four assertions against an Aug 11 `main.js` and read as a defect in new code.
+  failed all four assertions against an Aug 11 `main.js` and read as a defect in new code. Down to
+  one open half — relinking the Labs vault, a human step. Its "unexplained" half turned out to be a
+  real defect and left as `OMC-038`.
+- `OMC-038` / `#483` — **closed 2026-08-17**, the day it was split out. `prompts/list` cached a scan
+  taken before the file was indexed and never re-checked, so a prompt could stay invisible for a
+  whole session. Found by reading `OMC-030`'s "may have no close condition" half rather than
+  believing it.
 - `OMC-029` — measured figures written into comments are guarded by nothing. Deliberately has **no**
   mechanical fix and no issue: the defence is procedural and belongs in the habit.
 - `OMC-036` / `#476` — **closed 2026-08-17**, same day it was filed. `version.ts` now refuses a cut
@@ -109,6 +115,7 @@ section exists so the next drift is visible rather than rediscovered.
 | — | `#465` | **survey done and consumed by `ADR-0019`** — closed 2026-08-17 |
 | `OMC-036` | `#476` | **both closed 2026-08-17** — the guard ships with the dirty-`CHANGELOG.md` allowance the issue's proposal turned out to need |
 | `OMC-037` | `#481` | **both closed 2026-08-17** — found while archiving a branch: any tag published a release |
+| `OMC-038` | `#483` | **both closed 2026-08-17** — split out of `OMC-030` once the "unexplained" half turned out to have a mechanism |
 | — | `#427` | **closed 2026-08-17** — it had been open a week after 2.0.0 shipped and `R-18` verified it |
 
 **Which surface gets what.** An issue is for anything a contributor could hit, pick up, or reasonably
@@ -159,9 +166,20 @@ to be titled "actionable now", which was false for both.
       vault. Mutation-checked both ways. `readlink` may return a **relative** path and is resolved
       against the link's own directory, not the cwd — resolving against the cwd would refuse a
       perfectly good link.
-      **Still open, deliberately:** the Labs vault is still a copy, and moving that directory is a
-      human step this script now asks for rather than performing. The `prompts/list` mystery above
-      is untouched and may have no close condition <!-- src:session opened:2026-08-16 updated:2026-08-17 -->
+      **UPDATE 2026-08-17 — the `prompts/list` mystery is not a mystery, and it is not about the
+      vault.** It is a defect in plugin code, split out as `OMC-038` / `#483` and fixed there:
+      `discoverPrompts` reads frontmatter out of `app.metadataCache`, which lags the vault, and the
+      memoized lister is keyed on an epoch only a **vault** event advances — so a list served inside
+      the indexing window omits the new prompt, caches that answer, and never re-checks, because
+      indexing is not a vault event. Both guesses recorded above were unnecessary. Neither is
+      refuted either: the mechanism reproduces the symptom exactly, nothing recovers what actually
+      happened at 15:10, and the standing rule to confirm `prompts/list` sees the probe costs
+      nothing and stays.
+      **Still open, deliberately, and now this alone:** the Labs vault is still a copy, and moving
+      that directory is a human step this script asks for rather than performs. The recovery has a
+      fourth step `link.ts` does not print — the symlink points at the repo root, so `data.json` and
+      `embeddings/` have to be restored *there*, not left in the vault; both are gitignored at the
+      root and neither exists there today <!-- src:session opened:2026-08-16 updated:2026-08-17 -->
 - [ ] `OMC-027` **P3** MCP Apps empty state names the vault, not the query. The implementation
       plan's task 6 step 2 specified that the empty state should name "the query"; the result
       payload carries only `vaultName`, never the query string — both projections are called as
@@ -515,6 +533,42 @@ ship — `_meta` present but not an object — is ordinary shape validation the 
 
 ## Done
 
+- [x] `OMC-038` #483 `prompts/list` could return a list missing a prompt that demonstrably exists,
+      and keep returning it for the whole session. Split out of `OMC-030`, whose text called this
+      "recorded rather than explained" and "may not have a close condition". It has one.
+      **Three reasonable pieces, one hole between them.** `discoverPrompts` reads frontmatter from
+      `app.metadataCache.getFileCache` and skips any file whose cache is still null.
+      `app.metadataCache` lags the vault: `vault.on("create")` fires when the file appears, the
+      cache fills once the file has been indexed. And the memoized lister in `features/prompts/
+      index.ts` is keyed on an epoch that **only a vault event** advances. So a `prompts/list`
+      arriving inside the indexing window scans, correctly finds no frontmatter, omits the file —
+      and caches that under the current epoch. Indexing completing is not a vault event, so the
+      epoch never moves and the omission is permanent until some unrelated prompt file is touched.
+      **The same hole has two more faces.** The debounced comparison can fire
+      `notifications/prompts/list_changed` and not invalidate the memo, so a client that re-lists on
+      the notification is told the set changed and then shown that it had not. And if the comparison
+      itself runs before indexing it computes `next === lastNotified`, declines to notify, and is
+      never re-scheduled — which is exactly the state `#468` described as "a silent notification
+      path and a frozen list are indistinguishable". One cause, both symptoms. A third door is
+      startup: `promptsSetup` runs from `onload()`, not behind `onLayoutReady`, so a list served
+      while Obsidian is indexing at launch can freeze with no vault event anywhere to unstick it.
+      **The fix is one listener**: `app.metadataCache.on("changed", ...)` in `vaultWatcher.ts`,
+      behind the `isPromptFile` filter the vault hooks already use, unregistered from `stop()`.
+      Checked against the installed typings (`node_modules/obsidian/obsidian.d.ts`, obsidian 1.13.1,
+      read 2026-08-17): documented as "Called when a file has been indexed, and its (updated) cache
+      is now available", and documented as **not** firing on rename — already covered by the vault
+      rename hook, so this is the one event to add rather than the first of several. Nothing else in
+      `src/` listened to `metadataCache`.
+      **Why no test caught it.** Every existing prompt test sets the file and its metadata in the
+      same breath, so the window does not exist in the harness. The three regression tests set them
+      as separate steps with the list call in between; the mock `metadataCache` had `getFileCache`
+      and no `on`/`offref`, so it got both, on a **separate** handler map from the vault's — one
+      registry walked by event name would let a vault fire reach a metadata listener and erase the
+      very gap under test. All three fail before the fix; the `offref` and the path filter were each
+      mutation-checked.
+      **What is not claimed.** This reproduces the 15:10 symptom of 2026-08-16 exactly, but nothing
+      recovers what happened that afternoon, so it is not proven to have been that run's cause.
+      `OMC-030`'s two guesses are unnecessary, not refuted <!-- src:session opened:2026-08-17 closed:2026-08-17 -->
 - [x] `OMC-037` #481 Any tag pushed to this repo published a release. `release.yml` triggered on
       `tags: ["*"]` with the job gated only on `github.ref_type == 'tag'`, and that job creates a
       draft and then promotes it with `gh release edit --draft=false`. So `git push origin <tag>`

--- a/packages/obsidian-plugin/src/features/prompts/index.test.ts
+++ b/packages/obsidian-plugin/src/features/prompts/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, beforeEach, spyOn } from "bun:test";
 import {
+  fireMockMetadataEvent,
   fireMockVaultEvent,
   mockApp,
   resetMockVault,
@@ -391,5 +392,112 @@ describe("prompts list-changed notification (ADR-0017)", () => {
     await settle();
 
     expect(calls).toHaveLength(0);
+  });
+});
+
+/**
+ * The indexing window (#483).
+ *
+ * `discoverPrompts` reads frontmatter out of `app.metadataCache` and skips any
+ * file whose cache is still null. The vault announces a file the moment it
+ * appears; the cache is populated later, when the file has been indexed. Every
+ * test above sets the file and its metadata together, so none of them can see
+ * what happens in between — and what happens is that a list served inside that
+ * window omits the new prompt and is then MEMOIZED, keyed on an epoch only a
+ * vault event advances. Indexing is not a vault event, so the omission is
+ * permanent for the session.
+ *
+ * These tests therefore set the file and its metadata as two separate steps,
+ * with the list call deliberately placed between them.
+ */
+describe("prompts list vs the metadata indexing window", () => {
+  const DEBOUNCE = 5;
+  const settle = () => new Promise((r) => setTimeout(r, DEBOUNCE + 40));
+
+  /** A prompt that exists on disk but has not been indexed yet. */
+  function unindexedPromptFile(path: string): void {
+    setMockFile(path, "Body");
+  }
+
+  /** The indexing that `metadataCache` performs some time afterwards. */
+  function indexPromptFile(path: string, description = "d"): void {
+    setMockMetadata(path, {
+      frontmatter: { tags: ["mcp-tools-prompt"], description },
+    });
+    fireMockMetadataEvent("changed", { path });
+  }
+
+  test("a list served before the new file is indexed is not cached forever", async () => {
+    unindexedPromptFile("Prompts/greet.md");
+    indexPromptFile("Prompts/greet.md");
+
+    const registry = new PromptRegistryClass();
+    const app = mockApp();
+    const result = await setup(registry, app, { debounceMs: DEBOUNCE });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    unindexedPromptFile("Prompts/probe.md");
+    fireMockVaultEvent("create", { path: "Prompts/probe.md" });
+
+    // Correct at this instant, and the whole problem: the file is there, its
+    // frontmatter is not, so it is not a prompt yet. This answer gets cached.
+    expect((await registry.list()).prompts).toHaveLength(1);
+
+    indexPromptFile("Prompts/probe.md");
+
+    expect((await registry.list()).prompts).toHaveLength(2);
+    teardown(result.state);
+  });
+
+  test("a list served at startup, before ANY file is indexed, is not cached forever", async () => {
+    // No vault event anywhere in this test. This is a client that calls
+    // prompts/list while Obsidian is still indexing at launch — `setup` runs
+    // from `onload`, not behind `onLayoutReady`, so the window is reachable.
+    unindexedPromptFile("Prompts/greet.md");
+
+    const registry = new PromptRegistryClass();
+    const app = mockApp();
+    const result = await setup(registry, app, { debounceMs: DEBOUNCE });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect((await registry.list()).prompts).toHaveLength(0);
+
+    indexPromptFile("Prompts/greet.md");
+
+    expect((await registry.list()).prompts).toHaveLength(1);
+    teardown(result.state);
+  });
+
+  test("the list a client re-fetches on a notification is the list that was notified about", async () => {
+    unindexedPromptFile("Prompts/greet.md");
+    indexPromptFile("Prompts/greet.md");
+
+    const calls: number[] = [];
+    const registry = new PromptRegistryClass();
+    const app = mockApp();
+    const result = await setup(registry, app, {
+      notifyPromptsChanged: () => calls.push(1),
+      debounceMs: DEBOUNCE,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    unindexedPromptFile("Prompts/probe.md");
+    fireMockVaultEvent("create", { path: "Prompts/probe.md" });
+    // Poisons the memo, exactly as above.
+    await registry.list();
+
+    indexPromptFile("Prompts/probe.md");
+    await settle();
+
+    // The comparison re-scans and sees the probe, so it notifies. The memo is
+    // keyed on an epoch that comparison never touches, so a client acting on
+    // that notification used to be handed the list without the probe in it —
+    // told the set had changed and then shown that it had not.
+    expect(calls).toHaveLength(1);
+    expect((await registry.list()).prompts).toHaveLength(2);
+    teardown(result.state);
   });
 });

--- a/packages/obsidian-plugin/src/features/prompts/services/vaultWatcher.test.ts
+++ b/packages/obsidian-plugin/src/features/prompts/services/vaultWatcher.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test, beforeEach, mock } from "bun:test";
-import { mockApp, resetMockVault, fireMockVaultEvent } from "$/test-setup";
+import {
+  mockApp,
+  resetMockVault,
+  fireMockVaultEvent,
+  fireMockMetadataEvent,
+} from "$/test-setup";
 import { createVaultWatcher } from "./vaultWatcher";
 
 beforeEach(() => {
@@ -67,6 +72,29 @@ describe("createVaultWatcher", () => {
     expect(notifier).toHaveBeenCalledTimes(1);
   });
 
+  // The metadata cache is a second emitter, and the only one that says a file
+  // has become READABLE (#483). It is fired separately from the vault on
+  // purpose: the gap between the two is the defect these guard.
+  test("notifier called when a Prompts/ md file finishes indexing", () => {
+    const notifier = mock(() => {});
+    const app = mockApp();
+    createVaultWatcher(app, notifier);
+    fireMockMetadataEvent("changed", makeFile("Prompts/foo.md"));
+    expect(notifier).toHaveBeenCalledTimes(1);
+  });
+
+  test("notifier not called when a file outside Prompts/ finishes indexing", () => {
+    const notifier = mock(() => {});
+    const app = mockApp();
+    createVaultWatcher(app, notifier);
+    // Every indexed file in the vault reaches this listener, so the filter is
+    // the whole cost story: a large vault re-indexing must not re-scan prompts
+    // once per file.
+    fireMockMetadataEvent("changed", makeFile("Notes/foo.md"));
+    fireMockMetadataEvent("changed", makeFile("Prompts/sub/foo.md"));
+    expect(notifier).not.toHaveBeenCalled();
+  });
+
   test("stop() prevents subsequent events from calling notifier", () => {
     const notifier = mock(() => {});
     const app = mockApp();
@@ -75,6 +103,9 @@ describe("createVaultWatcher", () => {
     fireMockVaultEvent("create", makeFile("Prompts/foo.md"));
     fireMockVaultEvent("delete", makeFile("Prompts/foo.md"));
     fireMockVaultEvent("rename", makeFile("Prompts/foo.md"), "Notes/foo.md");
+    // The metadata listener is registered on a different emitter, so it needs
+    // its own `offref` and would survive a `stop()` that forgot it.
+    fireMockMetadataEvent("changed", makeFile("Prompts/foo.md"));
     expect(notifier).not.toHaveBeenCalled();
   });
 });

--- a/packages/obsidian-plugin/src/features/prompts/services/vaultWatcher.ts
+++ b/packages/obsidian-plugin/src/features/prompts/services/vaultWatcher.ts
@@ -1,4 +1,4 @@
-import type { App, EventRef, TAbstractFile } from "obsidian";
+import type { App, EventRef, TAbstractFile, TFile } from "obsidian";
 
 export type VaultWatcher = { stop: () => void };
 
@@ -35,12 +35,34 @@ export function createVaultWatcher(
     if (isPromptFile(file.path)) notifier();
   });
 
+  // The vault says a file EXISTS; the metadata cache says what is IN it, some
+  // time later. `discoverPrompts` reads frontmatter, so a prompt is not a
+  // prompt until this event — and this is the only moment no vault event
+  // announces, which is what made the gap invisible (#483).
+  //
+  // What it costs: a save now reaches `notifier()` twice, once through
+  // `modify` and once through here. That is intentional and cheap — the memo
+  // invalidation is idempotent and the debounce collapses the pair into a
+  // single re-scan. Losing the second one is not: it is the only signal that
+  // arrives after the frontmatter is actually readable.
+  //
+  // `changed` is documented as NOT firing on rename, for performance. The
+  // rename hook above already covers that case, so this is the one event to
+  // add rather than the first of several.
+  const indexedRef: EventRef = app.metadataCache.on(
+    "changed",
+    (file: TFile) => {
+      if (isPromptFile(file.path)) notifier();
+    },
+  );
+
   return {
     stop: () => {
       app.vault.offref(createRef);
       app.vault.offref(deleteRef);
       app.vault.offref(renameRef);
       app.vault.offref(modifyRef);
+      app.metadataCache.offref(indexedRef);
     },
   };
 }

--- a/packages/obsidian-plugin/src/test-setup.ts
+++ b/packages/obsidian-plugin/src/test-setup.ts
@@ -645,6 +645,14 @@ type MockVaultState = {
     object,
     { event: string; handler: (...args: unknown[]) => void }
   >;
+  // Same shape as `eventHandlers`, for metadataCache.on / offref, and
+  // deliberately a SEPARATE map. The two emitters share event names in
+  // the real API surface, so one registry walked by name would let
+  // `fireMockVaultEvent` reach a metadataCache listener and vice versa.
+  metadataEventHandlers: Map<
+    object,
+    { event: string; handler: (...args: unknown[]) => void }
+  >;
 };
 
 // Synthetic absolute filesystem prefix used by the mock `adapter.rmdir`
@@ -673,6 +681,7 @@ const _mockState: MockVaultState = {
   modifyFailPaths: new Set(),
   readMutations: new Map(),
   eventHandlers: new Map(),
+  metadataEventHandlers: new Map(),
 };
 
 export function resetMockVault(): void {
@@ -699,6 +708,7 @@ export function resetMockVault(): void {
   _mockState.modifyFailPaths.clear();
   _mockState.readMutations.clear();
   _mockState.eventHandlers.clear();
+  _mockState.metadataEventHandlers.clear();
   resetMockPeriodicNotes();
   resetMockDataview();
   resetMockBookmarks();
@@ -711,6 +721,24 @@ export function resetMockVault(): void {
  */
 export function fireMockVaultEvent(event: string, ...args: unknown[]): void {
   for (const { event: e, handler } of _mockState.eventHandlers.values()) {
+    if (e === event) handler(...args);
+  }
+}
+
+/**
+ * Simulate a `metadataCache` event (`changed` / `deleted` / `resolve` / ...).
+ *
+ * Separate from {@link fireMockVaultEvent} because the timing gap between the
+ * two emitters is the thing under test: the vault announces a file the moment
+ * it appears, the metadata cache only once that file has been indexed, and a
+ * list derived from frontmatter is wrong in between. Firing both from one
+ * helper would erase exactly the window a test needs to reproduce.
+ */
+export function fireMockMetadataEvent(event: string, ...args: unknown[]): void {
+  for (const {
+    event: e,
+    handler,
+  } of _mockState.metadataEventHandlers.values()) {
     if (e === event) handler(...args);
   }
 }
@@ -1228,6 +1256,20 @@ export function mockApp(): App {
       return _mockState.metadataCache.get(path) ?? null;
     },
     getTags: (): Record<string, number> => ({ ..._mockState.tags }),
+    // `metadataCache` is an `Events` subclass in the real API, so it
+    // carries the same on/offref pair the vault does. Driven by
+    // `fireMockMetadataEvent`, never by `fireMockVaultEvent`.
+    on: (event: string, handler: unknown) => {
+      const ref = {};
+      _mockState.metadataEventHandlers.set(ref, {
+        event,
+        handler: handler as (...args: unknown[]) => void,
+      });
+      return ref;
+    },
+    offref: (ref: object) => {
+      _mockState.metadataEventHandlers.delete(ref);
+    },
     // Mirrors Obsidian's runtime `MetadataCache.isUserIgnored` (not in
     // the bundled `obsidian.d.ts`). Backed by `setMockIgnored()`.
     isUserIgnored: (path: string): boolean => _mockState.ignored.has(path),


### PR DESCRIPTION
`prompts/list` could return a list missing a prompt that demonstrably exists, and keep returning it for the whole session. Full mechanism in #483; the short version and what is new here:

## The hole

Three reasonable pieces:

1. `discoverPrompts` reads frontmatter from `app.metadataCache.getFileCache` and skips any file whose cache is still `null`.
2. `app.metadataCache` lags the vault. `vault.on("create")` fires when the file appears; the cache fills once the file has been indexed.
3. The memoized lister in `features/prompts/index.ts` is keyed on an epoch that **only a vault event** advances.

A `prompts/list` arriving inside the indexing window scans, correctly finds no frontmatter, omits the file — and caches that answer under the current epoch. Indexing completing is not a vault event, so the epoch never moves again.

Two more faces of the same hole. The debounced comparison can fire `notifications/prompts/list_changed` without invalidating the memo, so a client that re-lists on the notification is told the set changed and then shown that it had not. And if the comparison runs before indexing it computes `next === lastNotified`, declines to notify, and is never re-scheduled — the state #468 recorded as "a silent notification path and a frozen list are indistinguishable". A third door is startup: `promptsSetup` runs from `onload()`, not behind `onLayoutReady`.

## The fix

One listener: `app.metadataCache.on("changed", ...)` in `services/vaultWatcher.ts`, behind the `isPromptFile` filter the vault hooks already use, unregistered from `stop()`.

Checked against the installed typings (`node_modules/obsidian/obsidian.d.ts`, obsidian 1.13.1, read 2026-08-17): documented as "Called when a file has been indexed, and its (updated) cache is now available", and documented as **not** firing on rename — already covered by the vault rename hook, so this is the one event to add rather than the first of several. Nothing else in `src/` listened to `metadataCache`.

Cost: a save now reaches the notifier twice, through `modify` and through `changed`. Intentional — memo invalidation is idempotent and the debounce collapses the pair into one re-scan. The filter keeps a vault-wide re-index from re-scanning prompts once per file, and there is a test for that.

## Why nothing caught it

Every existing prompt test sets the file and its metadata in the same breath, so the window does not exist in the harness. The three regression tests set them as **separate steps** with the list call in between:

- a list served before the new file is indexed is not cached forever
- a list served at startup, before any file is indexed, is not cached forever
- the list a client re-fetches on a notification is the list that was notified about

All three fail before the fix. The third fails on the list assertion only, with `calls` already at 1 — the notification fires, the list disagrees.

The mock `metadataCache` had `getFileCache` and no `on`/`offref`, so it got both, on a **separate** handler map from the vault's plus a `fireMockMetadataEvent`. One registry walked by event name would let a vault fire reach a metadata listener and erase the very gap under test.

## Verification

- `bun run check` — clean
- `bun test` — 1910 pass, 0 fail (1905 before)
- `bun run format:check` — clean
- `bun run check:svelte` — 1413 files, 0 errors
- `bun run test:mcpb` — all checks
- `python3 -m unittest discover -s scripts` — 32 OK
- transport untouched, so `test:conformance` is not implicated

Mutation-checked both ways: dropping `app.metadataCache.offref(indexedRef)` from `stop()` reds exactly the teardown test; dropping the `isPromptFile` filter reds exactly the outside-`Prompts/` test.

## Not claimed

This reproduces the 2026-08-16 15:10 symptom exactly, but nothing recovers what actually happened that afternoon. #468 named two other guesses and neither is refuted, only made unnecessary.

## What stays open

#468 keeps its remaining half: the Labs vault is still a copy, and relinking it is a human step `scripts/link.ts` asks for rather than performs.
