### PR TITLE
chore: match package.json tags to the repository topics

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "description": "Expose your vault to Claude and any MCP client over the Model Context Protocol. Runs inside Obsidian, with on-device semantic search.",
   "tags": [
     "obsidian",
-    "plugin",
-    "semantic search",
-    "templates",
-    "file management",
+    "obsidian-plugin",
     "mcp",
-    "model context protocol"
+    "model-context-protocol",
+    "claude",
+    "semantic-search",
+    "local-first",
+    "ai-tools"
   ],
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
The list still named templates and file management as headline features and spelled the protocol two different ways. Nothing reads this array (the package is `private`), so this is consistency, not behaviour.

Follows #495, which aligned the descriptions.