### PR TITLE
fix(scripts): stop link.ts telling you to shadow your own symlink

### DIFF
--- a/packages/obsidian-plugin/scripts/link.test.ts
+++ b/packages/obsidian-plugin/scripts/link.test.ts
@@ -11,8 +11,10 @@
  */
 import { describe, expect, test } from "bun:test";
 import {
+  backupPathFor,
   decideICloudTarget,
   decideLinkAction,
+  findShadowingPlugins,
   type LinkTargetState,
 } from "./link";
 
@@ -69,8 +71,14 @@ describe("decideLinkAction", () => {
     // Sourcing the copy from `targetPath` would read the symlink this script
     // is about to create — that is, the repo root — and copy a file onto
     // itself, or nothing at all.
+    //
+    // The literal was `${TARGET}.copy-backup/data.json` until the backup moved
+    // out of plugins/. The property under test is unchanged — source is the
+    // backup, never the live path — so it is asserted through `backupPathFor`
+    // rather than through a second hand-written copy of the layout, which is
+    // what made this assertion go stale in the first place.
     const { message } = decide({ kind: "directory" });
-    expect(message).toContain(`${TARGET}.copy-backup/data.json`);
+    expect(message).toContain(`${backupPathFor(TARGET)}/data.json`);
     expect(message).not.toMatch(/cp "[^"]*plugins\/mcp-tools-istefox\/data/);
   });
 
@@ -111,6 +119,74 @@ describe("decideLinkAction", () => {
     for (const state of states) {
       expect(decide(state).message).toContain(TARGET);
     }
+  });
+});
+
+describe("backupPathFor", () => {
+  test("the backup goes OUTSIDE plugins/, one level up", () => {
+    // The whole point, and the thing the first version of this message got
+    // wrong. A backup beside the link declares the same id in its manifest,
+    // Obsidian keys plugins by that id, and the copy wins — measured on
+    // 2026-08-17, where it served 2.0.1 across a full restart.
+    expect(backupPathFor(TARGET)).toBe(
+      "/vault/.obsidian/mcp-tools-istefox.copy-backup",
+    );
+  });
+
+  test("the backup is never a sibling of the link", () => {
+    const pluginsDir = TARGET.slice(0, TARGET.lastIndexOf("/"));
+    expect(backupPathFor(TARGET).startsWith(`${pluginsDir}/`)).toBe(false);
+  });
+
+  test("the directory refusal prints that path, not a sibling", () => {
+    const { message } = decide({ kind: "directory" });
+    expect(message).toContain(backupPathFor(TARGET));
+    // The old, shadowing form. Naming it keeps a future edit from drifting back.
+    expect(message).not.toContain(`${TARGET}.copy-backup`);
+  });
+});
+
+describe("findShadowingPlugins", () => {
+  const ID = "mcp-tools-istefox";
+
+  test("the link itself is not a shadow of itself", () => {
+    const s = [{ name: ID, id: ID }];
+    expect(findShadowingPlugins(s, ID, ID)).toEqual([]);
+  });
+
+  test("a backup left beside the link IS a shadow", () => {
+    const s = [
+      { name: ID, id: ID },
+      { name: `${ID}.copy-backup`, id: ID },
+    ];
+    expect(findShadowingPlugins(s, ID, ID)).toEqual([`${ID}.copy-backup`]);
+  });
+
+  test("it matches on the manifest id, not on the directory name", () => {
+    // The name can be anything; what collides is the id Obsidian keys on.
+    const s = [
+      { name: ID, id: ID },
+      { name: "an-unrelated-name", id: ID },
+      { name: "dataview", id: "dataview" },
+    ];
+    expect(findShadowingPlugins(s, ID, ID)).toEqual(["an-unrelated-name"]);
+  });
+
+  test("directories with no readable manifest are not shadows", () => {
+    const s = [
+      { name: ID, id: ID },
+      { name: "notes-backup", id: null },
+    ];
+    expect(findShadowingPlugins(s, ID, ID)).toEqual([]);
+  });
+
+  test("every colliding directory is reported, not just the first", () => {
+    const s = [
+      { name: ID, id: ID },
+      { name: `${ID}.copy-backup`, id: ID },
+      { name: `${ID}.old`, id: ID },
+    ];
+    expect(findShadowingPlugins(s, ID, ID)).toHaveLength(2);
   });
 });
 

