### PR TITLE
fix(ci): force LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Force LF on checkout regardless of the checking-out machine's OS or
+# `core.autocrlf`. Without this, a Windows checkout (GitHub Actions'
+# windows-latest included) converts every text file's real newlines to
+# CRLF, while a generated-source-matches-its-source drift test (the
+# connectorShim / mcp-app / discovery-broker pattern) compares a freshly
+# read file against a baked string constant that is immune to the
+# conversion (its newlines are escaped `\n` sequences inside a JSON string
+# literal, not raw bytes). The two diverge only on Windows, and only when
+# a `bun test` drift check actually runs there — which nothing in this
+# repo's CI did until the discovery-broker job (PR #500) became the first.
+* text=auto eol=lf


### PR DESCRIPTION
A generated-source-matches-its-source drift test (the `connectorShim`/`searchResultsAppSource`/`discoveryBroker` pattern) compares a freshly read `.js` file against a baked string constant. On Windows, git's checkout converts the `.js` file's real newlines to CRLF while the escaped constant stays LF, so the two diverge only there.

`check-and-test` (which runs `bun test`) is ubuntu-only; `bridge-tests` (windows-latest) only runs the Python bridge suite. Nothing in this repo's CI has ever run a `bun test` drift check on Windows until PR #500 added `discovery-broker-tests` on a windows/ubuntu/macos matrix, and its Windows leg failed on exactly this drift test.

`* text=auto eol=lf` forces LF on checkout regardless of OS or the checking-out machine's `core.autocrlf`, closing the gap for this generator and the two existing ones alike.

Two already-committed files (`packages/obsidian-plugin/.editorconfig`, `packages/obsidian-plugin/.gitignore`) carry CRLF today; left untouched here since neither is part of a drift comparison and touching them isn't needed for this fix.