### PR TITLE
feat(scripts): make link.ts stop before linking into an iCloud vault

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -175,11 +175,24 @@ to be titled "actionable now", which was false for both.
       refuted either: the mechanism reproduces the symptom exactly, nothing recovers what actually
       happened at 15:10, and the standing rule to confirm `prompts/list` sees the probe costs
       nothing and stays.
+      **UPDATE 2026-08-17 — the recovery `link.ts` prints was half of one, fixed in `2912174`.** It
+      named `mv` and stopped, and the two steps it skipped are the ones that lose data: the symlink
+      makes the **repo root** the plugin directory, so `data.json` and `embeddings/` have to be
+      copied *there*, not left behind in the vault. Both are gitignored at the root. Found by
+      compiling the sequence by hand for a real vault; verified by running what the script prints,
+      end to end, against a scratch vault.
+      **And the Labs vault turned out to be on iCloud Drive** (`~/Library/Mobile Documents/
+      com~apple~CloudDocs/Vaults/Labs`), which nothing in this repo recorded and which changes the
+      advice. Two claims, not one: *certain* — the link's target is outside the synced container, so
+      any other device on that vault finds a plugin folder it cannot resolve; *unverified* — whether
+      iCloud leaves the link itself alone, which nothing here has measured and for which this
+      machine has no precedent (no symlink exists anywhere in iCloud Drive, checked to depth 6).
+      `link.ts` now detects it on the **create** path only and refuses pending `ALLOW_ICLOUD=1`,
+      keeping the two claims separate in the message. The plugin directory is `mcp-tools-istefox`,
+      the manifest id — not `obsidian-mcp-tools`, which is what a hand-written recovery guessed.
       **Still open, deliberately, and now this alone:** the Labs vault is still a copy, and moving
-      that directory is a human step this script asks for rather than performs. The recovery has a
-      fourth step `link.ts` does not print — the symlink points at the repo root, so `data.json` and
-      `embeddings/` have to be restored *there*, not left in the vault; both are gitignored at the
-      root and neither exists there today <!-- src:session opened:2026-08-16 updated:2026-08-17 -->
+      that directory is a human step this script asks for rather than performs
+      <!-- src:session opened:2026-08-16 updated:2026-08-17 -->
 - [ ] `OMC-027` **P3** MCP Apps empty state names the vault, not the query. The implementation
       plan's task 6 step 2 specified that the empty state should name "the query"; the result
       payload carries only `vaultName`, never the query string — both projections are called as

--- a/packages/obsidian-plugin/scripts/link.test.ts
+++ b/packages/obsidian-plugin/scripts/link.test.ts
@@ -10,7 +10,11 @@
  * test process.
  */
 import { describe, expect, test } from "bun:test";
-import { decideLinkAction, type LinkTargetState } from "./link";
+import {
+  decideICloudTarget,
+  decideLinkAction,
+  type LinkTargetState,
+} from "./link";
 
 const REPO = "/Users/dev/Obsidian_MCP";
 const TARGET = "/vault/.obsidian/plugins/mcp-tools-istefox";
@@ -90,6 +94,14 @@ describe("decideLinkAction", () => {
     expect(decide({ kind: "file" }).action).toBe("refuse");
   });
 
