### PR TITLE
docs: align plugin and package descriptions with what the connector is

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "MCP Connector",
   "version": "2.1.1",
   "minAppVersion": "1.7.2",
-  "description": "Connect MCP-compatible clients (Claude Desktop, Claude Code, Cline) to your vault with semantic search, templates, file management and gated command execution.",
+  "description": "Expose your vault to Claude and any MCP client over the Model Context Protocol. Runs inside Obsidian, with on-device semantic search.",
   "author": "Stefano Ferri",
   "authorUrl": "https://github.com/istefox",
   "isDesktopOnly": true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mcp-tools-for-obsidian",
   "version": "2.1.1",
   "private": true,
-  "description": "Connect MCP-compatible clients (Claude Desktop, Claude Code, Cline) to your Obsidian vault with semantic search, templates, file management and gated command execution.",
+  "description": "Expose your vault to Claude and any MCP client over the Model Context Protocol. Runs inside Obsidian, with on-device semantic search.",
   "tags": [
     "obsidian",
     "plugin",


### PR DESCRIPTION
The GitHub About box, `manifest.json` and `package.json` all described the connector as an add-on that brings integrations to Claude. It is a server that runs inside Obsidian and serves any MCP client. `manifest.json` is the one users read, in the community plugin browser.

The About box and repository topics were updated directly on GitHub; this PR brings the two in-repo copies in line.