### PR TITLE
fix(scripts): make link.ts print the whole recovery, not half of it

### DIFF
--- a/packages/obsidian-plugin/scripts/link.test.ts
+++ b/packages/obsidian-plugin/scripts/link.test.ts
@@ -50,6 +50,26 @@ describe("decideLinkAction", () => {
     expect(decide({ kind: "directory" }).message).toMatch(/mv .*copy-backup/);
   });
 
+  test("the directory refusal names the RESTORE step, into the repo root", () => {
+    // `mv` alone is half a recovery and the wrong half to stop at: the link
+    // makes the repo root the plugin directory, so settings and vector store
+    // left behind in the vault are simply gone. The first version of this
+    // message said `mv` and stopped, and the step nobody prints is the step
+    // nobody performs.
+    const { message } = decide({ kind: "directory" });
+    expect(message).toContain(`data.json" "${REPO}/"`);
+    expect(message).toContain(`embeddings" "${REPO}/"`);
+  });
+
+  test("the restore step copies FROM the backup, not from the live directory", () => {
+    // Sourcing the copy from `targetPath` would read the symlink this script
+    // is about to create — that is, the repo root — and copy a file onto
+    // itself, or nothing at all.
+    const { message } = decide({ kind: "directory" });
+    expect(message).toContain(`${TARGET}.copy-backup/data.json`);
+    expect(message).not.toMatch(/cp "[^"]*plugins\/mcp-tools-istefox\/data/);
+  });
+
   test("REFUSES a symlink pointing at another checkout", () => {
     // Also silent before this change, and just as stale-making as a copy.
     const d = decide({ kind: "symlink", target: "/Users/dev/other-checkout" });

--- a/packages/obsidian-plugin/scripts/link.ts
+++ b/packages/obsidian-plugin/scripts/link.ts
@@ -82,8 +82,16 @@ export function decideLinkAction(
           `${targetPath} is a real directory, not a symlink — the plugin there is a COPY.\n` +
           `  A build in this repo does not reach it, and nothing else says so: this is #468.\n` +
           `  Not touching it, because it holds your live \`data.json\` and \`embeddings/\`.\n` +
-          `  Move it aside yourself, then re-run this script:\n` +
-          `    mv "${targetPath}" "${targetPath}.copy-backup"`,
+          `  Recovery, in full:\n` +
+          `    mv "${targetPath}" "${targetPath}.copy-backup"\n` +
+          `    <re-run this script>\n` +
+          `    cp "${targetPath}.copy-backup/data.json" "${repoRoot}/"\n` +
+          `    cp -R "${targetPath}.copy-backup/embeddings" "${repoRoot}/"\n` +
+          `  The last two steps are the ones that get skipped, and skipping them\n` +
+          `  loses your settings and your vector store: linking makes THIS repo the\n` +
+          `  plugin directory, so they have to end up here rather than staying in\n` +
+          `  the vault. Both paths are gitignored at the repo root.\n` +
+          `  Keep the backup until Obsidian has restarted and the settings look right.`,
       };
 
     case "file":


### PR DESCRIPTION
`link.ts`'s refusal for a copied plugin directory named `mv` and stopped there.

That is half a recovery, and the wrong half to stop at. Linking makes the **repo root** the plugin directory, so a `data.json` and an `embeddings/` left behind in the vault are not moved along with anything — they are simply out of the picture, the plugin comes up with default settings and no vector store, and the `.copy-backup` directory is the only copy left. The step nobody prints is the step nobody performs.

## What it prints now

```
<vault>/.obsidian/plugins/mcp-tools-istefox is a real directory, not a symlink — the plugin there is a COPY.
  A build in this repo does not reach it, and nothing else says so: this is #468.
  Not touching it, because it holds your live `data.json` and `embeddings/`.
  Recovery, in full:
    mv "<target>" "<target>.copy-backup"
    <re-run this script>
    cp "<target>.copy-backup/data.json" "<repo-root>/"
    cp -R "<target>.copy-backup/embeddings" "<repo-root>/"
  The last two steps are the ones that get skipped, and skipping them
  loses your settings and your vector store: linking makes THIS repo the
  plugin directory, so they have to end up here rather than staying in
  the vault. Both paths are gitignored at the repo root.
  Keep the backup until Obsidian has restarted and the settings look right.
```

The copy sources are the `.copy-backup` path and never the live one — after the link, the live path *is* the repo root, so copying from it would copy a file onto itself. There is a test asserting that direction specifically, because it is the kind of thing that reads fine and does nothing.

## How it was found, and how it was checked

Compiling this sequence by hand for a real vault, and noticing the script does not print the two steps that matter most.

Verified by running what it prints, end to end, against a scratch vault rather than by reading it: `mv`, re-run, both copies, re-run again. The created symlink resolves to this repo's `main.js` (3011578 bytes, the repo build) and the second run reports `Already linked` at exit 0. Two new unit tests cover the restore destination and the copy direction.

`bun run check` clean, `bun test` 1912 pass / 0 fail, `bun run format:check` clean.

## Scope

Message only. `decideLinkAction`'s branches, `inspectLinkTarget` and the exit codes are untouched. #468 keeps its remaining half — the Labs vault is still a copy, and moving it stays a human step.