--- a/packages/obsidian-plugin/scripts/link.ts
+++ b/packages/obsidian-plugin/scripts/link.ts
@@ -4,8 +4,10 @@ import {
   mkdirSync,
   lstatSync,
   readlinkSync,
+  readdirSync,
+  readFileSync,
 } from "fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 /**
  * This development script creates a symlink to the plugin in the Obsidian vault's plugin directory. This allows you to
@@ -29,6 +31,44 @@ export type LinkDecision = {
   action: "create" | "ok" | "refuse";
   message: string;
 };
+
+/**
+ * Where the copied plugin directory should be moved to — **one level above
+ * `plugins/`**, never a sibling inside it.
+ *
+ * This is not tidiness. Obsidian enumerates every directory under `plugins/`
+ * and keys what it finds by the `id` in each `manifest.json`. A backup left
+ * beside the link declares the *same id*, so the two collide and the copy
+ * wins — the symlink is loaded over, silently, and the vault keeps running the
+ * old build with no error anywhere.
+ *
+ * Measured on 2026-08-17: with `<id>.copy-backup` next to the link, a freshly
+ * restarted Obsidian served `2.0.1`; moving that one directory out and
+ * restarting again served `2.1.1`, nothing else changed. The first version of
+ * this recovery told people to create exactly that collision.
+ */
+export function backupPathFor(targetPath: string): string {
+  const pluginsDir = dirname(targetPath);
+  return join(dirname(pluginsDir), `${basename(targetPath)}.copy-backup`);
+}
+
+/**
+ * Sibling plugin directories that declare the same id as the one being linked,
+ * and would therefore shadow it.
+ *
+ * Pure, and the caller does the reading — the same split as
+ * {@link decideLinkAction} and `inspectLinkTarget`. `linkDirName` is excluded
+ * because it is the link itself, which legitimately carries that id.
+ */
+export function findShadowingPlugins(
+  siblings: Array<{ name: string; id: string | null }>,
+  pluginId: string,
+  linkDirName: string,
+): string[] {
+  return siblings
+    .filter((s) => s.name !== linkDirName && s.id === pluginId)
+    .map((s) => s.name);
+}
 
 /**
  * What to do about the vault's plugin path, given what is actually there.
@@ -83,15 +123,22 @@ export function decideLinkAction(
           `  A build in this repo does not reach it, and nothing else says so: this is #468.\n` +
           `  Not touching it, because it holds your live \`data.json\` and \`embeddings/\`.\n` +
           `  Recovery, in full:\n` +
-          `    mv "${targetPath}" "${targetPath}.copy-backup"\n` +
+          `    mv "${targetPath}" "${backupPathFor(targetPath)}"\n` +
           `    <re-run this script>\n` +
-          `    cp "${targetPath}.copy-backup/data.json" "${repoRoot}/"\n` +
-          `    cp -R "${targetPath}.copy-backup/embeddings" "${repoRoot}/"\n` +
-          `  The last two steps are the ones that get skipped, and skipping them\n` +
-          `  loses your settings and your vector store: linking makes THIS repo the\n` +
-          `  plugin directory, so they have to end up here rather than staying in\n` +
-          `  the vault. Both paths are gitignored at the repo root.\n` +
-          `  Keep the backup until Obsidian has restarted and the settings look right.`,
+          `    cp "${backupPathFor(targetPath)}/data.json" "${repoRoot}/"\n` +
+          `    cp -R "${backupPathFor(targetPath)}/embeddings" "${repoRoot}/"\n` +
+          `  Two things about that sequence, both learned the hard way.\n` +
+          `  The backup goes OUTSIDE plugins/. Obsidian loads every directory in\n` +
+          `  there and keys them by the id in manifest.json, so a backup left\n` +
+          `  beside the link declares the same id, wins, and your vault silently\n` +
+          `  keeps running the old build.\n` +
+          `  And the two cp lines are the ones that get skipped: linking makes\n` +
+          `  THIS repo the plugin directory, so your settings and vector store\n` +
+          `  have to end up here rather than staying in the vault. Both paths are\n` +
+          `  gitignored at the repo root.\n` +
+          `  Quit Obsidian with Cmd+Q first — closing the window does not quit it,\n` +
+          `  and a running instance survives the move and keeps serving the old\n` +
+          `  code. Keep the backup until it has restarted and the settings look right.`,
       };
 
     case "file":
@@ -259,6 +306,42 @@ async function main() {
       process.exit(1);
     }
     if (icloud.kind === "allowed") console.warn(`\n! ${icloud.message}`);
+  }
+
+  // Runs on BOTH paths, unlike the iCloud question, and that is the point: a
+  // shadow over an already-correct link is not a hypothetical, it is the exact
+  // state this check was written from. `bun run link` reporting "Already
+  // linked" while Obsidian serves a different build is the same class of false
+  // success as #468's original "Symlink already exists."
+  const siblings = readdirSync(pluginsDirectoryPath).map((name) => {
+    try {
+      const m = JSON.parse(
+        readFileSync(join(pluginsDirectoryPath, name, "manifest.json"), "utf8"),
+      );
+      return { name, id: typeof m.id === "string" ? m.id : null };
+    } catch {
+      // Not a plugin directory, or unreadable. Obsidian ignores those too.
+      return { name, id: null };
+    }
+  });
+  const shadows = findShadowingPlugins(siblings, pluginName, pluginName);
+  if (shadows.length > 0) {
+    console.error(
+      `\n✗ Another directory in ${pluginsDirectoryPath} declares id "${pluginName}":\n` +
+        shadows.map((s) => `    ${s}`).join("\n") +
+        `\n  Obsidian keys plugins by that id, so one of them wins and it is not\n` +
+        `  necessarily the link. Measured: a backup left there served the OLD\n` +
+        `  build across a full restart, with no error anywhere.\n` +
+        `  Move it out of plugins/ — one level up is enough:\n` +
+        shadows
+          .map(
+            (s) =>
+              `    mv "${join(pluginsDirectoryPath, s)}" "${join(dirname(pluginsDirectoryPath), s)}"`,
+          )
+          .join("\n") +
+        `\n`,
+    );
+    process.exit(1);
   }
 
   console.log(decision.message);


### PR DESCRIPTION
The recovery this script prints moved the copied plugin directory to `<plugins>/<id>.copy-backup` — a sibling of the link, **inside the one directory Obsidian enumerates**. Obsidian keys plugins by the `id` in each `manifest.json`, so the backup declared the same id as the link, the two collided, and the copy won.

The vault kept running the old build across a full restart, with no error anywhere, while `bun run link` reported `Already linked` the whole time. That is the same class of false success as #468's original "Symlink already exists." — reintroduced by the fix for it.

## Measured, not reasoned

With `<id>.copy-backup` beside the link, a freshly restarted Obsidian served `2.0.1`. Moving that one directory out and restarting again served `2.1.1`. Nothing else changed.

It also settles a question that had been open since the relink: **Obsidian does follow symlinks.** Shadowing was the whole story, and the competing hypothesis is dead.

## Two changes

**`backupPathFor`** puts the backup one level above `plugins/`, and the refusal explains why instead of just relocating it. It also now says to quit with **Cmd+Q** — a running instance survives the `mv` on its own file handles and keeps serving the old code, which cost a full verification session.

**`findShadowingPlugins`** refuses when any sibling directory declares the plugin's id. It runs on **both** paths, an already-correct link included: a shadowed correct link is precisely the state this was written from, and the state nothing reported.

Both pure, with the caller doing the I/O — the same split as `decideLinkAction` and `decideICloudTarget`.

## One test changed rather than disabled

`the restore step copies FROM the backup, not from the live directory` asserted the old sibling path as a literal. The property it guards is unchanged — source is the backup, never the live path — and is now asserted through `backupPathFor`, so the layout is stated once instead of twice. That second hand-written copy is what let the assertion go stale.

## Verification

Behavioural, by running the script rather than reading it:

| state | result |
|---|---|
| collision, no link | refuses at exit 1, prints the exact `mv` |
| after running that `mv` | links, exit 0 |
| collision, link already correct | still refuses — tonight's state |
| real Labs vault, healthy | `Already linked`, exit 0 |

`bun run check` clean · `bun test` 1927 pass / 0 fail · `format:check` clean · `check:svelte` 0 errors · `test:mcpb` all checks.