### PR TITLE
fix(shared): fix the two Reflect.get unsafe-return sites the previous pass missed

### DIFF
--- a/packages/obsidian-plugin/src/shared/guardedApp.ts
+++ b/packages/obsidian-plugin/src/shared/guardedApp.ts
@@ -119,7 +119,10 @@ function guardObject<T extends object>(
   const allowed = new Set([...passthrough, ...UNIVERSAL_PASSTHROUGH]);
   return new Proxy(raw, {
     get(target, prop) {
-      if (typeof prop === "symbol") return Reflect.get(target, prop, target);
+      if (typeof prop === "symbol") {
+        const value: unknown = Reflect.get(target, prop, target);
+        return value;
+      }
       if (Object.prototype.hasOwnProperty.call(guards, prop)) {
         return guards[prop];
       }
@@ -514,7 +517,8 @@ function guardMetadataCache(raw: object, policy: PolicySource): object {
           )[prop],
         );
       }
-      return Reflect.get(target, prop);
+      const value: unknown = Reflect.get(target, prop);
+      return value;
     },
   });
 }


### PR DESCRIPTION
## Pull Request Description
Follow-up to #505. After that PR shipped, the community review page still showed `no-unsafe-return` on `guardedApp.ts:517` — I'd only fixed the two assignment-shaped `const value = Reflect.get(...)` occurrences, not this direct `return Reflect.get(...)` in `guardMetadataCache`'s `resolvedLinks`/`unresolvedLinks` proxy. Same fix (type the result as `unknown` before returning) applied here, plus to an identical-shape twin at line 122 (`guardObject`'s symbol passthrough) that hadn't been flagged yet but is the same pattern.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] `bun run check`, `bun test` (2086 pass), `bun run format:check`, `bun run check:svelte` (0/0), `bun run test:mcpb` all green.

## Security Considerations
- [x] No hardcoded secrets or API keys
- [x] No new security vulnerabilities introduced
