### PR TITLE
fix(manifest): drop the redundant "Obsidian" from the plugin description

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "MCP Connector",
   "version": "2.2.0",
   "minAppVersion": "1.7.2",
-  "description": "Expose your vault to Claude and any MCP client over the Model Context Protocol. Runs inside Obsidian, with on-device semantic search.",
+  "description": "Expose your vault to Claude and any MCP client over the Model Context Protocol, with on-device semantic search.",
   "author": "Stefano Ferri",
   "authorUrl": "https://github.com/istefox",
   "isDesktopOnly": true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mcp-tools-for-obsidian",
   "version": "2.2.0",
   "private": true,
-  "description": "Expose your vault to Claude and any MCP client over the Model Context Protocol. Runs inside Obsidian, with on-device semantic search.",
+  "description": "Expose your vault to Claude and any MCP client over the Model Context Protocol, with on-device semantic search.",
   "tags": [
     "obsidian",
     "obsidian-plugin",


### PR DESCRIPTION
## Pull Request Description
The community plugin review scanner flags `manifest.json`'s `description` field for containing the word "Obsidian" — redundant, since it's implied by the plugin directory context. Dropped it, and mirrored the same edit in `package.json` for consistency.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] No functional code touched — a text-only fix to two metadata files.

## Checklist
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (none affected)

## Security Considerations
- [x] No hardcoded secrets or API keys
- [x] No new security vulnerabilities introduced

## Additional Context
No version bump needed for this — it corrects metadata read by the community review process, not shipped plugin behavior.