+  test("the iCloud question does not reach the copied-directory refusal", () => {
+    // The two decisions are separate functions for exactly this reason: a
+    // `directory` is refused on a fact, and no environment variable may turn
+    // that into a link. If these ever merge, this is what notices.
+    expect(decide({ kind: "directory" }).action).toBe("refuse");
+    expect(decide({ kind: "file" }).action).toBe("refuse");
+  });
+
   test("every refusal names the path it is refusing", () => {
     const states: LinkTargetState[] = [
       { kind: "directory" },
@@ -99,5 +111,54 @@ describe("decideLinkAction", () => {
     for (const state of states) {
       expect(decide(state).message).toContain(TARGET);
     }
+  });
+});
+
+describe("decideICloudTarget", () => {
+  const DRIVE =
+    "/Users/dev/Library/Mobile Documents/com~apple~CloudDocs/Vaults/Labs/.obsidian/plugins/mcp-tools-istefox";
+  const APP_CONTAINER =
+    "/Users/dev/Library/Mobile Documents/iCloud~md~obsidian/Documents/Labs/.obsidian/plugins/mcp-tools-istefox";
+
+  test("an ordinary path is not iCloud", () => {
+    expect(decideICloudTarget(TARGET, REPO, false).kind).toBe("not-icloud");
+  });
+
+  test("a path merely containing the word icloud is not iCloud", () => {
+    // The marker is a real directory, not a word to grep for. `~/icloud-backup`
+    // is somebody's ordinary folder.
+    const d = decideICloudTarget("/Users/dev/icloud-backup/vault", REPO, false);
+    expect(d.kind).toBe("not-icloud");
+  });
+
+  test("iCloud Drive is blocked without ALLOW_ICLOUD", () => {
+    expect(decideICloudTarget(DRIVE, REPO, false).kind).toBe("blocked");
+  });
+
+  test("an iCloud app container counts too, not just the Drive", () => {
+    // Obsidian's own iOS container is a sibling of com~apple~CloudDocs under
+    // the same parent, and is synced the same way. Matching only the Drive
+    // would miss it.
+    expect(decideICloudTarget(APP_CONTAINER, REPO, false).kind).toBe("blocked");
+  });
+
+  test("ALLOW_ICLOUD proceeds, and still says the same two things", () => {
+    const d = decideICloudTarget(DRIVE, REPO, true);
+    expect(d.kind).toBe("allowed");
+    if (d.kind === "not-icloud") return;
+    expect(d.message).toContain("Certain:");
+    expect(d.message).toContain("NOT known:");
+  });
+
+  test("the block separates what is certain from what is not", () => {
+    // The whole point of the wording: the target being outside the synced
+    // container is a fact, iCloud's treatment of the link itself is not, and
+    // presenting them as one confident warning would be the error.
+    const d = decideICloudTarget(DRIVE, REPO, false);
+    if (d.kind === "not-icloud") throw new Error("expected a decision");
+    expect(d.message).toContain("Certain:");
+    expect(d.message).toContain("NOT known:");
+    expect(d.message).toContain(REPO);
+    expect(d.message).toContain("ALLOW_ICLOUD=1");
   });
 });

--- a/packages/obsidian-plugin/scripts/link.ts
+++ b/packages/obsidian-plugin/scripts/link.ts
@@ -103,6 +103,73 @@ export function decideLinkAction(
 }
 
 /**
+ * Everything macOS keeps in iCloud lives under this one directory: the Drive
+ * itself is `com~apple~CloudDocs`, per-app containers are siblings of it
+ * (`iCloud~md~obsidian`). Matching the parent covers both, and a vault in
+ * either is synced the same way.
+ */
+const ICLOUD_MARKER = "/Library/Mobile Documents/";
+
+export type ICloudDecision =
+  | { kind: "not-icloud" }
+  | { kind: "allowed"; message: string }
+  | { kind: "blocked"; message: string };
+
+/**
+ * Whether to link into a vault that iCloud syncs, which is a question this
+ * script refuses to answer on its own.
+ *
+ * Deliberately separate from {@link decideLinkAction}: what is there is a fact
+ * about the filesystem, this is a judgement about someone's setup. Folding the
+ * two together would make a `create` conditional on an environment variable,
+ * and the copied-directory refusal must never become overridable by one.
+ *
+ * The confirmation is an env var rather than a stdin prompt, matching
+ * `scripts/version.ts`'s `FORCE=true`. A prompt would hang this script the
+ * first time anything non-interactive ran it. The name is narrow on purpose:
+ * `FORCE=true` would read as "override the refusals too", and those are not
+ * negotiable.
+ */
+export function decideICloudTarget(
+  targetPath: string,
+  repoRoot: string,
+  allowICloud: boolean,
+): ICloudDecision {
+  if (!targetPath.includes(ICLOUD_MARKER)) return { kind: "not-icloud" };
+
+  // Stated as two separate claims because they are not equally solid, and
+  // collapsing them into one confident warning would be the same error this
+  // repo keeps catching elsewhere.
+  const certain =
+    `  Certain: the link points at ${repoRoot}, which is OUTSIDE the synced\n` +
+    `    container. Any other device syncing this vault finds a plugin folder it\n` +
+    `    cannot resolve, so the plugin is simply absent there.\n`;
+  const unknown =
+    `  NOT known: whether iCloud leaves the link itself intact over time.\n` +
+    `    Nothing here has measured it. Treat it as unverified, not as safe.\n`;
+
+  if (allowICloud) {
+    return {
+      kind: "allowed",
+      message:
+        `${targetPath} is inside iCloud. Proceeding because ALLOW_ICLOUD is set.\n` +
+        certain +
+        unknown,
+    };
+  }
+
+  return {
+    kind: "blocked",
+    message:
+      `${targetPath} is inside iCloud, and this script will not decide that for you.\n` +
+      certain +
+      unknown +
+      `  If this vault is only ever opened on this Mac, neither point applies.\n` +
+      `  Re-run the same command with ALLOW_ICLOUD=1 in front of it.`,
+  };
+}
+
+/**
  * `lstat`, never `stat`, and that is load-bearing: `stat` follows the link, so a
  * valid symlink would report as a directory and a broken one as absent — the
  * exact conflation this whole change exists to undo.
@@ -173,6 +240,25 @@ async function main() {
     // `.catch(console.error)` and exited 0 whatever happened.
     console.error(`\n✗ ${decision.message}\n`);
     process.exit(1);
+  }
+
+  // BEFORE `decision.message` is printed, not after. That message is
+  // "Creating symlink at …", and printing it ahead of a refusal would announce
+  // an action that is not going to happen — the precise false claim #468 was
+  // about. Only the create path asks the question: an existing correct link is
+  // not a decision being taken now, and re-running must not start refusing a
+  // setup already in place and working.
+  if (decision.action === "create") {
+    const icloud = decideICloudTarget(
+      targetPath,
+      projectRootDirectory,
+      process.env.ALLOW_ICLOUD === "1",
+    );
+    if (icloud.kind === "blocked") {
+      console.error(`\n✗ ${icloud.message}\n`);
+      process.exit(1);
+    }
+    if (icloud.kind === "allowed") console.warn(`\n! ${icloud.message}`);
   }
 
   console.log(decision.message);


### PR DESCRIPTION
The Labs dev vault turned out to live under `~/Library/Mobile Documents/com~apple~CloudDocs/`. Nothing in this repo recorded that, and it changes what linking into it means.

## Two claims, deliberately not merged

**Certain.** The link's target is `/Users/.../Obsidian_MCP`, outside the synced container. Any other device syncing that vault finds a plugin folder it cannot resolve, so the plugin is simply absent there.

**Not known.** Whether iCloud leaves the link itself intact over time. Nothing here has measured it, and this machine offers no precedent — there is no symlink anywhere in iCloud Drive, checked to a depth of six.

Collapsing those into one confident warning would be the same error this repo keeps catching elsewhere, so the message states them separately and labels the second as unverified rather than as danger.

## The gate

Refuse on the create path, naming `ALLOW_ICLOUD=1` as the way through.

- **An env var, not a stdin prompt**, matching `version.ts`'s `FORCE=true`. A prompt would hang the first time anything non-interactive ran this.
- **A narrow name.** `FORCE` would read as "override the refusals too", and the copied-directory refusal must never become overridable by an environment variable. `decideICloudTarget` is a separate function from `decideLinkAction` for exactly that reason, with a test asserting the copied-directory and file branches still refuse regardless.
- **Only when a link is about to be created.** An already-correct link is not a decision being taken now, and re-running must not start refusing a setup that works.
- **Before `decision.message` is printed.** That message is "Creating symlink at …", and printing it ahead of a refusal announces an action that will not happen — the same false claim #468 was about. The first draft put the check after it and did exactly that; caught by running the script rather than by reading it.
- **The marker is `/Library/Mobile Documents/`**, the parent of both the Drive and the per-app containers, so Obsidian's own iOS container is covered too. A path merely containing the word "icloud" is not matched, and there is a test for that.

## Verification

Unit: 7 new tests on `decideICloudTarget` plus the separation test. `bun run check` clean, `bun test` 1919 pass / 0 fail, `bun run format:check` clean.

Behavioural, by running the real script against scratch paths:

| case | result |
|---|---|
| iCloud-shaped path, no flag | exit 1, no link created, **no "Creating symlink" line** |
| same, `ALLOW_ICLOUD=1` | warning printed, link created, exit 0 |
| already linked, no flag | `Already linked`, exit 0, question never asked |
| vault outside iCloud | unchanged, no extra output, exit 0 |

## Scope

`decideLinkAction`, `inspectLinkTarget` and every existing refusal are untouched. #468 keeps its remaining half.
